### PR TITLE
Sort devoid properly

### DIFF
--- a/src/__tests__/data/mockData.js
+++ b/src/__tests__/data/mockData.js
@@ -1,855 +1,1014 @@
 export default [
     {
-        "_id": "0e0d989d-7186-40dc-bdfe-cfbb77656bc8",
-        "object": "card",
-        "id": "0e0d989d-7186-40dc-bdfe-cfbb77656bc8",
-        "oracle_id": "900ca697-ad38-4b2b-bc74-2ff7eb6ea951",
-        "multiverse_ids": [
-            456600
-        ],
-        "mtgo_id": 70081,
-        "tcgplayer_id": 179448,
-        "name": "Emrakul, the Aeons Torn",
-        "lang": "en",
-        "released_at": "2018-12-07",
-        "uri": "https://api.scryfall.com/cards/0e0d989d-7186-40dc-bdfe-cfbb77656bc8",
-        "scryfall_uri": "https://scryfall.com/card/uma/4/emrakul-the-aeons-torn?utm_source=api",
-        "layout": "normal",
-        "highres_image": true,
-        "image_uris": {
-            "small": "https://img.scryfall.com/cards/small/front/0/e/0e0d989d-7186-40dc-bdfe-cfbb77656bc8.jpg?1559959218",
-            "normal": "https://img.scryfall.com/cards/normal/front/0/e/0e0d989d-7186-40dc-bdfe-cfbb77656bc8.jpg?1559959218",
-            "large": "https://img.scryfall.com/cards/large/front/0/e/0e0d989d-7186-40dc-bdfe-cfbb77656bc8.jpg?1559959218",
-            "png": "https://img.scryfall.com/cards/png/front/0/e/0e0d989d-7186-40dc-bdfe-cfbb77656bc8.png?1559959218",
-            "art_crop": "https://img.scryfall.com/cards/art_crop/front/0/e/0e0d989d-7186-40dc-bdfe-cfbb77656bc8.jpg?1559959218",
-            "border_crop": "https://img.scryfall.com/cards/border_crop/front/0/e/0e0d989d-7186-40dc-bdfe-cfbb77656bc8.jpg?1559959218"
+        _id: '0e0d989d-7186-40dc-bdfe-cfbb77656bc8',
+        object: 'card',
+        id: '0e0d989d-7186-40dc-bdfe-cfbb77656bc8',
+        oracle_id: '900ca697-ad38-4b2b-bc74-2ff7eb6ea951',
+        multiverse_ids: [456600],
+        mtgo_id: 70081,
+        tcgplayer_id: 179448,
+        name: 'Emrakul, the Aeons Torn',
+        lang: 'en',
+        released_at: '2018-12-07',
+        uri:
+            'https://api.scryfall.com/cards/0e0d989d-7186-40dc-bdfe-cfbb77656bc8',
+        scryfall_uri:
+            'https://scryfall.com/card/uma/4/emrakul-the-aeons-torn?utm_source=api',
+        layout: 'normal',
+        highres_image: true,
+        image_uris: {
+            small:
+                'https://img.scryfall.com/cards/small/front/0/e/0e0d989d-7186-40dc-bdfe-cfbb77656bc8.jpg?1559959218',
+            normal:
+                'https://img.scryfall.com/cards/normal/front/0/e/0e0d989d-7186-40dc-bdfe-cfbb77656bc8.jpg?1559959218',
+            large:
+                'https://img.scryfall.com/cards/large/front/0/e/0e0d989d-7186-40dc-bdfe-cfbb77656bc8.jpg?1559959218',
+            png:
+                'https://img.scryfall.com/cards/png/front/0/e/0e0d989d-7186-40dc-bdfe-cfbb77656bc8.png?1559959218',
+            art_crop:
+                'https://img.scryfall.com/cards/art_crop/front/0/e/0e0d989d-7186-40dc-bdfe-cfbb77656bc8.jpg?1559959218',
+            border_crop:
+                'https://img.scryfall.com/cards/border_crop/front/0/e/0e0d989d-7186-40dc-bdfe-cfbb77656bc8.jpg?1559959218',
         },
-        "mana_cost": "{15}",
-        "cmc": 15,
-        "type_line": "Legendary Creature — Eldrazi",
-        "oracle_text": "This spell can't be countered.\nWhen you cast this spell, take an extra turn after this one.\nFlying, protection from colored spells, annihilator 6\nWhen Emrakul, the Aeons Torn is put into a graveyard from anywhere, its owner shuffles their graveyard into their library.",
-        "power": "15",
-        "toughness": "15",
-        "colors": [],
-        "color_identity": [],
-        "legalities": {
-            "standard": "not_legal",
-            "future": "not_legal",
-            "historic": "not_legal",
-            "pioneer": "not_legal",
-            "modern": "legal",
-            "legacy": "legal",
-            "pauper": "not_legal",
-            "vintage": "legal",
-            "penny": "not_legal",
-            "commander": "banned",
-            "brawl": "not_legal",
-            "duel": "banned",
-            "oldschool": "not_legal"
+        mana_cost: '{15}',
+        cmc: 15,
+        type_line: 'Legendary Creature — Eldrazi',
+        oracle_text:
+            "This spell can't be countered.\nWhen you cast this spell, take an extra turn after this one.\nFlying, protection from colored spells, annihilator 6\nWhen Emrakul, the Aeons Torn is put into a graveyard from anywhere, its owner shuffles their graveyard into their library.",
+        power: '15',
+        toughness: '15',
+        colors: [],
+        color_identity: [],
+        legalities: {
+            standard: 'not_legal',
+            future: 'not_legal',
+            historic: 'not_legal',
+            pioneer: 'not_legal',
+            modern: 'legal',
+            legacy: 'legal',
+            pauper: 'not_legal',
+            vintage: 'legal',
+            penny: 'not_legal',
+            commander: 'banned',
+            brawl: 'not_legal',
+            duel: 'banned',
+            oldschool: 'not_legal',
         },
-        "games": [
-            "mtgo",
-            "paper"
-        ],
-        "reserved": false,
-        "foil": true,
-        "nonfoil": true,
-        "oversized": false,
-        "promo": false,
-        "reprint": true,
-        "variation": false,
-        "set": "uma",
-        "set_name": "Ultimate Masters",
-        "set_type": "masters",
-        "set_uri": "https://api.scryfall.com/sets/2ec77b94-6d47-4891-a480-5d0b4e5c9372",
-        "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Auma&unique=prints",
-        "scryfall_set_uri": "https://scryfall.com/sets/uma?utm_source=api",
-        "rulings_uri": "https://api.scryfall.com/cards/0e0d989d-7186-40dc-bdfe-cfbb77656bc8/rulings",
-        "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3A900ca697-ad38-4b2b-bc74-2ff7eb6ea951&unique=prints",
-        "collector_number": "4",
-        "digital": false,
-        "rarity": "mythic",
-        "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
-        "artist": "Mark Tedin",
-        "artist_ids": [
-            "9ee9a9cc-c09e-486f-918b-69f80cbc4188"
-        ],
-        "illustration_id": "77d49e83-98fd-440e-a4ee-ecf8c5535899",
-        "border_color": "black",
-        "frame": "2015",
-        "frame_effects": [
-            "legendary"
-        ],
-        "full_art": false,
-        "textless": false,
-        "booster": true,
-        "story_spotlight": false,
-        "related_uris": {
-            "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=456600",
-            "tcgplayer_decks": "https://decks.tcgplayer.com/magic/deck/search?contains=Emrakul%2C+the+Aeons+Torn&page=1&partner=Scryfall&utm_campaign=affiliate&utm_medium=scryfall&utm_source=scryfall",
-            "edhrec": "https://edhrec.com/route/?cc=Emrakul%2C+the+Aeons+Torn",
-            "mtgtop8": "https://mtgtop8.com/search?MD_check=1&SB_check=1&cards=Emrakul%2C+the+Aeons+Torn"
+        games: ['mtgo', 'paper'],
+        reserved: false,
+        foil: true,
+        nonfoil: true,
+        oversized: false,
+        promo: false,
+        reprint: true,
+        variation: false,
+        set: 'uma',
+        set_name: 'Ultimate Masters',
+        set_type: 'masters',
+        set_uri:
+            'https://api.scryfall.com/sets/2ec77b94-6d47-4891-a480-5d0b4e5c9372',
+        set_search_uri:
+            'https://api.scryfall.com/cards/search?order=set&q=e%3Auma&unique=prints',
+        scryfall_set_uri: 'https://scryfall.com/sets/uma?utm_source=api',
+        rulings_uri:
+            'https://api.scryfall.com/cards/0e0d989d-7186-40dc-bdfe-cfbb77656bc8/rulings',
+        prints_search_uri:
+            'https://api.scryfall.com/cards/search?order=released&q=oracleid%3A900ca697-ad38-4b2b-bc74-2ff7eb6ea951&unique=prints',
+        collector_number: '4',
+        digital: false,
+        rarity: 'mythic',
+        card_back_id: '0aeebaf5-8c7d-4636-9e82-8c27447861f7',
+        artist: 'Mark Tedin',
+        artist_ids: ['9ee9a9cc-c09e-486f-918b-69f80cbc4188'],
+        illustration_id: '77d49e83-98fd-440e-a4ee-ecf8c5535899',
+        border_color: 'black',
+        frame: '2015',
+        frame_effects: ['legendary'],
+        full_art: false,
+        textless: false,
+        booster: true,
+        story_spotlight: false,
+        related_uris: {
+            gatherer:
+                'https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=456600',
+            tcgplayer_decks:
+                'https://decks.tcgplayer.com/magic/deck/search?contains=Emrakul%2C+the+Aeons+Torn&page=1&partner=Scryfall&utm_campaign=affiliate&utm_medium=scryfall&utm_source=scryfall',
+            edhrec: 'https://edhrec.com/route/?cc=Emrakul%2C+the+Aeons+Torn',
+            mtgtop8:
+                'https://mtgtop8.com/search?MD_check=1&SB_check=1&cards=Emrakul%2C+the+Aeons+Torn',
         },
-        "qoh": {
-            "FOIL_NM": 1
+        qoh: {
+            FOIL_NM: 1,
         },
-        "finishCondition": "FOIL_NM",
-        "qtyToSell": 1,
-        "price": 0
+        finishCondition: 'FOIL_NM',
+        qtyToSell: 1,
+        price: 0,
     },
     {
-        "_id": "25b0b816-0583-44aa-9dc5-f3ff48993a51",
-        "artist": "Mark Zug",
-        "artist_ids": [
-            "48e2b98c-5467-4671-bd42-4c3746115117"
-        ],
-        "booster": true,
-        "border_color": "black",
-        "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
-        "cmc": 0,
-        "collector_number": "321",
-        "color_identity": [
-            "G"
-        ],
-        "colors": [],
-        "digital": false,
-        "edhrec_rank": 650,
-        "flavor_text": "\"Here sprouted the first seedling of Argoth. Here the last tree will fall.\" —Gamelen, Citanul elder",
-        "foil": false,
-        "frame": "1997",
-        "full_art": false,
-        "games": [
-            "paper",
-            "mtgo"
-        ],
-        "highres_image": true,
-        "id": "25b0b816-0583-44aa-9dc5-f3ff48993a51",
-        "illustration_id": "9f670261-15a3-4f13-a0f2-5a29982585e9",
-        "image_uris": {
-            "small": "https://img.scryfall.com/cards/small/front/2/5/25b0b816-0583-44aa-9dc5-f3ff48993a51.jpg?1562902898",
-            "normal": "https://img.scryfall.com/cards/normal/front/2/5/25b0b816-0583-44aa-9dc5-f3ff48993a51.jpg?1562902898",
-            "large": "https://img.scryfall.com/cards/large/front/2/5/25b0b816-0583-44aa-9dc5-f3ff48993a51.jpg?1562902898",
-            "png": "https://img.scryfall.com/cards/png/front/2/5/25b0b816-0583-44aa-9dc5-f3ff48993a51.png?1562902898",
-            "art_crop": "https://img.scryfall.com/cards/art_crop/front/2/5/25b0b816-0583-44aa-9dc5-f3ff48993a51.jpg?1562902898",
-            "border_crop": "https://img.scryfall.com/cards/border_crop/front/2/5/25b0b816-0583-44aa-9dc5-f3ff48993a51.jpg?1562902898"
+        _id: '25b0b816-0583-44aa-9dc5-f3ff48993a51',
+        artist: 'Mark Zug',
+        artist_ids: ['48e2b98c-5467-4671-bd42-4c3746115117'],
+        booster: true,
+        border_color: 'black',
+        card_back_id: '0aeebaf5-8c7d-4636-9e82-8c27447861f7',
+        cmc: 0,
+        collector_number: '321',
+        color_identity: ['G'],
+        colors: [],
+        digital: false,
+        edhrec_rank: 650,
+        flavor_text:
+            '"Here sprouted the first seedling of Argoth. Here the last tree will fall." —Gamelen, Citanul elder',
+        foil: false,
+        frame: '1997',
+        full_art: false,
+        games: ['paper', 'mtgo'],
+        highres_image: true,
+        id: '25b0b816-0583-44aa-9dc5-f3ff48993a51',
+        illustration_id: '9f670261-15a3-4f13-a0f2-5a29982585e9',
+        image_uris: {
+            small:
+                'https://img.scryfall.com/cards/small/front/2/5/25b0b816-0583-44aa-9dc5-f3ff48993a51.jpg?1562902898',
+            normal:
+                'https://img.scryfall.com/cards/normal/front/2/5/25b0b816-0583-44aa-9dc5-f3ff48993a51.jpg?1562902898',
+            large:
+                'https://img.scryfall.com/cards/large/front/2/5/25b0b816-0583-44aa-9dc5-f3ff48993a51.jpg?1562902898',
+            png:
+                'https://img.scryfall.com/cards/png/front/2/5/25b0b816-0583-44aa-9dc5-f3ff48993a51.png?1562902898',
+            art_crop:
+                'https://img.scryfall.com/cards/art_crop/front/2/5/25b0b816-0583-44aa-9dc5-f3ff48993a51.jpg?1562902898',
+            border_crop:
+                'https://img.scryfall.com/cards/border_crop/front/2/5/25b0b816-0583-44aa-9dc5-f3ff48993a51.jpg?1562902898',
         },
-        "lang": "en",
-        "layout": "normal",
-        "legalities": {
-            "standard": "not_legal",
-            "future": "not_legal",
-            "historic": "not_legal",
-            "pioneer": "not_legal",
-            "modern": "not_legal",
-            "legacy": "legal",
-            "pauper": "not_legal",
-            "vintage": "legal",
-            "penny": "not_legal",
-            "commander": "legal",
-            "brawl": "not_legal",
-            "duel": "banned",
-            "oldschool": "not_legal"
+        lang: 'en',
+        layout: 'normal',
+        legalities: {
+            standard: 'not_legal',
+            future: 'not_legal',
+            historic: 'not_legal',
+            pioneer: 'not_legal',
+            modern: 'not_legal',
+            legacy: 'legal',
+            pauper: 'not_legal',
+            vintage: 'legal',
+            penny: 'not_legal',
+            commander: 'legal',
+            brawl: 'not_legal',
+            duel: 'banned',
+            oldschool: 'not_legal',
         },
-        "mana_cost": "",
-        "mtgo_foil_id": 11868,
-        "mtgo_id": 11867,
-        "multiverse_ids": [
-            10422
-        ],
-        "name": "Gaea's Cradle",
-        "nonfoil": true,
-        "object": "card",
-        "oracle_id": "7c427c3d-ecd8-45ef-bebd-8f10f4a311db",
-        "oracle_text": "{T}: Add {G} for each creature you control.",
-        "oversized": false,
-        "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3A7c427c3d-ecd8-45ef-bebd-8f10f4a311db&unique=prints",
-        "promo": false,
-        "qoh": {
-            "NONFOIL_NM": 3
+        mana_cost: '',
+        mtgo_foil_id: 11868,
+        mtgo_id: 11867,
+        multiverse_ids: [10422],
+        name: "Gaea's Cradle",
+        nonfoil: true,
+        object: 'card',
+        oracle_id: '7c427c3d-ecd8-45ef-bebd-8f10f4a311db',
+        oracle_text: '{T}: Add {G} for each creature you control.',
+        oversized: false,
+        prints_search_uri:
+            'https://api.scryfall.com/cards/search?order=released&q=oracleid%3A7c427c3d-ecd8-45ef-bebd-8f10f4a311db&unique=prints',
+        promo: false,
+        qoh: {
+            NONFOIL_NM: 3,
         },
-        "rarity": "rare",
-        "related_uris": {
-            "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=10422",
-            "tcgplayer_decks": "https://decks.tcgplayer.com/magic/deck/search?contains=Gaea%27s+Cradle&page=1&partner=Scryfall&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
-            "edhrec": "https://edhrec.com/route/?cc=Gaea%27s+Cradle",
-            "mtgtop8": "https://mtgtop8.com/search?MD_check=1&SB_check=1&cards=Gaea%27s+Cradle"
+        rarity: 'rare',
+        related_uris: {
+            gatherer:
+                'https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=10422',
+            tcgplayer_decks:
+                'https://decks.tcgplayer.com/magic/deck/search?contains=Gaea%27s+Cradle&page=1&partner=Scryfall&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall',
+            edhrec: 'https://edhrec.com/route/?cc=Gaea%27s+Cradle',
+            mtgtop8:
+                'https://mtgtop8.com/search?MD_check=1&SB_check=1&cards=Gaea%27s+Cradle',
         },
-        "released_at": "1998-10-12",
-        "reprint": false,
-        "reserved": true,
-        "rulings_uri": "https://api.scryfall.com/cards/25b0b816-0583-44aa-9dc5-f3ff48993a51/rulings",
-        "scryfall_set_uri": "https://scryfall.com/sets/usg?utm_source=api",
-        "scryfall_uri": "https://scryfall.com/card/usg/321/gaeas-cradle?utm_source=api",
-        "set": "usg",
-        "set_name": "Urza's Saga",
-        "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Ausg&unique=prints",
-        "set_type": "expansion",
-        "set_uri": "https://api.scryfall.com/sets/c330df40-51db-4caf-bde6-48df6c181001",
-        "showImage": true,
-        "story_spotlight": false,
-        "tcgplayer_id": 6883,
-        "textless": false,
-        "type_line": "Legendary Land",
-        "uri": "https://api.scryfall.com/cards/25b0b816-0583-44aa-9dc5-f3ff48993a51",
-        "variation": false,
-        "finishCondition": "NONFOIL_NM",
-        "qtyToSell": 1,
-        "price": 0
+        released_at: '1998-10-12',
+        reprint: false,
+        reserved: true,
+        rulings_uri:
+            'https://api.scryfall.com/cards/25b0b816-0583-44aa-9dc5-f3ff48993a51/rulings',
+        scryfall_set_uri: 'https://scryfall.com/sets/usg?utm_source=api',
+        scryfall_uri:
+            'https://scryfall.com/card/usg/321/gaeas-cradle?utm_source=api',
+        set: 'usg',
+        set_name: "Urza's Saga",
+        set_search_uri:
+            'https://api.scryfall.com/cards/search?order=set&q=e%3Ausg&unique=prints',
+        set_type: 'expansion',
+        set_uri:
+            'https://api.scryfall.com/sets/c330df40-51db-4caf-bde6-48df6c181001',
+        showImage: true,
+        story_spotlight: false,
+        tcgplayer_id: 6883,
+        textless: false,
+        type_line: 'Legendary Land',
+        uri:
+            'https://api.scryfall.com/cards/25b0b816-0583-44aa-9dc5-f3ff48993a51',
+        variation: false,
+        finishCondition: 'NONFOIL_NM',
+        qtyToSell: 1,
+        price: 0,
     },
     {
-        "_id": "fcac0cff-efa6-4068-a69c-67ea4e7acea0",
-        "object": "card",
-        "id": "fcac0cff-efa6-4068-a69c-67ea4e7acea0",
-        "oracle_id": "e55104e2-4900-48de-b288-d3e6abd5e09e",
-        "multiverse_ids": [
-            456802
-        ],
-        "mtgo_id": 70485,
-        "mtgo_foil_id": 70486,
-        "tcgplayer_id": 179507,
-        "name": "Sigarda, Host of Herons",
-        "lang": "en",
-        "released_at": "2018-12-07",
-        "uri": "https://api.scryfall.com/cards/fcac0cff-efa6-4068-a69c-67ea4e7acea0",
-        "scryfall_uri": "https://scryfall.com/card/uma/206/sigarda-host-of-herons?utm_source=api",
-        "layout": "normal",
-        "highres_image": true,
-        "image_uris": {
-            "small": "https://img.scryfall.com/cards/small/front/f/c/fcac0cff-efa6-4068-a69c-67ea4e7acea0.jpg?1559959280",
-            "normal": "https://img.scryfall.com/cards/normal/front/f/c/fcac0cff-efa6-4068-a69c-67ea4e7acea0.jpg?1559959280",
-            "large": "https://img.scryfall.com/cards/large/front/f/c/fcac0cff-efa6-4068-a69c-67ea4e7acea0.jpg?1559959280",
-            "png": "https://img.scryfall.com/cards/png/front/f/c/fcac0cff-efa6-4068-a69c-67ea4e7acea0.png?1559959280",
-            "art_crop": "https://img.scryfall.com/cards/art_crop/front/f/c/fcac0cff-efa6-4068-a69c-67ea4e7acea0.jpg?1559959280",
-            "border_crop": "https://img.scryfall.com/cards/border_crop/front/f/c/fcac0cff-efa6-4068-a69c-67ea4e7acea0.jpg?1559959280"
+        _id: 'fcac0cff-efa6-4068-a69c-67ea4e7acea0',
+        object: 'card',
+        id: 'fcac0cff-efa6-4068-a69c-67ea4e7acea0',
+        oracle_id: 'e55104e2-4900-48de-b288-d3e6abd5e09e',
+        multiverse_ids: [456802],
+        mtgo_id: 70485,
+        mtgo_foil_id: 70486,
+        tcgplayer_id: 179507,
+        name: 'Sigarda, Host of Herons',
+        lang: 'en',
+        released_at: '2018-12-07',
+        uri:
+            'https://api.scryfall.com/cards/fcac0cff-efa6-4068-a69c-67ea4e7acea0',
+        scryfall_uri:
+            'https://scryfall.com/card/uma/206/sigarda-host-of-herons?utm_source=api',
+        layout: 'normal',
+        highres_image: true,
+        image_uris: {
+            small:
+                'https://img.scryfall.com/cards/small/front/f/c/fcac0cff-efa6-4068-a69c-67ea4e7acea0.jpg?1559959280',
+            normal:
+                'https://img.scryfall.com/cards/normal/front/f/c/fcac0cff-efa6-4068-a69c-67ea4e7acea0.jpg?1559959280',
+            large:
+                'https://img.scryfall.com/cards/large/front/f/c/fcac0cff-efa6-4068-a69c-67ea4e7acea0.jpg?1559959280',
+            png:
+                'https://img.scryfall.com/cards/png/front/f/c/fcac0cff-efa6-4068-a69c-67ea4e7acea0.png?1559959280',
+            art_crop:
+                'https://img.scryfall.com/cards/art_crop/front/f/c/fcac0cff-efa6-4068-a69c-67ea4e7acea0.jpg?1559959280',
+            border_crop:
+                'https://img.scryfall.com/cards/border_crop/front/f/c/fcac0cff-efa6-4068-a69c-67ea4e7acea0.jpg?1559959280',
         },
-        "mana_cost": "{2}{G}{W}{W}",
-        "cmc": 5,
-        "type_line": "Legendary Creature — Angel",
-        "oracle_text": "Flying, hexproof\nSpells and abilities your opponents control can't cause you to sacrifice permanents.",
-        "power": "5",
-        "toughness": "5",
-        "colors": [
-            "G",
-            "W"
-        ],
-        "color_identity": [
-            "G",
-            "W"
-        ],
-        "legalities": {
-            "standard": "not_legal",
-            "future": "not_legal",
-            "historic": "not_legal",
-            "pioneer": "not_legal",
-            "modern": "legal",
-            "legacy": "legal",
-            "pauper": "not_legal",
-            "vintage": "legal",
-            "penny": "not_legal",
-            "commander": "legal",
-            "brawl": "not_legal",
-            "duel": "legal",
-            "oldschool": "not_legal"
+        mana_cost: '{2}{G}{W}{W}',
+        cmc: 5,
+        type_line: 'Legendary Creature — Angel',
+        oracle_text:
+            "Flying, hexproof\nSpells and abilities your opponents control can't cause you to sacrifice permanents.",
+        power: '5',
+        toughness: '5',
+        colors: ['G', 'W'],
+        color_identity: ['G', 'W'],
+        legalities: {
+            standard: 'not_legal',
+            future: 'not_legal',
+            historic: 'not_legal',
+            pioneer: 'not_legal',
+            modern: 'legal',
+            legacy: 'legal',
+            pauper: 'not_legal',
+            vintage: 'legal',
+            penny: 'not_legal',
+            commander: 'legal',
+            brawl: 'not_legal',
+            duel: 'legal',
+            oldschool: 'not_legal',
         },
-        "games": [
-            "mtgo",
-            "paper"
-        ],
-        "reserved": false,
-        "foil": true,
-        "nonfoil": true,
-        "oversized": false,
-        "promo": false,
-        "reprint": true,
-        "variation": false,
-        "set": "uma",
-        "set_name": "Ultimate Masters",
-        "set_type": "masters",
-        "set_uri": "https://api.scryfall.com/sets/2ec77b94-6d47-4891-a480-5d0b4e5c9372",
-        "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Auma&unique=prints",
-        "scryfall_set_uri": "https://scryfall.com/sets/uma?utm_source=api",
-        "rulings_uri": "https://api.scryfall.com/cards/fcac0cff-efa6-4068-a69c-67ea4e7acea0/rulings",
-        "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3Ae55104e2-4900-48de-b288-d3e6abd5e09e&unique=prints",
-        "collector_number": "206",
-        "digital": false,
-        "rarity": "mythic",
-        "flavor_text": "Great devotion yields great reward.",
-        "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
-        "artist": "Chris Rahn",
-        "artist_ids": [
-            "7742047e-0f80-4c0f-a530-d07460165e86"
-        ],
-        "illustration_id": "6148d251-479b-4510-b79b-90fe624bc025",
-        "border_color": "black",
-        "frame": "2015",
-        "frame_effects": [
-            "legendary"
-        ],
-        "full_art": false,
-        "textless": false,
-        "booster": true,
-        "story_spotlight": false,
-        "edhrec_rank": 1257,
-        "related_uris": {
-            "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=456802",
-            "tcgplayer_decks": "https://decks.tcgplayer.com/magic/deck/search?contains=Sigarda%2C+Host+of+Herons&page=1&partner=Scryfall&utm_campaign=affiliate&utm_medium=scryfall&utm_source=scryfall",
-            "edhrec": "https://edhrec.com/route/?cc=Sigarda%2C+Host+of+Herons",
-            "mtgtop8": "https://mtgtop8.com/search?MD_check=1&SB_check=1&cards=Sigarda%2C+Host+of+Herons"
+        games: ['mtgo', 'paper'],
+        reserved: false,
+        foil: true,
+        nonfoil: true,
+        oversized: false,
+        promo: false,
+        reprint: true,
+        variation: false,
+        set: 'uma',
+        set_name: 'Ultimate Masters',
+        set_type: 'masters',
+        set_uri:
+            'https://api.scryfall.com/sets/2ec77b94-6d47-4891-a480-5d0b4e5c9372',
+        set_search_uri:
+            'https://api.scryfall.com/cards/search?order=set&q=e%3Auma&unique=prints',
+        scryfall_set_uri: 'https://scryfall.com/sets/uma?utm_source=api',
+        rulings_uri:
+            'https://api.scryfall.com/cards/fcac0cff-efa6-4068-a69c-67ea4e7acea0/rulings',
+        prints_search_uri:
+            'https://api.scryfall.com/cards/search?order=released&q=oracleid%3Ae55104e2-4900-48de-b288-d3e6abd5e09e&unique=prints',
+        collector_number: '206',
+        digital: false,
+        rarity: 'mythic',
+        flavor_text: 'Great devotion yields great reward.',
+        card_back_id: '0aeebaf5-8c7d-4636-9e82-8c27447861f7',
+        artist: 'Chris Rahn',
+        artist_ids: ['7742047e-0f80-4c0f-a530-d07460165e86'],
+        illustration_id: '6148d251-479b-4510-b79b-90fe624bc025',
+        border_color: 'black',
+        frame: '2015',
+        frame_effects: ['legendary'],
+        full_art: false,
+        textless: false,
+        booster: true,
+        story_spotlight: false,
+        edhrec_rank: 1257,
+        related_uris: {
+            gatherer:
+                'https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=456802',
+            tcgplayer_decks:
+                'https://decks.tcgplayer.com/magic/deck/search?contains=Sigarda%2C+Host+of+Herons&page=1&partner=Scryfall&utm_campaign=affiliate&utm_medium=scryfall&utm_source=scryfall',
+            edhrec: 'https://edhrec.com/route/?cc=Sigarda%2C+Host+of+Herons',
+            mtgtop8:
+                'https://mtgtop8.com/search?MD_check=1&SB_check=1&cards=Sigarda%2C+Host+of+Herons',
         },
-        "qoh": {
-            "NONFOIL_NM": 3
+        qoh: {
+            NONFOIL_NM: 3,
         },
-        "finishCondition": "NONFOIL_NM",
-        "qtyToSell": 1,
-        "price": 0
+        finishCondition: 'NONFOIL_NM',
+        qtyToSell: 1,
+        price: 0,
     },
     {
-        "_id": "d28056c7-c58d-4986-a45c-c9e55aed23a1",
-        "object": "card",
-        "id": "d28056c7-c58d-4986-a45c-c9e55aed23a1",
-        "oracle_id": "08c7db90-c0cf-4482-b7ee-bb033e5996d2",
-        "multiverse_ids": [
-            439782
-        ],
-        "mtgo_id": 66703,
-        "arena_id": 66867,
-        "tcgplayer_id": 155769,
-        "name": "Colossal Dreadmaw",
-        "lang": "en",
-        "released_at": "2018-01-19",
-        "uri": "https://api.scryfall.com/cards/d28056c7-c58d-4986-a45c-c9e55aed23a1",
-        "scryfall_uri": "https://scryfall.com/card/rix/125/colossal-dreadmaw?utm_source=api",
-        "layout": "normal",
-        "highres_image": true,
-        "image_uris": {
-            "small": "https://img.scryfall.com/cards/small/front/d/2/d28056c7-c58d-4986-a45c-c9e55aed23a1.jpg?1555040601",
-            "normal": "https://img.scryfall.com/cards/normal/front/d/2/d28056c7-c58d-4986-a45c-c9e55aed23a1.jpg?1555040601",
-            "large": "https://img.scryfall.com/cards/large/front/d/2/d28056c7-c58d-4986-a45c-c9e55aed23a1.jpg?1555040601",
-            "png": "https://img.scryfall.com/cards/png/front/d/2/d28056c7-c58d-4986-a45c-c9e55aed23a1.png?1555040601",
-            "art_crop": "https://img.scryfall.com/cards/art_crop/front/d/2/d28056c7-c58d-4986-a45c-c9e55aed23a1.jpg?1555040601",
-            "border_crop": "https://img.scryfall.com/cards/border_crop/front/d/2/d28056c7-c58d-4986-a45c-c9e55aed23a1.jpg?1555040601"
+        _id: 'd28056c7-c58d-4986-a45c-c9e55aed23a1',
+        object: 'card',
+        id: 'd28056c7-c58d-4986-a45c-c9e55aed23a1',
+        oracle_id: '08c7db90-c0cf-4482-b7ee-bb033e5996d2',
+        multiverse_ids: [439782],
+        mtgo_id: 66703,
+        arena_id: 66867,
+        tcgplayer_id: 155769,
+        name: 'Colossal Dreadmaw',
+        lang: 'en',
+        released_at: '2018-01-19',
+        uri:
+            'https://api.scryfall.com/cards/d28056c7-c58d-4986-a45c-c9e55aed23a1',
+        scryfall_uri:
+            'https://scryfall.com/card/rix/125/colossal-dreadmaw?utm_source=api',
+        layout: 'normal',
+        highres_image: true,
+        image_uris: {
+            small:
+                'https://img.scryfall.com/cards/small/front/d/2/d28056c7-c58d-4986-a45c-c9e55aed23a1.jpg?1555040601',
+            normal:
+                'https://img.scryfall.com/cards/normal/front/d/2/d28056c7-c58d-4986-a45c-c9e55aed23a1.jpg?1555040601',
+            large:
+                'https://img.scryfall.com/cards/large/front/d/2/d28056c7-c58d-4986-a45c-c9e55aed23a1.jpg?1555040601',
+            png:
+                'https://img.scryfall.com/cards/png/front/d/2/d28056c7-c58d-4986-a45c-c9e55aed23a1.png?1555040601',
+            art_crop:
+                'https://img.scryfall.com/cards/art_crop/front/d/2/d28056c7-c58d-4986-a45c-c9e55aed23a1.jpg?1555040601',
+            border_crop:
+                'https://img.scryfall.com/cards/border_crop/front/d/2/d28056c7-c58d-4986-a45c-c9e55aed23a1.jpg?1555040601',
         },
-        "mana_cost": "{4}{G}{G}",
-        "cmc": 6,
-        "type_line": "Creature — Dinosaur",
-        "oracle_text": "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)",
-        "power": "6",
-        "toughness": "6",
-        "colors": [
-            "G"
-        ],
-        "color_identity": [
-            "G"
-        ],
-        "legalities": {
-            "standard": "not_legal",
-            "future": "not_legal",
-            "historic": "legal",
-            "pioneer": "legal",
-            "modern": "legal",
-            "legacy": "legal",
-            "pauper": "legal",
-            "vintage": "legal",
-            "penny": "legal",
-            "commander": "legal",
-            "brawl": "not_legal",
-            "duel": "legal",
-            "oldschool": "not_legal"
+        mana_cost: '{4}{G}{G}',
+        cmc: 6,
+        type_line: 'Creature — Dinosaur',
+        oracle_text:
+            "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)",
+        power: '6',
+        toughness: '6',
+        colors: ['G'],
+        color_identity: ['G'],
+        legalities: {
+            standard: 'not_legal',
+            future: 'not_legal',
+            historic: 'legal',
+            pioneer: 'legal',
+            modern: 'legal',
+            legacy: 'legal',
+            pauper: 'legal',
+            vintage: 'legal',
+            penny: 'legal',
+            commander: 'legal',
+            brawl: 'not_legal',
+            duel: 'legal',
+            oldschool: 'not_legal',
         },
-        "games": [
-            "arena",
-            "mtgo",
-            "paper"
-        ],
-        "reserved": false,
-        "foil": true,
-        "nonfoil": true,
-        "oversized": false,
-        "promo": false,
-        "reprint": true,
-        "variation": false,
-        "set": "rix",
-        "set_name": "Rivals of Ixalan",
-        "set_type": "expansion",
-        "set_uri": "https://api.scryfall.com/sets/2f7e40fc-772d-4a85-bfdd-01653c41d0fa",
-        "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Arix&unique=prints",
-        "scryfall_set_uri": "https://scryfall.com/sets/rix?utm_source=api",
-        "rulings_uri": "https://api.scryfall.com/cards/d28056c7-c58d-4986-a45c-c9e55aed23a1/rulings",
-        "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3A08c7db90-c0cf-4482-b7ee-bb033e5996d2&unique=prints",
-        "collector_number": "125",
-        "digital": false,
-        "rarity": "common",
-        "flavor_text": "\"Remember when it was the most terrifying thing you'd ever seen?\" —Captain Lannery Storm",
-        "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
-        "artist": "Jesper Ejsing",
-        "artist_ids": [
-            "a5f8354a-8b51-4e59-96b2-0e3aeae4fa1d"
-        ],
-        "illustration_id": "1339de69-bb3d-4925-a3c3-fd44da310958",
-        "border_color": "black",
-        "frame": "2015",
-        "full_art": false,
-        "textless": false,
-        "booster": true,
-        "story_spotlight": false,
-        "edhrec_rank": 5320,
-        "related_uris": {
-            "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=439782",
-            "tcgplayer_decks": "https://decks.tcgplayer.com/magic/deck/search?contains=Colossal+Dreadmaw&page=1&partner=Scryfall&utm_campaign=affiliate&utm_medium=scryfall&utm_source=scryfall",
-            "edhrec": "https://edhrec.com/route/?cc=Colossal+Dreadmaw",
-            "mtgtop8": "https://mtgtop8.com/search?MD_check=1&SB_check=1&cards=Colossal+Dreadmaw"
+        games: ['arena', 'mtgo', 'paper'],
+        reserved: false,
+        foil: true,
+        nonfoil: true,
+        oversized: false,
+        promo: false,
+        reprint: true,
+        variation: false,
+        set: 'rix',
+        set_name: 'Rivals of Ixalan',
+        set_type: 'expansion',
+        set_uri:
+            'https://api.scryfall.com/sets/2f7e40fc-772d-4a85-bfdd-01653c41d0fa',
+        set_search_uri:
+            'https://api.scryfall.com/cards/search?order=set&q=e%3Arix&unique=prints',
+        scryfall_set_uri: 'https://scryfall.com/sets/rix?utm_source=api',
+        rulings_uri:
+            'https://api.scryfall.com/cards/d28056c7-c58d-4986-a45c-c9e55aed23a1/rulings',
+        prints_search_uri:
+            'https://api.scryfall.com/cards/search?order=released&q=oracleid%3A08c7db90-c0cf-4482-b7ee-bb033e5996d2&unique=prints',
+        collector_number: '125',
+        digital: false,
+        rarity: 'common',
+        flavor_text:
+            '"Remember when it was the most terrifying thing you\'d ever seen?" —Captain Lannery Storm',
+        card_back_id: '0aeebaf5-8c7d-4636-9e82-8c27447861f7',
+        artist: 'Jesper Ejsing',
+        artist_ids: ['a5f8354a-8b51-4e59-96b2-0e3aeae4fa1d'],
+        illustration_id: '1339de69-bb3d-4925-a3c3-fd44da310958',
+        border_color: 'black',
+        frame: '2015',
+        full_art: false,
+        textless: false,
+        booster: true,
+        story_spotlight: false,
+        edhrec_rank: 5320,
+        related_uris: {
+            gatherer:
+                'https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=439782',
+            tcgplayer_decks:
+                'https://decks.tcgplayer.com/magic/deck/search?contains=Colossal+Dreadmaw&page=1&partner=Scryfall&utm_campaign=affiliate&utm_medium=scryfall&utm_source=scryfall',
+            edhrec: 'https://edhrec.com/route/?cc=Colossal+Dreadmaw',
+            mtgtop8:
+                'https://mtgtop8.com/search?MD_check=1&SB_check=1&cards=Colossal+Dreadmaw',
         },
-        "qoh": {
-            "NONFOIL_NM": 5
+        qoh: {
+            NONFOIL_NM: 5,
         },
-        "finishCondition": "NONFOIL_NM",
-        "qtyToSell": 1,
-        "price": 0
+        finishCondition: 'NONFOIL_NM',
+        qtyToSell: 1,
+        price: 0,
     },
     {
-        "_id": "9052369f-840f-438e-b86d-e2f8d6339585",
-        "artist": "Daniel Gelon",
-        "artist_ids": [
-            "63ac31a8-dd1a-4679-9f82-ece89429a084"
-        ],
-        "booster": true,
-        "border_color": "black",
-        "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
-        "cmc": 3,
-        "collector_number": "184",
-        "color_identity": [
-            "R"
-        ],
-        "colors": [
-            "R"
-        ],
-        "digital": false,
-        "edhrec_rank": 547,
-        "foil": false,
-        "frame": "1993",
-        "full_art": false,
-        "games": [
-            "paper"
-        ],
-        "highres_image": true,
-        "id": "9052369f-840f-438e-b86d-e2f8d6339585",
-        "illustration_id": "2374c264-9c65-4961-84e4-ec44c241355c",
-        "image_uris": {
-            "small": "https://img.scryfall.com/cards/small/front/9/0/9052369f-840f-438e-b86d-e2f8d6339585.jpg?1559591625",
-            "normal": "https://img.scryfall.com/cards/normal/front/9/0/9052369f-840f-438e-b86d-e2f8d6339585.jpg?1559591625",
-            "large": "https://img.scryfall.com/cards/large/front/9/0/9052369f-840f-438e-b86d-e2f8d6339585.jpg?1559591625",
-            "png": "https://img.scryfall.com/cards/png/front/9/0/9052369f-840f-438e-b86d-e2f8d6339585.png?1559591625",
-            "art_crop": "https://img.scryfall.com/cards/art_crop/front/9/0/9052369f-840f-438e-b86d-e2f8d6339585.jpg?1559591625",
-            "border_crop": "https://img.scryfall.com/cards/border_crop/front/9/0/9052369f-840f-438e-b86d-e2f8d6339585.jpg?1559591625"
+        _id: '9052369f-840f-438e-b86d-e2f8d6339585',
+        artist: 'Daniel Gelon',
+        artist_ids: ['63ac31a8-dd1a-4679-9f82-ece89429a084'],
+        booster: true,
+        border_color: 'black',
+        card_back_id: '0aeebaf5-8c7d-4636-9e82-8c27447861f7',
+        cmc: 3,
+        collector_number: '184',
+        color_identity: ['R'],
+        colors: ['R'],
+        digital: false,
+        edhrec_rank: 547,
+        foil: false,
+        frame: '1993',
+        full_art: false,
+        games: ['paper'],
+        highres_image: true,
+        id: '9052369f-840f-438e-b86d-e2f8d6339585',
+        illustration_id: '2374c264-9c65-4961-84e4-ec44c241355c',
+        image_uris: {
+            small:
+                'https://img.scryfall.com/cards/small/front/9/0/9052369f-840f-438e-b86d-e2f8d6339585.jpg?1559591625',
+            normal:
+                'https://img.scryfall.com/cards/normal/front/9/0/9052369f-840f-438e-b86d-e2f8d6339585.jpg?1559591625',
+            large:
+                'https://img.scryfall.com/cards/large/front/9/0/9052369f-840f-438e-b86d-e2f8d6339585.jpg?1559591625',
+            png:
+                'https://img.scryfall.com/cards/png/front/9/0/9052369f-840f-438e-b86d-e2f8d6339585.png?1559591625',
+            art_crop:
+                'https://img.scryfall.com/cards/art_crop/front/9/0/9052369f-840f-438e-b86d-e2f8d6339585.jpg?1559591625',
+            border_crop:
+                'https://img.scryfall.com/cards/border_crop/front/9/0/9052369f-840f-438e-b86d-e2f8d6339585.jpg?1559591625',
         },
-        "lang": "en",
-        "layout": "normal",
-        "legalities": {
-            "standard": "not_legal",
-            "future": "not_legal",
-            "historic": "not_legal",
-            "pioneer": "not_legal",
-            "modern": "not_legal",
-            "legacy": "banned",
-            "pauper": "not_legal",
-            "vintage": "restricted",
-            "penny": "not_legal",
-            "commander": "legal",
-            "brawl": "not_legal",
-            "duel": "legal",
-            "oldschool": "restricted"
+        lang: 'en',
+        layout: 'normal',
+        legalities: {
+            standard: 'not_legal',
+            future: 'not_legal',
+            historic: 'not_legal',
+            pioneer: 'not_legal',
+            modern: 'not_legal',
+            legacy: 'banned',
+            pauper: 'not_legal',
+            vintage: 'restricted',
+            penny: 'not_legal',
+            commander: 'legal',
+            brawl: 'not_legal',
+            duel: 'legal',
+            oldschool: 'restricted',
         },
-        "mana_cost": "{2}{R}",
-        "multiverse_ids": [
-            526
-        ],
-        "name": "Wheel of Fortune",
-        "nonfoil": true,
-        "object": "card",
-        "oracle_id": "a8abd966-de7b-46a3-8ac7-8747ab35653a",
-        "oracle_text": "Each player discards their hand, then draws seven cards.",
-        "oversized": false,
-        "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3Aa8abd966-de7b-46a3-8ac7-8747ab35653a&unique=prints",
-        "promo": false,
-        "qoh": {
-            "NONFOIL_NM": 4
+        mana_cost: '{2}{R}',
+        multiverse_ids: [526],
+        name: 'Wheel of Fortune',
+        nonfoil: true,
+        object: 'card',
+        oracle_id: 'a8abd966-de7b-46a3-8ac7-8747ab35653a',
+        oracle_text: 'Each player discards their hand, then draws seven cards.',
+        oversized: false,
+        prints_search_uri:
+            'https://api.scryfall.com/cards/search?order=released&q=oracleid%3Aa8abd966-de7b-46a3-8ac7-8747ab35653a&unique=prints',
+        promo: false,
+        qoh: {
+            NONFOIL_NM: 4,
         },
-        "rarity": "rare",
-        "related_uris": {
-            "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=526",
-            "tcgplayer_decks": "https://decks.tcgplayer.com/magic/deck/search?contains=Wheel+of+Fortune&page=1&partner=Scryfall&utm_campaign=affiliate&utm_medium=scryfall&utm_source=scryfall",
-            "edhrec": "https://edhrec.com/route/?cc=Wheel+of+Fortune",
-            "mtgtop8": "https://mtgtop8.com/search?MD_check=1&SB_check=1&cards=Wheel+of+Fortune"
+        rarity: 'rare',
+        related_uris: {
+            gatherer:
+                'https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=526',
+            tcgplayer_decks:
+                'https://decks.tcgplayer.com/magic/deck/search?contains=Wheel+of+Fortune&page=1&partner=Scryfall&utm_campaign=affiliate&utm_medium=scryfall&utm_source=scryfall',
+            edhrec: 'https://edhrec.com/route/?cc=Wheel+of+Fortune',
+            mtgtop8:
+                'https://mtgtop8.com/search?MD_check=1&SB_check=1&cards=Wheel+of+Fortune',
         },
-        "released_at": "1993-10-04",
-        "reprint": true,
-        "reserved": true,
-        "rulings_uri": "https://api.scryfall.com/cards/9052369f-840f-438e-b86d-e2f8d6339585/rulings",
-        "scryfall_set_uri": "https://scryfall.com/sets/leb?utm_source=api",
-        "scryfall_uri": "https://scryfall.com/card/leb/184/wheel-of-fortune?utm_source=api",
-        "set": "leb",
-        "set_name": "Limited Edition Beta",
-        "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Aleb&unique=prints",
-        "set_type": "core",
-        "set_uri": "https://api.scryfall.com/sets/5307bd88-637c-4a5c-9801-a0d887715302",
-        "showImage": true,
-        "story_spotlight": false,
-        "tcgplayer_id": 8962,
-        "textless": false,
-        "type_line": "Sorcery",
-        "uri": "https://api.scryfall.com/cards/9052369f-840f-438e-b86d-e2f8d6339585",
-        "variation": false,
-        "finishCondition": "NONFOIL_NM",
-        "qtyToSell": 1,
-        "price": 0
+        released_at: '1993-10-04',
+        reprint: true,
+        reserved: true,
+        rulings_uri:
+            'https://api.scryfall.com/cards/9052369f-840f-438e-b86d-e2f8d6339585/rulings',
+        scryfall_set_uri: 'https://scryfall.com/sets/leb?utm_source=api',
+        scryfall_uri:
+            'https://scryfall.com/card/leb/184/wheel-of-fortune?utm_source=api',
+        set: 'leb',
+        set_name: 'Limited Edition Beta',
+        set_search_uri:
+            'https://api.scryfall.com/cards/search?order=set&q=e%3Aleb&unique=prints',
+        set_type: 'core',
+        set_uri:
+            'https://api.scryfall.com/sets/5307bd88-637c-4a5c-9801-a0d887715302',
+        showImage: true,
+        story_spotlight: false,
+        tcgplayer_id: 8962,
+        textless: false,
+        type_line: 'Sorcery',
+        uri:
+            'https://api.scryfall.com/cards/9052369f-840f-438e-b86d-e2f8d6339585',
+        variation: false,
+        finishCondition: 'NONFOIL_NM',
+        qtyToSell: 1,
+        price: 0,
     },
     {
-        "_id": "c89c6895-b0f8-444a-9c89-c6b4fd027b3e",
-        "object": "card",
-        "id": "c89c6895-b0f8-444a-9c89-c6b4fd027b3e",
-        "oracle_id": "94a844d2-0574-45a7-b347-e0e329767c42",
-        "multiverse_ids": [
-            438664
-        ],
-        "mtgo_id": 66075,
-        "mtgo_foil_id": 66076,
-        "tcgplayer_id": 145298,
-        "name": "Necropotence",
-        "lang": "en",
-        "released_at": "2017-11-17",
-        "uri": "https://api.scryfall.com/cards/c89c6895-b0f8-444a-9c89-c6b4fd027b3e",
-        "scryfall_uri": "https://scryfall.com/card/ima/98/necropotence?utm_source=api",
-        "layout": "normal",
-        "highres_image": true,
-        "image_uris": {
-            "small": "https://img.scryfall.com/cards/small/front/c/8/c89c6895-b0f8-444a-9c89-c6b4fd027b3e.jpg?1562853736",
-            "normal": "https://img.scryfall.com/cards/normal/front/c/8/c89c6895-b0f8-444a-9c89-c6b4fd027b3e.jpg?1562853736",
-            "large": "https://img.scryfall.com/cards/large/front/c/8/c89c6895-b0f8-444a-9c89-c6b4fd027b3e.jpg?1562853736",
-            "png": "https://img.scryfall.com/cards/png/front/c/8/c89c6895-b0f8-444a-9c89-c6b4fd027b3e.png?1562853736",
-            "art_crop": "https://img.scryfall.com/cards/art_crop/front/c/8/c89c6895-b0f8-444a-9c89-c6b4fd027b3e.jpg?1562853736",
-            "border_crop": "https://img.scryfall.com/cards/border_crop/front/c/8/c89c6895-b0f8-444a-9c89-c6b4fd027b3e.jpg?1562853736"
+        _id: 'c89c6895-b0f8-444a-9c89-c6b4fd027b3e',
+        object: 'card',
+        id: 'c89c6895-b0f8-444a-9c89-c6b4fd027b3e',
+        oracle_id: '94a844d2-0574-45a7-b347-e0e329767c42',
+        multiverse_ids: [438664],
+        mtgo_id: 66075,
+        mtgo_foil_id: 66076,
+        tcgplayer_id: 145298,
+        name: 'Necropotence',
+        lang: 'en',
+        released_at: '2017-11-17',
+        uri:
+            'https://api.scryfall.com/cards/c89c6895-b0f8-444a-9c89-c6b4fd027b3e',
+        scryfall_uri:
+            'https://scryfall.com/card/ima/98/necropotence?utm_source=api',
+        layout: 'normal',
+        highres_image: true,
+        image_uris: {
+            small:
+                'https://img.scryfall.com/cards/small/front/c/8/c89c6895-b0f8-444a-9c89-c6b4fd027b3e.jpg?1562853736',
+            normal:
+                'https://img.scryfall.com/cards/normal/front/c/8/c89c6895-b0f8-444a-9c89-c6b4fd027b3e.jpg?1562853736',
+            large:
+                'https://img.scryfall.com/cards/large/front/c/8/c89c6895-b0f8-444a-9c89-c6b4fd027b3e.jpg?1562853736',
+            png:
+                'https://img.scryfall.com/cards/png/front/c/8/c89c6895-b0f8-444a-9c89-c6b4fd027b3e.png?1562853736',
+            art_crop:
+                'https://img.scryfall.com/cards/art_crop/front/c/8/c89c6895-b0f8-444a-9c89-c6b4fd027b3e.jpg?1562853736',
+            border_crop:
+                'https://img.scryfall.com/cards/border_crop/front/c/8/c89c6895-b0f8-444a-9c89-c6b4fd027b3e.jpg?1562853736',
         },
-        "mana_cost": "{B}{B}{B}",
-        "cmc": 3,
-        "type_line": "Enchantment",
-        "oracle_text": "Skip your draw step.\nWhenever you discard a card, exile that card from your graveyard.\nPay 1 life: Exile the top card of your library face down. Put that card into your hand at the beginning of your next end step.",
-        "colors": [
-            "B"
-        ],
-        "color_identity": [
-            "B"
-        ],
-        "legalities": {
-            "standard": "not_legal",
-            "future": "not_legal",
-            "historic": "not_legal",
-            "pioneer": "not_legal",
-            "modern": "not_legal",
-            "legacy": "banned",
-            "pauper": "not_legal",
-            "vintage": "restricted",
-            "penny": "not_legal",
-            "commander": "legal",
-            "brawl": "not_legal",
-            "duel": "legal",
-            "oldschool": "not_legal"
+        mana_cost: '{B}{B}{B}',
+        cmc: 3,
+        type_line: 'Enchantment',
+        oracle_text:
+            'Skip your draw step.\nWhenever you discard a card, exile that card from your graveyard.\nPay 1 life: Exile the top card of your library face down. Put that card into your hand at the beginning of your next end step.',
+        colors: ['B'],
+        color_identity: ['B'],
+        legalities: {
+            standard: 'not_legal',
+            future: 'not_legal',
+            historic: 'not_legal',
+            pioneer: 'not_legal',
+            modern: 'not_legal',
+            legacy: 'banned',
+            pauper: 'not_legal',
+            vintage: 'restricted',
+            penny: 'not_legal',
+            commander: 'legal',
+            brawl: 'not_legal',
+            duel: 'legal',
+            oldschool: 'not_legal',
         },
-        "games": [
-            "mtgo",
-            "paper"
-        ],
-        "reserved": false,
-        "foil": true,
-        "nonfoil": true,
-        "oversized": false,
-        "promo": false,
-        "reprint": true,
-        "variation": false,
-        "set": "ima",
-        "set_name": "Iconic Masters",
-        "set_type": "masters",
-        "set_uri": "https://api.scryfall.com/sets/741bcd30-7709-4133-8919-f4b46483bed7",
-        "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Aima&unique=prints",
-        "scryfall_set_uri": "https://scryfall.com/sets/ima?utm_source=api",
-        "rulings_uri": "https://api.scryfall.com/cards/c89c6895-b0f8-444a-9c89-c6b4fd027b3e/rulings",
-        "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3A94a844d2-0574-45a7-b347-e0e329767c42&unique=prints",
-        "collector_number": "98",
-        "digital": false,
-        "rarity": "mythic",
-        "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
-        "artist": "Dave Kendall",
-        "artist_ids": [
-            "8a5540a8-18c9-4fa9-802c-59d6866114d5"
-        ],
-        "illustration_id": "bd27df63-cbdc-4c76-b868-55893de8da6c",
-        "border_color": "black",
-        "frame": "2015",
-        "full_art": false,
-        "textless": false,
-        "booster": true,
-        "story_spotlight": false,
-        "edhrec_rank": 232,
-        "related_uris": {
-            "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=438664",
-            "tcgplayer_decks": "https://decks.tcgplayer.com/magic/deck/search?contains=Necropotence&page=1&partner=Scryfall&utm_campaign=affiliate&utm_medium=scryfall&utm_source=scryfall",
-            "edhrec": "https://edhrec.com/route/?cc=Necropotence",
-            "mtgtop8": "https://mtgtop8.com/search?MD_check=1&SB_check=1&cards=Necropotence"
+        games: ['mtgo', 'paper'],
+        reserved: false,
+        foil: true,
+        nonfoil: true,
+        oversized: false,
+        promo: false,
+        reprint: true,
+        variation: false,
+        set: 'ima',
+        set_name: 'Iconic Masters',
+        set_type: 'masters',
+        set_uri:
+            'https://api.scryfall.com/sets/741bcd30-7709-4133-8919-f4b46483bed7',
+        set_search_uri:
+            'https://api.scryfall.com/cards/search?order=set&q=e%3Aima&unique=prints',
+        scryfall_set_uri: 'https://scryfall.com/sets/ima?utm_source=api',
+        rulings_uri:
+            'https://api.scryfall.com/cards/c89c6895-b0f8-444a-9c89-c6b4fd027b3e/rulings',
+        prints_search_uri:
+            'https://api.scryfall.com/cards/search?order=released&q=oracleid%3A94a844d2-0574-45a7-b347-e0e329767c42&unique=prints',
+        collector_number: '98',
+        digital: false,
+        rarity: 'mythic',
+        card_back_id: '0aeebaf5-8c7d-4636-9e82-8c27447861f7',
+        artist: 'Dave Kendall',
+        artist_ids: ['8a5540a8-18c9-4fa9-802c-59d6866114d5'],
+        illustration_id: 'bd27df63-cbdc-4c76-b868-55893de8da6c',
+        border_color: 'black',
+        frame: '2015',
+        full_art: false,
+        textless: false,
+        booster: true,
+        story_spotlight: false,
+        edhrec_rank: 232,
+        related_uris: {
+            gatherer:
+                'https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=438664',
+            tcgplayer_decks:
+                'https://decks.tcgplayer.com/magic/deck/search?contains=Necropotence&page=1&partner=Scryfall&utm_campaign=affiliate&utm_medium=scryfall&utm_source=scryfall',
+            edhrec: 'https://edhrec.com/route/?cc=Necropotence',
+            mtgtop8:
+                'https://mtgtop8.com/search?MD_check=1&SB_check=1&cards=Necropotence',
         },
-        "qoh": {
-            "NONFOIL_NM": 2
+        qoh: {
+            NONFOIL_NM: 2,
         },
-        "finishCondition": "NONFOIL_NM",
-        "qtyToSell": 1,
-        "price": 0
+        finishCondition: 'NONFOIL_NM',
+        qtyToSell: 1,
+        price: 0,
     },
     {
-        "_id": "9d75faf7-fc27-4fc2-9e80-e35232c42542",
-        "object": "card",
-        "id": "9d75faf7-fc27-4fc2-9e80-e35232c42542",
-        "oracle_id": "6c94a255-c031-48d7-aa07-1189ad3da3b6",
-        "multiverse_ids": [
-            463990
-        ],
-        "mtgo_id": 72454,
-        "tcgplayer_id": 190980,
-        "name": "Bazaar Trademage",
-        "lang": "en",
-        "released_at": "2019-06-14",
-        "uri": "https://api.scryfall.com/cards/9d75faf7-fc27-4fc2-9e80-e35232c42542",
-        "scryfall_uri": "https://scryfall.com/card/mh1/41/bazaar-trademage?utm_source=api",
-        "layout": "normal",
-        "highres_image": true,
-        "image_uris": {
-            "small": "https://img.scryfall.com/cards/small/front/9/d/9d75faf7-fc27-4fc2-9e80-e35232c42542.jpg?1562201307",
-            "normal": "https://img.scryfall.com/cards/normal/front/9/d/9d75faf7-fc27-4fc2-9e80-e35232c42542.jpg?1562201307",
-            "large": "https://img.scryfall.com/cards/large/front/9/d/9d75faf7-fc27-4fc2-9e80-e35232c42542.jpg?1562201307",
-            "png": "https://img.scryfall.com/cards/png/front/9/d/9d75faf7-fc27-4fc2-9e80-e35232c42542.png?1562201307",
-            "art_crop": "https://img.scryfall.com/cards/art_crop/front/9/d/9d75faf7-fc27-4fc2-9e80-e35232c42542.jpg?1562201307",
-            "border_crop": "https://img.scryfall.com/cards/border_crop/front/9/d/9d75faf7-fc27-4fc2-9e80-e35232c42542.jpg?1562201307"
+        _id: '9d75faf7-fc27-4fc2-9e80-e35232c42542',
+        object: 'card',
+        id: '9d75faf7-fc27-4fc2-9e80-e35232c42542',
+        oracle_id: '6c94a255-c031-48d7-aa07-1189ad3da3b6',
+        multiverse_ids: [463990],
+        mtgo_id: 72454,
+        tcgplayer_id: 190980,
+        name: 'Bazaar Trademage',
+        lang: 'en',
+        released_at: '2019-06-14',
+        uri:
+            'https://api.scryfall.com/cards/9d75faf7-fc27-4fc2-9e80-e35232c42542',
+        scryfall_uri:
+            'https://scryfall.com/card/mh1/41/bazaar-trademage?utm_source=api',
+        layout: 'normal',
+        highres_image: true,
+        image_uris: {
+            small:
+                'https://img.scryfall.com/cards/small/front/9/d/9d75faf7-fc27-4fc2-9e80-e35232c42542.jpg?1562201307',
+            normal:
+                'https://img.scryfall.com/cards/normal/front/9/d/9d75faf7-fc27-4fc2-9e80-e35232c42542.jpg?1562201307',
+            large:
+                'https://img.scryfall.com/cards/large/front/9/d/9d75faf7-fc27-4fc2-9e80-e35232c42542.jpg?1562201307',
+            png:
+                'https://img.scryfall.com/cards/png/front/9/d/9d75faf7-fc27-4fc2-9e80-e35232c42542.png?1562201307',
+            art_crop:
+                'https://img.scryfall.com/cards/art_crop/front/9/d/9d75faf7-fc27-4fc2-9e80-e35232c42542.jpg?1562201307',
+            border_crop:
+                'https://img.scryfall.com/cards/border_crop/front/9/d/9d75faf7-fc27-4fc2-9e80-e35232c42542.jpg?1562201307',
         },
-        "mana_cost": "{2}{U}",
-        "cmc": 3,
-        "type_line": "Creature — Human Wizard",
-        "oracle_text": "Flying\nWhen Bazaar Trademage enters the battlefield, draw two cards, then discard three cards.",
-        "power": "3",
-        "toughness": "4",
-        "colors": [
-            "U"
-        ],
-        "color_identity": [
-            "U"
-        ],
-        "legalities": {
-            "standard": "not_legal",
-            "future": "not_legal",
-            "historic": "not_legal",
-            "pioneer": "not_legal",
-            "modern": "legal",
-            "legacy": "legal",
-            "pauper": "not_legal",
-            "vintage": "legal",
-            "penny": "legal",
-            "commander": "legal",
-            "brawl": "not_legal",
-            "duel": "legal",
-            "oldschool": "not_legal"
+        mana_cost: '{2}{U}',
+        cmc: 3,
+        type_line: 'Creature — Human Wizard',
+        oracle_text:
+            'Flying\nWhen Bazaar Trademage enters the battlefield, draw two cards, then discard three cards.',
+        power: '3',
+        toughness: '4',
+        colors: ['U'],
+        color_identity: ['U'],
+        legalities: {
+            standard: 'not_legal',
+            future: 'not_legal',
+            historic: 'not_legal',
+            pioneer: 'not_legal',
+            modern: 'legal',
+            legacy: 'legal',
+            pauper: 'not_legal',
+            vintage: 'legal',
+            penny: 'legal',
+            commander: 'legal',
+            brawl: 'not_legal',
+            duel: 'legal',
+            oldschool: 'not_legal',
         },
-        "games": [
-            "mtgo",
-            "paper"
-        ],
-        "reserved": false,
-        "foil": true,
-        "nonfoil": true,
-        "oversized": false,
-        "promo": false,
-        "reprint": false,
-        "variation": false,
-        "set": "mh1",
-        "set_name": "Modern Horizons",
-        "set_type": "draft_innovation",
-        "set_uri": "https://api.scryfall.com/sets/d7efccd6-55bc-4fb8-9138-e72577510a99",
-        "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Amh1&unique=prints",
-        "scryfall_set_uri": "https://scryfall.com/sets/mh1?utm_source=api",
-        "rulings_uri": "https://api.scryfall.com/cards/9d75faf7-fc27-4fc2-9e80-e35232c42542/rulings",
-        "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3A6c94a255-c031-48d7-aa07-1189ad3da3b6&unique=prints",
-        "collector_number": "41",
-        "digital": false,
-        "rarity": "rare",
-        "flavor_text": "He traded a lamp for a scepter, a scepter for a ruby, and the ruby for a simple rug.",
-        "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
-        "artist": "Christopher Moeller",
-        "artist_ids": [
-            "21e10012-06ae-44f2-b38d-3824dd2e73d4"
-        ],
-        "illustration_id": "8ae9df7a-8829-4f1e-bb2a-a14970671409",
-        "border_color": "black",
-        "frame": "2015",
-        "full_art": false,
-        "textless": false,
-        "booster": true,
-        "story_spotlight": false,
-        "edhrec_rank": 10504,
-        "preview": {
-            "source": "Autumn Burchett",
-            "source_uri": "https://twitter.com/AutumnLilyMTG/status/1131616962436567040?s=19",
-            "previewed_at": "2019-05-23"
+        games: ['mtgo', 'paper'],
+        reserved: false,
+        foil: true,
+        nonfoil: true,
+        oversized: false,
+        promo: false,
+        reprint: false,
+        variation: false,
+        set: 'mh1',
+        set_name: 'Modern Horizons',
+        set_type: 'draft_innovation',
+        set_uri:
+            'https://api.scryfall.com/sets/d7efccd6-55bc-4fb8-9138-e72577510a99',
+        set_search_uri:
+            'https://api.scryfall.com/cards/search?order=set&q=e%3Amh1&unique=prints',
+        scryfall_set_uri: 'https://scryfall.com/sets/mh1?utm_source=api',
+        rulings_uri:
+            'https://api.scryfall.com/cards/9d75faf7-fc27-4fc2-9e80-e35232c42542/rulings',
+        prints_search_uri:
+            'https://api.scryfall.com/cards/search?order=released&q=oracleid%3A6c94a255-c031-48d7-aa07-1189ad3da3b6&unique=prints',
+        collector_number: '41',
+        digital: false,
+        rarity: 'rare',
+        flavor_text:
+            'He traded a lamp for a scepter, a scepter for a ruby, and the ruby for a simple rug.',
+        card_back_id: '0aeebaf5-8c7d-4636-9e82-8c27447861f7',
+        artist: 'Christopher Moeller',
+        artist_ids: ['21e10012-06ae-44f2-b38d-3824dd2e73d4'],
+        illustration_id: '8ae9df7a-8829-4f1e-bb2a-a14970671409',
+        border_color: 'black',
+        frame: '2015',
+        full_art: false,
+        textless: false,
+        booster: true,
+        story_spotlight: false,
+        edhrec_rank: 10504,
+        preview: {
+            source: 'Autumn Burchett',
+            source_uri:
+                'https://twitter.com/AutumnLilyMTG/status/1131616962436567040?s=19',
+            previewed_at: '2019-05-23',
         },
-        "related_uris": {
-            "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=463990",
-            "tcgplayer_decks": "https://decks.tcgplayer.com/magic/deck/search?contains=Bazaar+Trademage&page=1&partner=Scryfall&utm_campaign=affiliate&utm_medium=scryfall&utm_source=scryfall",
-            "edhrec": "https://edhrec.com/route/?cc=Bazaar+Trademage",
-            "mtgtop8": "https://mtgtop8.com/search?MD_check=1&SB_check=1&cards=Bazaar+Trademage"
+        related_uris: {
+            gatherer:
+                'https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=463990',
+            tcgplayer_decks:
+                'https://decks.tcgplayer.com/magic/deck/search?contains=Bazaar+Trademage&page=1&partner=Scryfall&utm_campaign=affiliate&utm_medium=scryfall&utm_source=scryfall',
+            edhrec: 'https://edhrec.com/route/?cc=Bazaar+Trademage',
+            mtgtop8:
+                'https://mtgtop8.com/search?MD_check=1&SB_check=1&cards=Bazaar+Trademage',
         },
-        "qoh": {
-            "FOIL_NM": 1,
-            "NONFOIL_NM": 1
+        qoh: {
+            FOIL_NM: 1,
+            NONFOIL_NM: 1,
         },
-        "finishCondition": "FOIL_NM",
-        "qtyToSell": 1,
-        "price": 0
+        finishCondition: 'FOIL_NM',
+        qtyToSell: 1,
+        price: 0,
     },
     {
-        "_id": "ae155ee2-008f-4dc6-82bf-476be7baa224",
-        "artist": "James Ryman",
-        "artist_ids": [
-            "3852bbc9-11c0-4fe3-8722-a06ad7e2bcc5"
-        ],
-        "booster": true,
-        "border_color": "black",
-        "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
-        "card_faces": [
+        _id: 'ae155ee2-008f-4dc6-82bf-476be7baa224',
+        artist: 'James Ryman',
+        artist_ids: ['3852bbc9-11c0-4fe3-8722-a06ad7e2bcc5'],
+        booster: true,
+        border_color: 'black',
+        card_back_id: '0aeebaf5-8c7d-4636-9e82-8c27447861f7',
+        card_faces: [
             {
-                "object": "card_face",
-                "name": "Archangel Avacyn",
-                "mana_cost": "{3}{W}{W}",
-                "type_line": "Legendary Creature — Angel",
-                "oracle_text": "Flash\nFlying, vigilance\nWhen Archangel Avacyn enters the battlefield, creatures you control gain indestructible until end of turn.\nWhen a non-Angel creature you control dies, transform Archangel Avacyn at the beginning of the next upkeep.",
-                "colors": [
-                    "W"
-                ],
-                "power": "4",
-                "toughness": "4",
-                "artist": "James Ryman",
-                "artist_id": "3852bbc9-11c0-4fe3-8722-a06ad7e2bcc5",
-                "illustration_id": "f90dd248-e671-4055-8031-c0f9938132ee",
-                "image_uris": {
-                    "small": "https://img.scryfall.com/cards/small/front/a/e/ae155ee2-008f-4dc6-82bf-476be7baa224.jpg?1576383667",
-                    "normal": "https://img.scryfall.com/cards/normal/front/a/e/ae155ee2-008f-4dc6-82bf-476be7baa224.jpg?1576383667",
-                    "large": "https://img.scryfall.com/cards/large/front/a/e/ae155ee2-008f-4dc6-82bf-476be7baa224.jpg?1576383667",
-                    "png": "https://img.scryfall.com/cards/png/front/a/e/ae155ee2-008f-4dc6-82bf-476be7baa224.png?1576383667",
-                    "art_crop": "https://img.scryfall.com/cards/art_crop/front/a/e/ae155ee2-008f-4dc6-82bf-476be7baa224.jpg?1576383667",
-                    "border_crop": "https://img.scryfall.com/cards/border_crop/front/a/e/ae155ee2-008f-4dc6-82bf-476be7baa224.jpg?1576383667"
-                }
+                object: 'card_face',
+                name: 'Archangel Avacyn',
+                mana_cost: '{3}{W}{W}',
+                type_line: 'Legendary Creature — Angel',
+                oracle_text:
+                    'Flash\nFlying, vigilance\nWhen Archangel Avacyn enters the battlefield, creatures you control gain indestructible until end of turn.\nWhen a non-Angel creature you control dies, transform Archangel Avacyn at the beginning of the next upkeep.',
+                colors: ['W'],
+                power: '4',
+                toughness: '4',
+                artist: 'James Ryman',
+                artist_id: '3852bbc9-11c0-4fe3-8722-a06ad7e2bcc5',
+                illustration_id: 'f90dd248-e671-4055-8031-c0f9938132ee',
+                image_uris: {
+                    small:
+                        'https://img.scryfall.com/cards/small/front/a/e/ae155ee2-008f-4dc6-82bf-476be7baa224.jpg?1576383667',
+                    normal:
+                        'https://img.scryfall.com/cards/normal/front/a/e/ae155ee2-008f-4dc6-82bf-476be7baa224.jpg?1576383667',
+                    large:
+                        'https://img.scryfall.com/cards/large/front/a/e/ae155ee2-008f-4dc6-82bf-476be7baa224.jpg?1576383667',
+                    png:
+                        'https://img.scryfall.com/cards/png/front/a/e/ae155ee2-008f-4dc6-82bf-476be7baa224.png?1576383667',
+                    art_crop:
+                        'https://img.scryfall.com/cards/art_crop/front/a/e/ae155ee2-008f-4dc6-82bf-476be7baa224.jpg?1576383667',
+                    border_crop:
+                        'https://img.scryfall.com/cards/border_crop/front/a/e/ae155ee2-008f-4dc6-82bf-476be7baa224.jpg?1576383667',
+                },
             },
             {
-                "object": "card_face",
-                "name": "Avacyn, the Purifier",
-                "mana_cost": "",
-                "type_line": "Legendary Creature — Angel",
-                "oracle_text": "Flying\nWhen this creature transforms into Avacyn, the Purifier, it deals 3 damage to each other creature and each opponent.",
-                "colors": [
-                    "R"
-                ],
-                "color_indicator": [
-                    "R"
-                ],
-                "power": "6",
-                "toughness": "5",
-                "flavor_text": "\"Wings that once bore hope are now stained with blood. She is our guardian no longer.\"\n—Grete, cathar apostate",
-                "artist": "James Ryman",
-                "artist_id": "3852bbc9-11c0-4fe3-8722-a06ad7e2bcc5",
-                "illustration_id": "7c028c56-e6d0-4ce9-aea9-994ba128245f",
-                "image_uris": {
-                    "small": "https://img.scryfall.com/cards/small/back/a/e/ae155ee2-008f-4dc6-82bf-476be7baa224.jpg?1576383667",
-                    "normal": "https://img.scryfall.com/cards/normal/back/a/e/ae155ee2-008f-4dc6-82bf-476be7baa224.jpg?1576383667",
-                    "large": "https://img.scryfall.com/cards/large/back/a/e/ae155ee2-008f-4dc6-82bf-476be7baa224.jpg?1576383667",
-                    "png": "https://img.scryfall.com/cards/png/back/a/e/ae155ee2-008f-4dc6-82bf-476be7baa224.png?1576383667",
-                    "art_crop": "https://img.scryfall.com/cards/art_crop/back/a/e/ae155ee2-008f-4dc6-82bf-476be7baa224.jpg?1576383667",
-                    "border_crop": "https://img.scryfall.com/cards/border_crop/back/a/e/ae155ee2-008f-4dc6-82bf-476be7baa224.jpg?1576383667"
-                }
-            }
+                object: 'card_face',
+                name: 'Avacyn, the Purifier',
+                mana_cost: '',
+                type_line: 'Legendary Creature — Angel',
+                oracle_text:
+                    'Flying\nWhen this creature transforms into Avacyn, the Purifier, it deals 3 damage to each other creature and each opponent.',
+                colors: ['R'],
+                color_indicator: ['R'],
+                power: '6',
+                toughness: '5',
+                flavor_text:
+                    '"Wings that once bore hope are now stained with blood. She is our guardian no longer."\n—Grete, cathar apostate',
+                artist: 'James Ryman',
+                artist_id: '3852bbc9-11c0-4fe3-8722-a06ad7e2bcc5',
+                illustration_id: '7c028c56-e6d0-4ce9-aea9-994ba128245f',
+                image_uris: {
+                    small:
+                        'https://img.scryfall.com/cards/small/back/a/e/ae155ee2-008f-4dc6-82bf-476be7baa224.jpg?1576383667',
+                    normal:
+                        'https://img.scryfall.com/cards/normal/back/a/e/ae155ee2-008f-4dc6-82bf-476be7baa224.jpg?1576383667',
+                    large:
+                        'https://img.scryfall.com/cards/large/back/a/e/ae155ee2-008f-4dc6-82bf-476be7baa224.jpg?1576383667',
+                    png:
+                        'https://img.scryfall.com/cards/png/back/a/e/ae155ee2-008f-4dc6-82bf-476be7baa224.png?1576383667',
+                    art_crop:
+                        'https://img.scryfall.com/cards/art_crop/back/a/e/ae155ee2-008f-4dc6-82bf-476be7baa224.jpg?1576383667',
+                    border_crop:
+                        'https://img.scryfall.com/cards/border_crop/back/a/e/ae155ee2-008f-4dc6-82bf-476be7baa224.jpg?1576383667',
+                },
+            },
         ],
-        "cmc": 5,
-        "collector_number": "5",
-        "color_identity": [
-            "R",
-            "W"
-        ],
-        "digital": false,
-        "edhrec_rank": 2387,
-        "foil": true,
-        "frame": "2015",
-        "frame_effects": [
-            "sunmoondfc"
-        ],
-        "full_art": false,
-        "games": [
-            "paper",
-            "mtgo"
-        ],
-        "highres_image": true,
-        "id": "ae155ee2-008f-4dc6-82bf-476be7baa224",
-        "lang": "en",
-        "layout": "transform",
-        "legalities": {
-            "standard": "not_legal",
-            "future": "not_legal",
-            "historic": "not_legal",
-            "pioneer": "legal",
-            "modern": "legal",
-            "legacy": "legal",
-            "pauper": "not_legal",
-            "vintage": "legal",
-            "penny": "not_legal",
-            "commander": "legal",
-            "brawl": "not_legal",
-            "duel": "legal",
-            "oldschool": "not_legal"
+        cmc: 5,
+        collector_number: '5',
+        color_identity: ['R', 'W'],
+        digital: false,
+        edhrec_rank: 2387,
+        foil: true,
+        frame: '2015',
+        frame_effects: ['sunmoondfc'],
+        full_art: false,
+        games: ['paper', 'mtgo'],
+        highres_image: true,
+        id: 'ae155ee2-008f-4dc6-82bf-476be7baa224',
+        lang: 'en',
+        layout: 'transform',
+        legalities: {
+            standard: 'not_legal',
+            future: 'not_legal',
+            historic: 'not_legal',
+            pioneer: 'legal',
+            modern: 'legal',
+            legacy: 'legal',
+            pauper: 'not_legal',
+            vintage: 'legal',
+            penny: 'not_legal',
+            commander: 'legal',
+            brawl: 'not_legal',
+            duel: 'legal',
+            oldschool: 'not_legal',
         },
-        "mtgo_foil_id": 59767,
-        "mtgo_id": 59766,
-        "multiverse_ids": [
-            409741,
-            409742
-        ],
-        "name": "Archangel Avacyn // Avacyn, the Purifier",
-        "nonfoil": true,
-        "object": "card",
-        "oracle_id": "432b37a5-d32a-4b78-91ab-860aa026b7cc",
-        "oversized": false,
-        "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3A432b37a5-d32a-4b78-91ab-860aa026b7cc&unique=prints",
-        "promo": false,
-        "qoh": {
-            "NONFOIL_NM": 1
+        mtgo_foil_id: 59767,
+        mtgo_id: 59766,
+        multiverse_ids: [409741, 409742],
+        name: 'Archangel Avacyn // Avacyn, the Purifier',
+        nonfoil: true,
+        object: 'card',
+        oracle_id: '432b37a5-d32a-4b78-91ab-860aa026b7cc',
+        oversized: false,
+        prints_search_uri:
+            'https://api.scryfall.com/cards/search?order=released&q=oracleid%3A432b37a5-d32a-4b78-91ab-860aa026b7cc&unique=prints',
+        promo: false,
+        qoh: {
+            NONFOIL_NM: 1,
         },
-        "rarity": "mythic",
-        "related_uris": {
-            "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=409741",
-            "tcgplayer_decks": "https://decks.tcgplayer.com/magic/deck/search?contains=Archangel+Avacyn&page=1&partner=Scryfall&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall",
-            "edhrec": "https://edhrec.com/route/?cc=Archangel+Avacyn",
-            "mtgtop8": "https://mtgtop8.com/search?MD_check=1&SB_check=1&cards=Archangel+Avacyn"
+        rarity: 'mythic',
+        related_uris: {
+            gatherer:
+                'https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=409741',
+            tcgplayer_decks:
+                'https://decks.tcgplayer.com/magic/deck/search?contains=Archangel+Avacyn&page=1&partner=Scryfall&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall',
+            edhrec: 'https://edhrec.com/route/?cc=Archangel+Avacyn',
+            mtgtop8:
+                'https://mtgtop8.com/search?MD_check=1&SB_check=1&cards=Archangel+Avacyn',
         },
-        "released_at": "2016-04-08",
-        "reprint": false,
-        "reserved": false,
-        "rulings_uri": "https://api.scryfall.com/cards/ae155ee2-008f-4dc6-82bf-476be7baa224/rulings",
-        "scryfall_set_uri": "https://scryfall.com/sets/soi?utm_source=api",
-        "scryfall_uri": "https://scryfall.com/card/soi/5/archangel-avacyn-avacyn-the-purifier?utm_source=api",
-        "set": "soi",
-        "set_name": "Shadows over Innistrad",
-        "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Asoi&unique=prints",
-        "set_type": "expansion",
-        "set_uri": "https://api.scryfall.com/sets/5e914d7e-c1e9-446c-a33d-d093c02b2743",
-        "showImage": true,
-        "story_spotlight": false,
-        "tcgplayer_id": 114848,
-        "textless": false,
-        "type_line": "Legendary Creature — Angel // Legendary Creature — Angel",
-        "uri": "https://api.scryfall.com/cards/ae155ee2-008f-4dc6-82bf-476be7baa224",
-        "variation": false,
-        "finishCondition": "NONFOIL_NM",
-        "qtyToSell": 1,
-        "price": 0
-    }
-]
+        released_at: '2016-04-08',
+        reprint: false,
+        reserved: false,
+        rulings_uri:
+            'https://api.scryfall.com/cards/ae155ee2-008f-4dc6-82bf-476be7baa224/rulings',
+        scryfall_set_uri: 'https://scryfall.com/sets/soi?utm_source=api',
+        scryfall_uri:
+            'https://scryfall.com/card/soi/5/archangel-avacyn-avacyn-the-purifier?utm_source=api',
+        set: 'soi',
+        set_name: 'Shadows over Innistrad',
+        set_search_uri:
+            'https://api.scryfall.com/cards/search?order=set&q=e%3Asoi&unique=prints',
+        set_type: 'expansion',
+        set_uri:
+            'https://api.scryfall.com/sets/5e914d7e-c1e9-446c-a33d-d093c02b2743',
+        showImage: true,
+        story_spotlight: false,
+        tcgplayer_id: 114848,
+        textless: false,
+        type_line: 'Legendary Creature — Angel // Legendary Creature — Angel',
+        uri:
+            'https://api.scryfall.com/cards/ae155ee2-008f-4dc6-82bf-476be7baa224',
+        variation: false,
+        finishCondition: 'NONFOIL_NM',
+        qtyToSell: 1,
+        price: 0,
+    },
+    {
+        object: 'card',
+        id: '0020a124-ba76-4d40-84e9-9803268d9f16',
+        oracle_id: 'deeb7e22-b207-42de-b9d4-f790403d52a9',
+        multiverse_ids: [407636],
+        mtgo_id: 59563,
+        mtgo_foil_id: 59564,
+        tcgplayer_id: 110837,
+        cardmarket_id: 287047,
+        name: 'World Breaker',
+        lang: 'en',
+        released_at: '2016-01-22',
+        uri:
+            'https://api.scryfall.com/cards/0020a124-ba76-4d40-84e9-9803268d9f16',
+        scryfall_uri:
+            'https://scryfall.com/card/ogw/126/world-breaker?utm_source=api',
+        layout: 'normal',
+        highres_image: true,
+        image_uris: {
+            small:
+                'https://c1.scryfall.com/file/scryfall-cards/small/front/0/0/0020a124-ba76-4d40-84e9-9803268d9f16.jpg?1562895014',
+            normal:
+                'https://c1.scryfall.com/file/scryfall-cards/normal/front/0/0/0020a124-ba76-4d40-84e9-9803268d9f16.jpg?1562895014',
+            large:
+                'https://c1.scryfall.com/file/scryfall-cards/large/front/0/0/0020a124-ba76-4d40-84e9-9803268d9f16.jpg?1562895014',
+            png:
+                'https://c1.scryfall.com/file/scryfall-cards/png/front/0/0/0020a124-ba76-4d40-84e9-9803268d9f16.png?1562895014',
+            art_crop:
+                'https://c1.scryfall.com/file/scryfall-cards/art_crop/front/0/0/0020a124-ba76-4d40-84e9-9803268d9f16.jpg?1562895014',
+            border_crop:
+                'https://c1.scryfall.com/file/scryfall-cards/border_crop/front/0/0/0020a124-ba76-4d40-84e9-9803268d9f16.jpg?1562895014',
+        },
+        mana_cost: '{6}{G}',
+        cmc: 7,
+        type_line: 'Creature — Eldrazi',
+        oracle_text:
+            'Devoid (This card has no color.) When you cast this spell, exile target artifact, enchantment, or land. Reach {2}{C}, Sacrifice a land: Return World Breaker from your graveyard to your hand. ({C} represents colorless mana.)',
+        power: '5',
+        toughness: '7',
+        colors: [],
+        color_identity: ['G'],
+        keywords: ['Reach', 'Devoid'],
+        legalities: {
+            standard: 'not_legal',
+            future: 'not_legal',
+            historic: 'not_legal',
+            pioneer: 'legal',
+            modern: 'legal',
+            legacy: 'legal',
+            pauper: 'not_legal',
+            vintage: 'legal',
+            penny: 'not_legal',
+            commander: 'legal',
+            brawl: 'not_legal',
+            duel: 'legal',
+            oldschool: 'not_legal',
+        },
+        games: ['paper', 'mtgo'],
+        reserved: false,
+        foil: true,
+        nonfoil: true,
+        oversized: false,
+        promo: false,
+        reprint: false,
+        variation: false,
+        set: 'ogw',
+        set_name: 'Oath of the Gatewatch',
+        set_type: 'expansion',
+        set_uri:
+            'https://api.scryfall.com/sets/cd51d245-8f95-45b0-ab5f-e2b3a3eb5dfe',
+        set_search_uri:
+            'https://api.scryfall.com/cards/search?order=set&q=e%3Aogw&unique=prints',
+        scryfall_set_uri: 'https://scryfall.com/sets/ogw?utm_source=api',
+        rulings_uri:
+            'https://api.scryfall.com/cards/0020a124-ba76-4d40-84e9-9803268d9f16/rulings',
+        prints_search_uri:
+            'https://api.scryfall.com/cards/search?order=released&q=oracleid%3Adeeb7e22-b207-42de-b9d4-f790403d52a9&unique=prints',
+        collector_number: '126',
+        digital: false,
+        rarity: 'mythic',
+        card_back_id: '0aeebaf5-8c7d-4636-9e82-8c27447861f7',
+        artist: 'Jaime Jones',
+        artist_ids: ['92f6c2c1-fa57-4b52-99c4-0fd866c13dc9'],
+        illustration_id: '92c9d95d-ea26-46c8-b473-1a3393b3a1c2',
+        border_color: 'black',
+        frame: '2015',
+        frame_effects: ['devoid'],
+        full_art: false,
+        textless: false,
+        booster: true,
+        story_spotlight: false,
+        edhrec_rank: 2012,
+        prices: {
+            usd: '3.10',
+            usd_foil: '9.44',
+            eur: '3.60',
+            eur_foil: '6.48',
+            tix: '0.12',
+        },
+        related_uris: {
+            gatherer:
+                'https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=407636',
+            tcgplayer_decks:
+                'https://decks.tcgplayer.com/magic/deck/search?contains=World+Breaker&page=1&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall',
+            edhrec: 'https://edhrec.com/route/?cc=World+Breaker',
+            mtgtop8:
+                'https://mtgtop8.com/search?MD_check=1&SB_check=1&cards=World+Breaker',
+        },
+        purchase_uris: {
+            tcgplayer:
+                'https://shop.tcgplayer.com/product/productsearch?id=110837&utm_campaign=affiliate&utm_medium=api&utm_source=scryfall',
+            cardmarket:
+                'https://www.cardmarket.com/en/Magic/Products/Singles/Oath-of-the-Gatewatch/World-Breaker?referrer=scryfall&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall',
+            cardhoarder:
+                'https://www.cardhoarder.com/cards/59563?affiliate_id=scryfall&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall',
+        },
+    },
+];

--- a/src/__tests__/sorting.test.js
+++ b/src/__tests__/sorting.test.js
@@ -31,8 +31,9 @@ describe('Sort function', () => {
         expect(sorted[2].name).toBe('Necropotence');
         expect(sorted[3].name).toBe('Wheel of Fortune');
         expect(sorted[4].name).toBe('Colossal Dreadmaw');
-        expect(sorted[5].name).toBe('Sigarda, Host of Herons');
-        expect(sorted[6].name).toBe('Emrakul, the Aeons Torn');
-        expect(sorted[7].name).toBe("Gaea's Cradle");
+        expect(sorted[5].name).toBe('World Breaker');
+        expect(sorted[6].name).toBe('Sigarda, Host of Herons');
+        expect(sorted[7].name).toBe('Emrakul, the Aeons Torn');
+        expect(sorted[8].name).toBe("Gaea's Cradle");
     });
 });

--- a/src/utils/ScryfallCard.js
+++ b/src/utils/ScryfallCard.js
@@ -10,13 +10,20 @@ export class ScryfallCard {
 
         if (lang !== 'en') return `${name} (${lang.toUpperCase()})`;
 
-        if ((name !== printed_name) && printed_name) { // Covers cards like Godzilla series
+        if (name !== printed_name && printed_name) {
+            // Covers cards like Godzilla series
             return `${name} (IP series)`;
-        } else if (frame_effects.length === 0 && border_color === 'borderless') { // Covers cards like comic-art Vivien, Monsters' Advocate
+        } else if (
+            frame_effects.length === 0 &&
+            border_color === 'borderless'
+        ) {
+            // Covers cards like comic-art Vivien, Monsters' Advocate
             return `${name} (Borderless)`;
-        } else if (frame_effects.includes('showcase')) { // Covers showcase cards like comic-art Illuna, Apex of Wishes
+        } else if (frame_effects.includes('showcase')) {
+            // Covers showcase cards like comic-art Illuna, Apex of Wishes
             return `${name} (Showcase)`;
-        } else if (frame_effects.includes('extendedart')) { // Covers cards with extended left and roght border art
+        } else if (frame_effects.includes('extendedart')) {
+            // Covers cards with extended left and roght border art
             return `${name} (Extended art)`;
         } else {
             return name;
@@ -54,6 +61,7 @@ export class ScryfallCard {
         this.border_color = card.border_color;
         this.display_name = this._createDisplayName();
         this.cardImage = this._getCardImage();
+        this.color_identity = card.color_identity || null;
     }
 }
 

--- a/src/utils/sortSaleList.js
+++ b/src/utils/sortSaleList.js
@@ -41,13 +41,23 @@ export default function sortSaleList(cards) {
 
         // Drill into colorless cards, if they are lands or not
         if (arrayConst === 'COLORLESS') {
+            if (cardFace.color_identity) {
+                if (cardFace.color_identity.length === 1) {
+                    arrayConst = cardFace.color_identity[0];
+                }
+                if (cardFace.color_identity.length > 1) {
+                    arrayConst = 'MULTI';
+                }
+            }
             if (cardFace.type_line.includes('Land')) {
                 arrayConst = 'LAND';
             }
         }
 
         // Final check to guard against a null arrayConst
-        if (!arrayConst) { arrayConst = 'LAND' }
+        if (!arrayConst) {
+            arrayConst = 'LAND';
+        }
 
         return arrayConst;
     }


### PR DESCRIPTION
Adds `color_identity` to our scryfall card class and sorts cards with Devoid into their proper color pipped buckets for clubhouse use

Closes #36 