### PR TITLE
Optimize suspended sales

### DIFF
--- a/monolith/interactors/createSuspendedSale.ts
+++ b/monolith/interactors/createSuspendedSale.ts
@@ -68,7 +68,7 @@ async function createSuspendedSale(
         // Removes the passed cards from inventory prior to creating
         const dbInserts = saleList.map(
             async (card) =>
-                await updateCardInventoryWithFlag(card, 'DEC', location)
+                await updateCardInventoryWithFlag(card, 'DEC', location, client)
         );
         await Promise.all(dbInserts);
 

--- a/monolith/interactors/createSuspendedSale.ts
+++ b/monolith/interactors/createSuspendedSale.ts
@@ -12,14 +12,11 @@ const DATABASE_NAME = getDatabaseName();
  */
 async function validateInventory(
     { qtyToSell, finishCondition, name, id },
-    location: ClubhouseLocation
+    location: ClubhouseLocation,
+    databaseClient: MongoClient
 ) {
-    const client = await new MongoClient(process.env.MONGO_URI, mongoOptions);
-
     try {
-        await client.connect();
-
-        const db = client
+        const db = databaseClient
             .db(DATABASE_NAME)
             .collection(collectionFromLocation(location).cardInventory);
 
@@ -36,8 +33,6 @@ async function validateInventory(
         return true;
     } catch (e) {
         throw e;
-    } finally {
-        await client.close();
     }
 }
 
@@ -66,7 +61,7 @@ async function createSuspendedSale(
 
         // Validate inventory prior to transacting
         const validations = saleList.map(
-            async (card) => await validateInventory(card, location)
+            async (card) => await validateInventory(card, location, client)
         );
         await Promise.all(validations);
 

--- a/monolith/interactors/deleteSuspendedSale.ts
+++ b/monolith/interactors/deleteSuspendedSale.ts
@@ -26,7 +26,7 @@ async function deleteSuspendedSale(id, location) {
         // Adds the passed cards back to inventory prior to deleting
         const dbInserts = list.map(
             async (card) =>
-                await updateCardInventoryWithFlag(card, 'INC', location)
+                await updateCardInventoryWithFlag(card, 'INC', location, client)
         );
         await Promise.all(dbInserts);
 

--- a/monolith/interactors/updateCardInventoryWithFlag.ts
+++ b/monolith/interactors/updateCardInventoryWithFlag.ts
@@ -13,7 +13,8 @@ const DATABASE_NAME = getDatabaseName();
 async function updateCardInventoryWithFlag(
     card,
     CHANGE_FLAG,
-    location: ClubhouseLocation
+    location: ClubhouseLocation,
+    databaseClient: MongoClient
 ) {
     const { qtyToSell, finishCondition, id, name } = card;
     let quantityChange;
@@ -26,16 +27,12 @@ async function updateCardInventoryWithFlag(
         throw new Error('CHANGE_FLAG was not provided');
     }
 
-    const client = await new MongoClient(process.env.MONGO_URI, mongoOptions);
-
     try {
-        await client.connect();
-
         console.log(
             `Suspend sale, ${CHANGE_FLAG}: QTY: ${qtyToSell}, ${finishCondition}, ${name}, ${id}, LOCATION: ${location}`
         );
 
-        const db = client
+        const db = databaseClient
             .db(DATABASE_NAME)
             .collection(collectionFromLocation(location).cardInventory);
 
@@ -58,8 +55,6 @@ async function updateCardInventoryWithFlag(
         );
     } catch (e) {
         throw e;
-    } finally {
-        await client.close();
     }
 }
 

--- a/monolith/package.json
+++ b/monolith/package.json
@@ -5,7 +5,7 @@
     "scripts": {
         "start": "node ./built/bin/www",
         "gcp-build": "tsc -p .",
-        "start-dev": "PORT=7331 ENVIRONMENT=development node ./built/bin/www",
+        "start-dev": "tsc -p . && echo \"Built TS source\" && PORT=7331 ENVIRONMENT=development node ./built/bin/www",
         "deploy": "gcloud app deploy app.yaml --stop-previous-version"
     },
     "dependencies": {


### PR DESCRIPTION
Creating a suspended sale invoked two functions which in turn created new instances of the Mongo client, and performed operations on potentially large collections of cards. Users had noted performance degradation when lists exceeded 75 items.

The low hanging fix here is to share the database client and pass it around; we shouldn't have to create and destroy multiple instance of the client instance.