### PR TITLE
Preserve CNAME

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     },
     "scripts": {
         "start": "REACT_APP_ENVIRONMENT=development react-scripts start",
-        "build": "react-scripts build",
+        "build": "react-scripts build && mv ./build ./docs",
         "test": "react-scripts test --env=jsdom-fourteen",
         "eject": "react-scripts eject"
     },

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+chcollector.com


### PR DESCRIPTION
Manually copying CNAME and renaming CRA's build output was getting tedious. This PR places CNAME in the `public` directory to include it in the build, and extends the `npm run build` script to rename the recently built `build` folder to `docs`