### PR TITLE
Patch pricing bug

### DIFF
--- a/src/common/Price.test.js
+++ b/src/common/Price.test.js
@@ -19,3 +19,8 @@ test('Price', () => {
     render(<Price num="-765.437" />);
     screen.getByText('$-765.44');
 });
+
+test('Price', () => {
+    render(<Price num={null} />);
+    screen.getByText('$0.00');
+});

--- a/src/common/Price.tsx
+++ b/src/common/Price.tsx
@@ -7,7 +7,7 @@ interface Props {
 const Price: FC<Props> = ({ num }) => {
     let price: number = typeof num === 'string' ? Number(num) : num;
 
-    if (isNaN(price)) return <span>$0.00</span>;
+    if (num === null || isNaN(price)) return <span>$0.00</span>;
     return <span>${price.toFixed(2)}</span>;
 };
 


### PR DESCRIPTION
The price component error'd out if it received a `null` prop. We now guard against it. 