### PR TITLE
prefer autocomplete index

### DIFF
--- a/monolith/interactors/autocomplete.ts
+++ b/monolith/interactors/autocomplete.ts
@@ -32,7 +32,7 @@ async function autocomplete(term: string) {
                     },
                 },
                 {
-                    $limit: 7,
+                    $limit: 15,
                 },
                 {
                     $project: {

--- a/monolith/interactors/autocomplete.ts
+++ b/monolith/interactors/autocomplete.ts
@@ -18,19 +18,21 @@ async function autocomplete(term: string) {
             .aggregate([
                 {
                     $search: {
-                        text: {
+                        index: 'autocomplete',
+                        autocomplete: {
                             query: term,
                             path: 'name',
+                            tokenOrder: 'sequential',
                             fuzzy: {
                                 maxEdits: 1,
                                 maxExpansions: 50,
-                                prefixLength: 2,
+                                prefixLength: 3,
                             },
                         },
                     },
                 },
                 {
-                    $limit: 15,
+                    $limit: 7,
                 },
                 {
                     $project: {


### PR DESCRIPTION
## Summary
Used the Atlas `autocomplete` data type to re-index the search with autocomplete in mind. This seems to increase the sensitivity/specificity of the search despite a small tradeoff in performance.