### PR TITLE
Autocomplete atlas

### DIFF
--- a/monolith/interactors/autocomplete.ts
+++ b/monolith/interactors/autocomplete.ts
@@ -13,7 +13,7 @@ async function autocomplete(term: string) {
 
         const db = client.db(DATABASE_NAME);
 
-        return await db
+        const results = await db
             .collection('scryfall_bulk_cards')
             .aggregate([
                 {
@@ -30,7 +30,7 @@ async function autocomplete(term: string) {
                     },
                 },
                 {
-                    $limit: 10,
+                    $limit: 15,
                 },
                 {
                     $project: {
@@ -40,6 +40,12 @@ async function autocomplete(term: string) {
                 },
             ])
             .toArray();
+
+        return results
+            .map((r: { name: string }) => r.name)
+            .filter((el, idx, arr) => {
+                return arr.indexOf(el) === idx;
+            });
     } catch (err) {
         console.log(err);
         throw err;

--- a/monolith/interactors/autocomplete.ts
+++ b/monolith/interactors/autocomplete.ts
@@ -1,0 +1,51 @@
+const MongoClient = require('mongodb').MongoClient;
+import getDatabaseName from '../lib/getDatabaseName';
+const DATABASE_NAME = getDatabaseName();
+
+async function autocomplete(term: string) {
+    const client = await new MongoClient(process.env.MONGO_URI, {
+        useNewUrlParser: true,
+        useUnifiedTopology: true,
+    });
+
+    try {
+        await client.connect();
+
+        const db = client.db(DATABASE_NAME);
+
+        return await db
+            .collection('scryfall_bulk_cards')
+            .aggregate([
+                {
+                    $search: {
+                        text: {
+                            query: term,
+                            path: 'name',
+                            fuzzy: {
+                                maxEdits: 1,
+                                maxExpansions: 50,
+                                prefixLength: 2,
+                            },
+                        },
+                    },
+                },
+                {
+                    $limit: 10,
+                },
+                {
+                    $project: {
+                        _id: 0,
+                        name: 1,
+                    },
+                },
+            ])
+            .toArray();
+    } catch (err) {
+        console.log(err);
+        throw err;
+    } finally {
+        await client.close();
+    }
+}
+
+export default autocomplete;

--- a/monolith/routes/index.ts
+++ b/monolith/routes/index.ts
@@ -1,8 +1,15 @@
-import express from 'express';
+import express, { Request } from 'express';
 const router = express.Router();
 import getJwt from '../interactors/getJwt';
 import getCardsWithInfo from '../interactors/getCardsWithInfo';
 import getCardFromAllLocations from '../interactors/getCardFromAllLocations';
+import autocomplete from '../interactors/autocomplete';
+
+interface RequestWithQuery extends Request {
+    query: {
+        title: string;
+    };
+}
 
 router.post('/jwt', async (req, res) => {
     try {
@@ -11,6 +18,17 @@ router.post('/jwt', async (req, res) => {
         const token = await getJwt(username, password, currentLocation);
 
         res.status(200).send(token);
+    } catch (err) {
+        console.log(err);
+        res.status(500).send(err);
+    }
+});
+
+router.get('/autocomplete', async (req: RequestWithQuery, res) => {
+    try {
+        const { title } = req.query;
+        const results = await autocomplete(title);
+        res.status(200).send(results);
     } catch (err) {
         console.log(err);
         res.status(500).send(err);

--- a/src/common/SearchBar.tsx
+++ b/src/common/SearchBar.tsx
@@ -30,8 +30,8 @@ const SearchBar: FC<Props> = ({ handleSearchSelect, onBlur }) => {
         setTimeout(async () => {
             const data = await autocompleteQuery(value);
 
-            const formattedResults = data.data
-                .map((el) => ({ title: el }))
+            const formattedResults = data
+                .map((el) => ({ title: el.name }))
                 .slice(0, 7);
 
             setResults(formattedResults);

--- a/src/common/SearchBar.tsx
+++ b/src/common/SearchBar.tsx
@@ -29,11 +29,7 @@ const SearchBar: FC<Props> = ({ handleSearchSelect, onBlur }) => {
 
         setTimeout(async () => {
             const data = await autocompleteQuery(value);
-
-            const formattedResults = data
-                .map((el) => ({ title: el.name }))
-                .slice(0, 7);
-
+            const formattedResults = data.map((el) => ({ title: el }));
             setResults(formattedResults);
             setLoading(false);
         }, 100);

--- a/src/common/autocompleteQuery.ts
+++ b/src/common/autocompleteQuery.ts
@@ -1,23 +1,17 @@
 import axios from 'axios';
-import makeAuthHeader from '../utils/makeAuthHeader';
-import { SCRYFALL_AUTOCOMPLETE } from '../utils/api_resources';
+import { AUTOCOMPLETE } from '../utils/api_resources';
 
 interface Response {
-    data: {
-        data: string[];
-        object: string;
-        total_values: 1;
-    };
+    data: { name: string }[];
 }
 
 const autocompleteQuery = async (cardName: string) => {
     try {
-        const { data }: Response = await axios.get(
-            `${SCRYFALL_AUTOCOMPLETE}?q=${cardName}`,
-            {
-                headers: makeAuthHeader(),
-            }
-        );
+        const { data }: Response = await axios.get(AUTOCOMPLETE, {
+            params: {
+                title: cardName,
+            },
+        });
 
         return data;
     } catch (err) {

--- a/src/common/autocompleteQuery.ts
+++ b/src/common/autocompleteQuery.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 import { AUTOCOMPLETE } from '../utils/api_resources';
 
 interface Response {
-    data: { name: string }[];
+    data: string[];
 }
 
 const autocompleteQuery = async (cardName: string) => {

--- a/src/utils/api_resources.ts
+++ b/src/utils/api_resources.ts
@@ -31,5 +31,3 @@ export const GET_CARDS_WITH_INFO = `${getPrefix()}/auth/getCardsWithInfo`;
 export const AUTOCOMPLETE = `${getPrefix()}/autocomplete`;
 export const SCRYFALL_SEARCH = 'https://api.scryfall.com/cards/search';
 export const GET_LIVE_PRICE = `https://us-central1-clubhouse-collection.cloudfunctions.net/getPriceFromTcg${env}`;
-export const SCRYFALL_AUTOCOMPLETE =
-    'https://api.scryfall.com/cards/autocomplete';

--- a/src/utils/api_resources.ts
+++ b/src/utils/api_resources.ts
@@ -28,6 +28,7 @@ export const GET_SALES_BY_TITLE = `${getPrefix()}/auth/getSaleByTitle`;
 export const GET_ALL_SALES = `${getPrefix()}/auth/allSales`;
 export const GET_CARDS_WITH_INFO_PUBLIC = `${getPrefix()}/getCardsWithInfo`;
 export const GET_CARDS_WITH_INFO = `${getPrefix()}/auth/getCardsWithInfo`;
+export const AUTOCOMPLETE = `${getPrefix()}/autocomplete`;
 export const SCRYFALL_SEARCH = 'https://api.scryfall.com/cards/search';
 export const GET_LIVE_PRICE = `https://us-central1-clubhouse-collection.cloudfunctions.net/getPriceFromTcg${env}`;
 export const SCRYFALL_AUTOCOMPLETE =


### PR DESCRIPTION
## Summary
This PR introduces integration with Mongo Atlas' `$search` aggregation pipeline stage, after creating corresponding search indices on `scryfall_bulk_cards` in each collection.

We've refactored the backend to include an `autocomplete` route and corresponding interactor, and updated the frontend's `autocomplete` query used in the `SearchBar` component.