### PR TITLE
Query for quantity on hand for both store locations

### DIFF
--- a/monolith/interactors/getCardFromAllLocations.ts
+++ b/monolith/interactors/getCardFromAllLocations.ts
@@ -75,7 +75,6 @@ async function getSingleLocationCard(
 }
 
 async function getCardFromAllLocations(title: string) {
-    // if matchInStock is false, we get all cards, even those with no stock
     const mongoConfig = { useNewUrlParser: true, useUnifiedTopology: true };
 
     try {

--- a/monolith/interactors/getCardFromAllLocations.ts
+++ b/monolith/interactors/getCardFromAllLocations.ts
@@ -1,0 +1,95 @@
+import { Db, MongoClient } from 'mongodb';
+import collectionFromLocation from '../lib/collectionFromLocation';
+import getDatabaseName from '../lib/getDatabaseName';
+import { ClubhouseLocation } from './getJwt';
+const DATABASE_NAME = getDatabaseName();
+
+async function getSingleLocationCard(
+    title: string,
+    db: Db,
+    location: ClubhouseLocation
+) {
+    const pipeline = [];
+
+    // Fetch by title
+    const match = {
+        $match: {
+            name: title,
+            games: {
+                $in: ['paper'],
+            },
+        },
+    };
+
+    // Zip up bulk with qoh
+    const lookup = {
+        $lookup: {
+            from: collectionFromLocation(location).cardInventory,
+            localField: 'id',
+            foreignField: '_id',
+            as: 'qoh',
+        },
+    };
+
+    // $lookup yields an array - replace the new qoh with the nested card value
+    const addFields = {
+        $addFields: {
+            qoh: { $arrayElemAt: ['$qoh.qoh', 0] },
+        },
+    };
+
+    // Only yield cards that are in-stock, if needed
+    const inventoryMatch = {
+        $match: {
+            $or: [
+                { 'qoh.FOIL_NM': { $gt: 0 } },
+                { 'qoh.FOIL_LP': { $gt: 0 } },
+                { 'qoh.FOIL_MP': { $gt: 0 } },
+                { 'qoh.FOIL_HP': { $gt: 0 } },
+                { 'qoh.NONFOIL_NM': { $gt: 0 } },
+                { 'qoh.NONFOIL_LP': { $gt: 0 } },
+                { 'qoh.NONFOIL_MP': { $gt: 0 } },
+                { 'qoh.NONFOIL_HP': { $gt: 0 } },
+            ],
+        },
+    };
+
+    pipeline.push(match);
+    pipeline.push(lookup);
+    pipeline.push(addFields);
+    pipeline.push(inventoryMatch);
+
+    return await db
+        .collection('scryfall_bulk_cards')
+        .aggregate(pipeline)
+        .toArray();
+}
+
+async function getCardFromAllLocations(title: string) {
+    // if matchInStock is false, we get all cards, even those with no stock
+    const mongoConfig = { useNewUrlParser: true, useUnifiedTopology: true };
+
+    try {
+        var client = await new MongoClient(
+            process.env.MONGO_URI,
+            mongoConfig
+        ).connect();
+
+        const db = client.db(DATABASE_NAME);
+
+        const ch1 = await getSingleLocationCard(title, db, 'ch1');
+        const ch2 = await getSingleLocationCard(title, db, 'ch2');
+
+        return {
+            ch1,
+            ch2,
+        };
+    } catch (err) {
+        console.log(err);
+        throw err;
+    } finally {
+        await client.close();
+    }
+}
+
+export default getCardFromAllLocations;

--- a/monolith/lib/parseQoh.ts
+++ b/monolith/lib/parseQoh.ts
@@ -1,0 +1,37 @@
+interface QOH {
+    FOIL_NM?: number;
+    FOIL_LP?: number;
+    FOIL_MP?: number;
+    FOIL_HP?: number;
+    NONFOIL_NM?: number;
+    NONFOIL_LP?: number;
+    NONFOIL_MP?: number;
+    NONFOIL_HP?: number;
+}
+
+/**
+ * This function parses the `qoh` object from mongo into something more presentable
+ */
+export default function parseQoh(
+    qoh: QOH
+): { foilQty: number; nonfoilQty: number } {
+    let foilQty = 0;
+    let nonfoilQty = 0;
+
+    foilQty =
+        (qoh.FOIL_NM || 0) +
+        (qoh.FOIL_LP || 0) +
+        (qoh.FOIL_MP || 0) +
+        (qoh.FOIL_HP || 0);
+
+    nonfoilQty =
+        (qoh.NONFOIL_NM || 0) +
+        (qoh.NONFOIL_LP || 0) +
+        (qoh.NONFOIL_MP || 0) +
+        (qoh.NONFOIL_HP || 0);
+
+    return {
+        foilQty,
+        nonfoilQty,
+    };
+}

--- a/monolith/routes/index.ts
+++ b/monolith/routes/index.ts
@@ -2,6 +2,7 @@ import express from 'express';
 const router = express.Router();
 import getJwt from '../interactors/getJwt';
 import getCardsWithInfo from '../interactors/getCardsWithInfo';
+import getCardFromAllLocations from '../interactors/getCardFromAllLocations';
 
 router.post('/jwt', async (req, res) => {
     try {
@@ -24,6 +25,22 @@ router.get('/getCardsWithInfo', async (req, res) => {
             (location === 'ch1' || location === 'ch2')
         ) {
             const message = await getCardsWithInfo(title, myMatch, location);
+            res.status(200).send(message);
+        } else {
+            throw new Error('title should be a string');
+        }
+    } catch (err) {
+        console.log(err);
+        res.status(500).send(err);
+    }
+});
+
+router.get('/getCardFromAllLocations', async (req, res) => {
+    try {
+        const { title } = req.query;
+
+        if (typeof title === 'string') {
+            const message = await getCardFromAllLocations(title);
             res.status(200).send(message);
         } else {
             throw new Error('title should be a string');

--- a/src/ManageInventory/AllLocationInventory.js
+++ b/src/ManageInventory/AllLocationInventory.js
@@ -12,6 +12,13 @@ const FlexContainer = styled('div')({
     display: 'flex',
 });
 
+const QohLabel = ({ label, value }) => (
+    <Label color={value > 0 ? 'blue' : 'transparent'} image>
+        {label}
+        <Label.Detail>{value}</Label.Detail>
+    </Label>
+);
+
 // TODO: refetch on result set change
 export default function AllLocationInventory({ title }) {
     const [quantities, setQuantities] = useState({
@@ -46,51 +53,21 @@ export default function AllLocationInventory({ title }) {
             <div>
                 <Header sub>Beaverton totals:</Header>
                 <StyledContainer>
-                    <Label
-                        color={
-                            quantities.ch1.foilQty > 0 ? 'blue' : 'transparent'
-                        }
-                        image
-                    >
-                        Foil
-                        <Label.Detail>{quantities.ch1.foilQty}</Label.Detail>
-                    </Label>
-                    <Label
-                        color={
-                            quantities.ch1.nonfoilQty > 0
-                                ? 'blue'
-                                : 'transparent'
-                        }
-                        image
-                    >
-                        Nonfoil
-                        <Label.Detail>{quantities.ch1.nonfoilQty}</Label.Detail>
-                    </Label>
+                    <QohLabel label="Foil" value={quantities.ch1.foilQty} />
+                    <QohLabel
+                        label="Nonfoil"
+                        value={quantities.ch1.nonfoilQty}
+                    />
                 </StyledContainer>
             </div>
             <div>
                 <Header sub>Hillsboro totals:</Header>
                 <StyledContainer>
-                    <Label
-                        color={
-                            quantities.ch2.foilQty > 0 ? 'blue' : 'transparent'
-                        }
-                        image
-                    >
-                        Foil
-                        <Label.Detail>{quantities.ch2.foilQty}</Label.Detail>
-                    </Label>
-                    <Label
-                        color={
-                            quantities.ch2.nonfoilQty > 0
-                                ? 'blue'
-                                : 'transparent'
-                        }
-                        image
-                    >
-                        Nonfoil
-                        <Label.Detail>{quantities.ch2.nonfoilQty}</Label.Detail>
-                    </Label>
+                    <QohLabel label="Foil" value={quantities.ch2.foilQty} />
+                    <QohLabel
+                        label="Nonfoil"
+                        value={quantities.ch2.nonfoilQty}
+                    />
                 </StyledContainer>
             </div>
         </FlexContainer>

--- a/src/ManageInventory/AllLocationInventory.js
+++ b/src/ManageInventory/AllLocationInventory.js
@@ -41,7 +41,7 @@ export default function AllLocationInventory({ title }) {
             } catch (err) {
                 console.log(err);
             }
-        })().catch(console.log);
+        })();
     }, [title]);
 
     return loading ? (

--- a/src/ManageInventory/AllLocationInventory.js
+++ b/src/ManageInventory/AllLocationInventory.js
@@ -10,6 +10,10 @@ const StyledContainer = styled('div')({
 
 const FlexContainer = styled('div')({
     display: 'flex',
+    alignItems: 'center',
+    '& > *': {
+        marginLeft: '10px',
+    },
 });
 
 const QohLabel = ({ label, value }) => (
@@ -46,7 +50,10 @@ export default function AllLocationInventory({ title }) {
 
     return loading ? (
         <FlexContainer>
-            Loading totals for all locations... <Loader active inline />
+            <span>Loading totals for all locations</span>
+            <div>
+                <Loader active inline size="small" />
+            </div>
         </FlexContainer>
     ) : (
         <FlexContainer>

--- a/src/ManageInventory/AllLocationInventory.js
+++ b/src/ManageInventory/AllLocationInventory.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import React, { useEffect, useState } from 'react';
-import { Label } from 'semantic-ui-react';
+import { Label, Loader } from 'semantic-ui-react';
 import styled from 'styled-components';
 import { GET_CARD_FROM_ALL_LOCATIONS } from '../utils/api_resources';
 
@@ -8,30 +8,36 @@ const StyledContainer = styled('div')({
     display: 'inline-flex',
 });
 
-export default function SearchMetadata({ title }) {
+// TODO: refetch on result set change
+export default function AllLocationInventory({ title }) {
     const [quantities, setQuantities] = useState({
         ch1: { foilQty: 0, nonfoilQty: 0 },
         ch2: { foilQty: 0, nonfoilQty: 0 },
     });
 
-    const fetchCardQuantities = async () => {
-        try {
-            const { data } = await axios.get(GET_CARD_FROM_ALL_LOCATIONS, {
-                params: { title: 'Birds of Paradise' },
-            });
-
-            setQuantities(data);
-            console.log(data);
-        } catch (err) {
-            console.log(err);
-        }
-    };
+    const [loading, setLoading] = useState(false);
 
     useEffect(() => {
-        fetchCardQuantities().catch((err) => console.log);
-    }, []);
+        (async () => {
+            try {
+                setLoading(true);
+                const { data } = await axios.get(GET_CARD_FROM_ALL_LOCATIONS, {
+                    params: { title },
+                });
 
-    return (
+                setQuantities(data);
+                setLoading(false);
+            } catch (err) {
+                console.log(err);
+            }
+        })().catch(console.log);
+    }, [title]);
+
+    return loading ? (
+        <div>
+            Loading totals for all locations... <Loader active inline />
+        </div>
+    ) : (
         <>
             <StyledContainer>
                 Beaverton totals: {''}

--- a/src/ManageInventory/AllLocationInventory.js
+++ b/src/ManageInventory/AllLocationInventory.js
@@ -45,9 +45,9 @@ export default function AllLocationInventory({ title }) {
     }, [title]);
 
     return loading ? (
-        <>
+        <FlexContainer>
             Loading totals for all locations... <Loader active inline />
-        </>
+        </FlexContainer>
     ) : (
         <FlexContainer>
             <div>

--- a/src/ManageInventory/AllLocationInventory.js
+++ b/src/ManageInventory/AllLocationInventory.js
@@ -17,14 +17,14 @@ const FlexContainer = styled('div')({
 });
 
 const QohLabel = ({ label, value }) => (
-    <Label color={value > 0 ? 'blue' : 'transparent'} image>
+    <Label {...(value > 0 && { color: 'blue' })} image>
         {label}
         <Label.Detail>{value}</Label.Detail>
     </Label>
 );
 
 // TODO: refetch on result set change
-export default function AllLocationInventory({ title }) {
+export default function AllLocationInventory({ title, searchResults }) {
     const [quantities, setQuantities] = useState({
         ch1: { foilQty: 0, nonfoilQty: 0 },
         ch2: { foilQty: 0, nonfoilQty: 0 },
@@ -46,7 +46,7 @@ export default function AllLocationInventory({ title }) {
                 console.log(err);
             }
         })();
-    }, [title]);
+    }, [title, searchResults]);
 
     return loading ? (
         <FlexContainer>

--- a/src/ManageInventory/AllLocationInventory.js
+++ b/src/ManageInventory/AllLocationInventory.js
@@ -1,11 +1,15 @@
 import axios from 'axios';
 import React, { useEffect, useState } from 'react';
-import { Label, Loader } from 'semantic-ui-react';
+import { Header, Label, Loader } from 'semantic-ui-react';
 import styled from 'styled-components';
 import { GET_CARD_FROM_ALL_LOCATIONS } from '../utils/api_resources';
 
 const StyledContainer = styled('div')({
-    display: 'inline-flex',
+    display: 'inline',
+});
+
+const FlexContainer = styled('div')({
+    display: 'flex',
 });
 
 // TODO: refetch on result set change
@@ -34,47 +38,61 @@ export default function AllLocationInventory({ title }) {
     }, [title]);
 
     return loading ? (
-        <div>
-            Loading totals for all locations... <Loader active inline />
-        </div>
-    ) : (
         <>
-            <StyledContainer>
-                Beaverton totals: {''}
-                <Label
-                    color={quantities.ch1.foilQty > 0 ? 'blue' : 'transparent'}
-                    image
-                >
-                    Foil<Label.Detail>{quantities.ch1.foilQty}</Label.Detail>
-                </Label>
-                <Label
-                    color={
-                        quantities.ch1.nonfoilQty > 0 ? 'blue' : 'transparent'
-                    }
-                    image
-                >
-                    Nonfoil
-                    <Label.Detail>{quantities.ch1.nonfoilQty}</Label.Detail>
-                </Label>
-            </StyledContainer>
-            <StyledContainer>
-                Hillsboro totals: {''}
-                <Label
-                    color={quantities.ch2.foilQty > 0 ? 'blue' : 'transparent'}
-                    image
-                >
-                    Foil<Label.Detail>{quantities.ch2.foilQty}</Label.Detail>
-                </Label>
-                <Label
-                    color={
-                        quantities.ch2.nonfoilQty > 0 ? 'blue' : 'transparent'
-                    }
-                    image
-                >
-                    Nonfoil
-                    <Label.Detail>{quantities.ch2.nonfoilQty}</Label.Detail>
-                </Label>
-            </StyledContainer>
+            Loading totals for all locations... <Loader active inline />
         </>
+    ) : (
+        <FlexContainer>
+            <div>
+                <Header sub>Beaverton totals:</Header>
+                <StyledContainer>
+                    <Label
+                        color={
+                            quantities.ch1.foilQty > 0 ? 'blue' : 'transparent'
+                        }
+                        image
+                    >
+                        Foil
+                        <Label.Detail>{quantities.ch1.foilQty}</Label.Detail>
+                    </Label>
+                    <Label
+                        color={
+                            quantities.ch1.nonfoilQty > 0
+                                ? 'blue'
+                                : 'transparent'
+                        }
+                        image
+                    >
+                        Nonfoil
+                        <Label.Detail>{quantities.ch1.nonfoilQty}</Label.Detail>
+                    </Label>
+                </StyledContainer>
+            </div>
+            <div>
+                <Header sub>Hillsboro totals:</Header>
+                <StyledContainer>
+                    <Label
+                        color={
+                            quantities.ch2.foilQty > 0 ? 'blue' : 'transparent'
+                        }
+                        image
+                    >
+                        Foil
+                        <Label.Detail>{quantities.ch2.foilQty}</Label.Detail>
+                    </Label>
+                    <Label
+                        color={
+                            quantities.ch2.nonfoilQty > 0
+                                ? 'blue'
+                                : 'transparent'
+                        }
+                        image
+                    >
+                        Nonfoil
+                        <Label.Detail>{quantities.ch2.nonfoilQty}</Label.Detail>
+                    </Label>
+                </StyledContainer>
+            </div>
+        </FlexContainer>
     );
 }

--- a/src/ManageInventory/ManageInventory.js
+++ b/src/ManageInventory/ManageInventory.js
@@ -1,11 +1,7 @@
 import React, { useContext } from 'react';
 import SearchBar from '../common/SearchBar';
-import axios from 'axios';
-import makeAuthHeader from '../utils/makeAuthHeader';
 import ManageInventoryList from './ManageInventoryList';
 import { Segment, Header, Icon, Divider } from 'semantic-ui-react';
-import { GET_CARDS_WITH_INFO } from '../utils/api_resources';
-import { InventoryCard } from '../utils/ScryfallCard';
 import styled from 'styled-components';
 import AllLocationInventory from './AllLocationInventory';
 import { InventoryContext } from '../context/InventoryContext';
@@ -16,22 +12,7 @@ const HeaderContainer = styled('div')({
 });
 
 export default function ManageInventory() {
-    const { searchResults, setSearchResults } = useContext(InventoryContext);
-
-    const handleSearchSelect = async (term) => {
-        try {
-            const { data } = await axios.get(GET_CARDS_WITH_INFO, {
-                params: { title: term, matchInStock: false },
-                headers: makeAuthHeader(),
-            });
-
-            const modeledData = data.map((c) => new InventoryCard(c));
-
-            setSearchResults(modeledData);
-        } catch (e) {
-            console.log(e);
-        }
-    };
+    const { searchResults, handleSearchSelect } = useContext(InventoryContext);
 
     return (
         <>

--- a/src/ManageInventory/ManageInventory.js
+++ b/src/ManageInventory/ManageInventory.js
@@ -23,7 +23,7 @@ export default function ManageInventory() {
                 {searchResults.length > 0 && (
                     <div>
                         <AllLocationInventory
-                            resultSet={searchResults}
+                            searchResults={searchResults}
                             title={searchResults[0].name}
                         />
                     </div>

--- a/src/ManageInventory/ManageInventory.js
+++ b/src/ManageInventory/ManageInventory.js
@@ -19,9 +19,7 @@ export default function ManageInventory() {
             <SearchBar handleSearchSelect={handleSearchSelect} />
             <br />
             <HeaderContainer>
-                <div>
-                    <Header as="h2">Manage Inventory</Header>
-                </div>
+                <Header as="h2">Manage Inventory</Header>
                 {searchResults.length > 0 && (
                     <div>
                         <AllLocationInventory
@@ -43,7 +41,6 @@ export default function ManageInventory() {
                     </Header>
                 </Segment>
             )}
-
             <ManageInventoryList cards={searchResults} />
         </>
     );

--- a/src/ManageInventory/ManageInventory.js
+++ b/src/ManageInventory/ManageInventory.js
@@ -7,7 +7,7 @@ import { Segment, Header, Icon, Divider } from 'semantic-ui-react';
 import { GET_CARDS_WITH_INFO } from '../utils/api_resources';
 import { InventoryCard } from '../utils/ScryfallCard';
 import styled from 'styled-components';
-import SearchMetadata from './SearchMetadata';
+import AllLocationInventory from './AllLocationInventory';
 import { InventoryContext } from '../context/InventoryContext';
 
 const HeaderContainer = styled('div')({
@@ -43,7 +43,10 @@ export default function ManageInventory() {
                 </div>
                 {searchResults.length > 0 && (
                     <div>
-                        <SearchMetadata searchResults={searchResults} />
+                        <AllLocationInventory
+                            resultSet={searchResults}
+                            title={searchResults[0].name}
+                        />
                     </div>
                 )}
             </HeaderContainer>

--- a/src/ManageInventory/ManageInventory.js
+++ b/src/ManageInventory/ManageInventory.js
@@ -35,8 +35,8 @@ export default function ManageInventory() {
                     <Header icon>
                         <Icon name="search" />
                         <em>
-                            "Searching the future for answers often leads to
-                            further questions."
+                            "For the first time in his life, Grakk felt a little
+                            warm and fuzzy inside."
                         </em>
                     </Header>
                 </Segment>

--- a/src/ManageInventory/SearchMetadata.js
+++ b/src/ManageInventory/SearchMetadata.js
@@ -1,23 +1,74 @@
-import React from 'react';
+import axios from 'axios';
+import React, { useEffect, useState } from 'react';
 import { Label } from 'semantic-ui-react';
+import styled from 'styled-components';
+import { GET_CARD_FROM_ALL_LOCATIONS } from '../utils/api_resources';
 
-export default function SearchMetadata({ searchResults }) {
-    const foilQuantity = searchResults
-        .map((c) => c.qohParsed[0])
-        .reduce((acc, c) => acc + c, 0);
-    const nonfoilQuantity = searchResults
-        .map((c) => c.qohParsed[1])
-        .reduce((acc, c) => acc + c, 0);
+const StyledContainer = styled('div')({
+    display: 'inline-flex',
+});
+
+export default function SearchMetadata({ title }) {
+    const [quantities, setQuantities] = useState({
+        ch1: { foilQty: 0, nonfoilQty: 0 },
+        ch2: { foilQty: 0, nonfoilQty: 0 },
+    });
+
+    const fetchCardQuantities = async () => {
+        try {
+            const { data } = await axios.get(GET_CARD_FROM_ALL_LOCATIONS, {
+                params: { title: 'Birds of Paradise' },
+            });
+
+            setQuantities(data);
+            console.log(data);
+        } catch (err) {
+            console.log(err);
+        }
+    };
+
+    useEffect(() => {
+        fetchCardQuantities().catch((err) => console.log);
+    }, []);
 
     return (
-        <div>
-            Totals on hand: {''}
-            <Label color={nonfoilQuantity > 0 ? 'blue' : 'transparent'} image>
-                Nonfoil<Label.Detail>{nonfoilQuantity}</Label.Detail>
-            </Label>
-            <Label color={foilQuantity > 0 ? 'blue' : 'transparent'} image>
-                Foil<Label.Detail>{foilQuantity}</Label.Detail>
-            </Label>
-        </div>
+        <>
+            <StyledContainer>
+                Beaverton totals: {''}
+                <Label
+                    color={quantities.ch1.foilQty > 0 ? 'blue' : 'transparent'}
+                    image
+                >
+                    Foil<Label.Detail>{quantities.ch1.foilQty}</Label.Detail>
+                </Label>
+                <Label
+                    color={
+                        quantities.ch1.nonfoilQty > 0 ? 'blue' : 'transparent'
+                    }
+                    image
+                >
+                    Nonfoil
+                    <Label.Detail>{quantities.ch1.nonfoilQty}</Label.Detail>
+                </Label>
+            </StyledContainer>
+            <StyledContainer>
+                Hillsboro totals: {''}
+                <Label
+                    color={quantities.ch2.foilQty > 0 ? 'blue' : 'transparent'}
+                    image
+                >
+                    Foil<Label.Detail>{quantities.ch2.foilQty}</Label.Detail>
+                </Label>
+                <Label
+                    color={
+                        quantities.ch2.nonfoilQty > 0 ? 'blue' : 'transparent'
+                    }
+                    image
+                >
+                    Nonfoil
+                    <Label.Detail>{quantities.ch2.nonfoilQty}</Label.Detail>
+                </Label>
+            </StyledContainer>
+        </>
     );
 }

--- a/src/NewSale/BrowseCardList.js
+++ b/src/NewSale/BrowseCardList.js
@@ -5,26 +5,33 @@ import { Segment, Header, Icon } from 'semantic-ui-react';
 export default function BrowseCardList({ term, cards }) {
     // Creates text to notify the user of zero-result searches
     const searchNotification = () => {
-        if (term && !cards.length) { // Check to make sure the user has searched and no results
-            return <p>Zero results for <em>{term}</em></p>
+        if (term && !cards.length) {
+            // Check to make sure the user has searched and no results
+            return (
+                <p>
+                    Zero results for <em>{term}</em>
+                </p>
+            );
         }
-        return <p>Search for inventory to sell</p>
-    }
+        return (
+            <p>
+                <em>"Don't give the people what they want"</em>
+            </p>
+        );
+    };
 
     if (cards.length === 0) {
-        return <Segment placeholder>
-            <Header icon>
-                <Icon name="search" />
-                <span>{searchNotification()}</span>
-            </Header>
-        </Segment>
+        return (
+            <Segment placeholder>
+                <Header icon>
+                    <Icon name="search" />
+                    <span>{searchNotification()}</span>
+                </Header>
+            </Segment>
+        );
     }
 
-    return cards.map(card => {
-        return <BrowseCardItem
-            key={card.id}
-            {...card}
-            qoh={card.qoh}
-        />
+    return cards.map((card) => {
+        return <BrowseCardItem key={card.id} {...card} qoh={card.qoh} />;
     });
 }

--- a/src/NewSale/CustomerSaleList.js
+++ b/src/NewSale/CustomerSaleList.js
@@ -6,32 +6,38 @@ import FinishSale from './FinishSale';
 
 export default function CustomerSaleList({ saleList }) {
     if (saleList.length === 0) {
-        return <Segment placeholder>
-            <Header icon>
-                <Icon name="plus" />
-                    View and manage customer sale list here
-            </Header>
-        </Segment>
+        return (
+            <Segment placeholder>
+                <Header icon>
+                    <Icon name="plus" />
+                    <em>"Give them what they need"</em>
+                </Header>
+            </Segment>
+        );
     }
 
-    return <React.Fragment>
-        <Table>
-            <Table.Body>
-                {saleList.map(card => {
-                    return <SaleLineItem
-                        {...card}
-                        key={`${card.id}${card.finishCondition}${card.qtyToSell}`}
-                    />
-                })}
-            </Table.Body>
-        </Table>
+    return (
+        <React.Fragment>
+            <Table>
+                <Table.Body>
+                    {saleList.map((card) => {
+                        return (
+                            <SaleLineItem
+                                {...card}
+                                key={`${card.id}${card.finishCondition}${card.qtyToSell}`}
+                            />
+                        );
+                    })}
+                </Table.Body>
+            </Table>
 
-        <Segment clearing>
-            <Header floated="left">
-                <Header sub>Subtotal</Header>
-                <SalePriceTotal saleList={saleList} />
-            </Header>
-            <FinishSale />
-        </Segment>
-    </React.Fragment>
-};
+            <Segment clearing>
+                <Header floated="left">
+                    <Header sub>Subtotal</Header>
+                    <SalePriceTotal saleList={saleList} />
+                </Header>
+                <FinishSale />
+            </Segment>
+        </React.Fragment>
+    );
+}

--- a/src/NewSale/PrintList.js
+++ b/src/NewSale/PrintList.js
@@ -4,39 +4,64 @@ import Price from '../common/Price';
 import './PrintList.css';
 import SalePriceTotal from './SalePriceTotal';
 
-const Row = ({ id, display_name, qtyToSell, finishCondition, set_name, price }) => {
-    return <li key={id}>
-        <b>{display_name} | x{qtyToSell} | {finishCondition} | {set_name} | <Price num={price} /></b>
-    </li>
-}
+const Row = ({
+    id,
+    display_name,
+    qtyToSell,
+    finishCondition,
+    set_name,
+    price,
+}) => {
+    return (
+        <li key={id}>
+            <b>
+                {display_name} | x{qtyToSell} | {finishCondition} | {set_name} |{' '}
+                <Price num={price} />
+            </b>
+        </li>
+    );
+};
 
 export default class PrintList extends React.Component {
-    state = { printClicked: false }
+    state = { printClicked: false };
 
     print = () => {
         this.setState({ printClicked: true }, () => {
             window.print();
-            this.setState({ printClicked: false })
+            this.setState({ printClicked: false });
         });
-    }
+    };
 
     render() {
         const { saleListCards } = this.props;
         const { printClicked } = this.state;
 
-        if (saleListCards.length > 0) { // Ensure print is hidden if no cards in list
+        if (saleListCards.length > 0) {
+            // Ensure print is hidden if no cards in list
             return (
-                <React.Fragment>
-                    <Button style={{ display: 'inline-block', float: 'right' }} onClick={this.print} icon>
-                        <Icon name="print" />
-                    </Button>
-
-                    <div id="printme" style={{ display: printClicked ? 'inline-block' : 'none' }}>
-                        <ul>{saleListCards.map(c => Row(c))}</ul>
-                        <span><b>Subtotal: <SalePriceTotal saleList={saleListCards} /></b></span>
+                <>
+                    <div>
+                        <Button size="tiny" onClick={this.print} icon>
+                            <Icon name="print" />
+                        </Button>
                     </div>
-                </React.Fragment >
-            )
+
+                    <div
+                        id="printme"
+                        style={{
+                            display: printClicked ? 'inline-block' : 'none',
+                        }}
+                    >
+                        <ul>{saleListCards.map((c) => Row(c))}</ul>
+                        <span>
+                            <b>
+                                Subtotal:{' '}
+                                <SalePriceTotal saleList={saleListCards} />
+                            </b>
+                        </span>
+                    </div>
+                </>
+            );
         } else {
             return null;
         }

--- a/src/NewSale/Sale.js
+++ b/src/NewSale/Sale.js
@@ -20,6 +20,13 @@ const HeaderContainer = styled('div')({
     justifyContent: 'space-between',
 });
 
+const ButtonContainer = styled('div')({
+    display: 'flex',
+    '& > *': {
+        marginLeft: '10px',
+    },
+});
+
 export default function Sale() {
     const {
         saleListCards,
@@ -77,28 +84,26 @@ export default function Sale() {
                         />
                     </Grid.Column>
                     <Grid.Column width="5">
-                        <Header
-                            as="h2"
-                            style={{ display: 'inline-block' }}
-                            id="sale-header"
-                        >
-                            {suspendedSale.name === ''
-                                ? 'Sale Items'
-                                : `${suspendedSale.name}'s Items`}
-                            <TotalCardsLabel
-                                listLength={findSaleCardsQty(saleListCards)}
-                            />
-                        </Header>
-
-                        <SuspendedSale
-                            restoreSale={restoreSale}
-                            suspendSale={suspendSale}
-                            saleListLength={saleListCards.length}
-                            deleteSuspendedSale={deleteSuspendedSale}
-                            id={suspendedSale._id}
-                        />
-
-                        <PrintList saleListCards={saleListCards} />
+                        <HeaderContainer>
+                            <Header as="h2" id="sale-header">
+                                {suspendedSale.name === ''
+                                    ? 'Sale Items'
+                                    : `${suspendedSale.name}'s Items`}
+                                <TotalCardsLabel
+                                    listLength={findSaleCardsQty(saleListCards)}
+                                />
+                            </Header>
+                            <ButtonContainer>
+                                <SuspendedSale
+                                    restoreSale={restoreSale}
+                                    suspendSale={suspendSale}
+                                    saleListLength={saleListCards.length}
+                                    deleteSuspendedSale={deleteSuspendedSale}
+                                    id={suspendedSale._id}
+                                />
+                                <PrintList saleListCards={saleListCards} />
+                            </ButtonContainer>
+                        </HeaderContainer>
 
                         <Divider />
 

--- a/src/NewSale/Sale.js
+++ b/src/NewSale/Sale.js
@@ -70,7 +70,7 @@ export default function Sale() {
                             <Header as="h2">Inventory</Header>
                             {searchResults.length > 0 && (
                                 <AllLocationInventory
-                                    resultSet={searchResults}
+                                    searchResults={searchResults}
                                     title={searchResults[0].name}
                                 />
                             )}

--- a/src/NewSale/Sale.js
+++ b/src/NewSale/Sale.js
@@ -12,6 +12,13 @@ import SuspendedSale from './SuspendedSale';
 import { InventoryCard } from '../utils/ScryfallCard';
 import { SaleContext } from '../context/SaleContext';
 import TotalCardsLabel, { findSaleCardsQty } from '../common/TotalCardsLabel';
+import AllLocationInventory from '../ManageInventory/AllLocationInventory';
+import styled from 'styled-components';
+
+const HeaderContainer = styled('div')({
+    display: 'flex',
+    justifyContent: 'space-between',
+});
 
 export default function Sale() {
     const {
@@ -47,16 +54,20 @@ export default function Sale() {
 
     return (
         <>
-            <Grid.Row style={{ display: 'flex', alignItems: 'center' }}>
-                <SearchBar handleSearchSelect={handleResultSelect} />
-            </Grid.Row>
+            <SearchBar handleSearchSelect={handleResultSelect} />
             <br />
             <Grid stackable={true}>
                 <Grid.Row>
                     <Grid.Column width="11">
-                        <Header as="h2" style={{ display: 'inline-block' }}>
-                            Inventory
-                        </Header>
+                        <HeaderContainer>
+                            <Header as="h2">Inventory</Header>
+                            {searchResults.length > 0 && (
+                                <AllLocationInventory
+                                    resultSet={searchResults}
+                                    title={searchResults[0].name}
+                                />
+                            )}
+                        </HeaderContainer>
 
                         <Divider />
 

--- a/src/NewSale/SuspendedSale.js
+++ b/src/NewSale/SuspendedSale.js
@@ -59,12 +59,14 @@ export default function SuspendedSale({
     }, [id]); // If the parent-level suspended-sale _id changes, we fetch again
 
     const modalTrigger = (
-        <Button
-            id="suspend-sale-btn"
-            style={{ display: 'inline-block', float: 'right' }}
-            onClick={() => setModalOpen(true)}
-            icon="ellipsis horizontal"
-        />
+        <div>
+            <Button
+                size="tiny"
+                id="suspend-sale-btn"
+                onClick={() => setModalOpen(true)}
+                icon="ellipsis horizontal"
+            />
+        </div>
     );
 
     const submitSuspendSale = async () => {

--- a/src/Receiving/Receiving.js
+++ b/src/Receiving/Receiving.js
@@ -1,57 +1,77 @@
 import React, { useContext, useEffect } from 'react';
 import SearchBar from '../common/SearchBar';
 import ReceivingSearchList from './ReceivingSearchList';
-import { Header, Grid, Divider } from 'semantic-ui-react'
+import { Header, Grid, Divider } from 'semantic-ui-react';
 import { ReceivingContext } from '../context/ReceivingContext';
 import DefaultPlaceholder from './DefaultPlaceholder';
 import ReceivingList from './ReceivingList';
 import TotalCardsLabel from '../common/TotalCardsLabel';
+import styled from 'styled-components';
+import AllLocationInventory from '../ManageInventory/AllLocationInventory';
+
+const HeaderContainer = styled('div')({
+    display: 'flex',
+    justifyContent: 'space-between',
+});
 
 export default function Receiving() {
     const {
         searchResults,
         receivingList,
         handleSearchSelect,
-        resetSearchResults
+        resetSearchResults,
     } = useContext(ReceivingContext);
 
     // Reset the search results on componentDidUnmount to clear store
     useEffect(() => {
-        return () => resetSearchResults()
-    }, [])
+        return () => resetSearchResults();
+    }, []);
 
-    return <React.Fragment>
-        <SearchBar handleSearchSelect={handleSearchSelect} />
-        <br />
-        <Grid stackable={true}>
-            <Grid.Row>
-                <Grid.Column width="10">
-                    <Header as="h2" style={{ display: "inline-block" }}>Card Search</Header>
+    return (
+        <>
+            <SearchBar handleSearchSelect={handleSearchSelect} />
+            <br />
+            <Grid stackable={true}>
+                <Grid.Row>
+                    <Grid.Column width="10">
+                        <HeaderContainer>
+                            <Header as="h2">Card Search</Header>
+                            {searchResults.length > 0 && (
+                                <div>
+                                    <AllLocationInventory
+                                        resultSet={searchResults}
+                                        title={searchResults[0].name}
+                                    />
+                                </div>
+                            )}
+                        </HeaderContainer>
 
-                    <Divider />
+                        <Divider />
 
-                    <DefaultPlaceholder active={!searchResults.length}>
-                        "So many cards, so little time."
-                    </DefaultPlaceholder>
+                        <DefaultPlaceholder active={!searchResults.length}>
+                            "So many cards, so little time."
+                        </DefaultPlaceholder>
 
-                    <ReceivingSearchList />
-                </Grid.Column>
-                <Grid.Column width="6">
-                    <Header as="h2" style={{ display: "inline-block" }}>
-                        Buylist
-                        <TotalCardsLabel listLength={receivingList.length} />
-                    </Header>
+                        <ReceivingSearchList />
+                    </Grid.Column>
+                    <Grid.Column width="6">
+                        <Header as="h2" style={{ display: 'inline-block' }}>
+                            Buylist
+                            <TotalCardsLabel
+                                listLength={receivingList.length}
+                            />
+                        </Header>
 
-                    <Divider />
+                        <Divider />
 
-                    <DefaultPlaceholder active={!receivingList.length}>
-                        "If you receive it, they will come."
-                     </DefaultPlaceholder>
+                        <DefaultPlaceholder active={!receivingList.length}>
+                            "If you receive it, they will come."
+                        </DefaultPlaceholder>
 
-                    <ReceivingList cards={receivingList} />
-
-                </Grid.Column>
-            </Grid.Row>
-        </Grid>
-    </React.Fragment>
+                        <ReceivingList cards={receivingList} />
+                    </Grid.Column>
+                </Grid.Row>
+            </Grid>
+        </>
+    );
 }

--- a/src/Receiving/Receiving.js
+++ b/src/Receiving/Receiving.js
@@ -39,7 +39,7 @@ export default function Receiving() {
                             {searchResults.length > 0 && (
                                 <div>
                                     <AllLocationInventory
-                                        resultSet={searchResults}
+                                        searchResults={searchResults}
                                         title={searchResults[0].name}
                                     />
                                 </div>

--- a/src/context/InventoryContext.js
+++ b/src/context/InventoryContext.js
@@ -1,9 +1,28 @@
+import axios from 'axios';
 import React, { createContext, useState } from 'react';
+import makeAuthHeader from '../utils/makeAuthHeader';
+import { InventoryCard } from '../utils/ScryfallCard';
+import { GET_CARDS_WITH_INFO } from '../utils/api_resources';
 
 export const InventoryContext = createContext();
 
 export function InventoryProvider({ children }) {
     const [searchResults, setSearchResults] = useState([]);
+
+    const handleSearchSelect = async (term) => {
+        try {
+            const { data } = await axios.get(GET_CARDS_WITH_INFO, {
+                params: { title: term, matchInStock: false },
+                headers: makeAuthHeader(),
+            });
+
+            const modeledData = data.map((c) => new InventoryCard(c));
+
+            setSearchResults(modeledData);
+        } catch (e) {
+            console.log(e);
+        }
+    };
 
     const changeCardQuantity = (id, qoh) => {
         const copiedState = [...searchResults];
@@ -14,7 +33,7 @@ export function InventoryProvider({ children }) {
 
     return (
         <InventoryContext.Provider
-            value={{ searchResults, setSearchResults, changeCardQuantity }}
+            value={{ searchResults, changeCardQuantity, handleSearchSelect }}
         >
             {children}
         </InventoryContext.Provider>

--- a/src/utils/api_resources.js
+++ b/src/utils/api_resources.js
@@ -18,6 +18,7 @@ const getPrefix = () => {
 
 const endpoints = {
     FINISH_SALE: `${getPrefix()}/auth/finishSale`,
+    GET_CARD_FROM_ALL_LOCATIONS: `${getPrefix()}/getCardFromAllLocations`,
     ADD_CARD_TO_INVENTORY: `${getPrefix()}/auth/addCardToInventory`,
     RECEIVE_CARDS: `${getPrefix()}/auth/receiveCards`,
     GET_CARDS_BY_FILTER: `${getPrefix()}/auth/getCardsByFilter`,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/15024562/105615350-b80f2a80-5d84-11eb-8ea5-864701151767.png)

#### Summary:
Users needed to view the QOH for both store locations while scoped under one location login. The challenge here was not impacting search speed - adding another aggregation query with two joins to the current single-card query would likely cause a noticeable lag, and when employees are adding or managing large lists of cards, this time can add up. The tradeoff was to reprioritize location-specific QOH over all-location QOH. The second round trip is lightweight, but if it's needed to view, users can wait the extra 0.5 seconds for the query to complete. Essentially, I chose to offload another query into the rendered component using `useEffect` rather than extending the existing query with it.

#### Major changes:
- Style fixes throughout
- Implement `AllLocationInventory`
- Implement interactor and route for `getCardFromAllLocations`
- Implement `parseQoh` on the backend
- Hoist `handleSearchSelect` into `InventoryContext`
- Changes to the app's flavor text 😆 