### PR TITLE
Reduce saleList payload size

### DIFF
--- a/monolith/routes/auth.ts
+++ b/monolith/routes/auth.ts
@@ -129,8 +129,8 @@ router.post('/finishSale', (req: RequestWithUserInfo, res, next) => {
         const { price, qtyToSell, finishCondition, name, set_name, id } = card;
 
         if (!id) throw new Error(`Card property id missing`);
-        if (!name && !set_name)
-            throw new Error(`Card name or set_name missing for ${id}`);
+        if (!name) throw new Error(`Card name missing for ${id}`);
+        if (!set_name) throw new Error(`Card set_name missing for ${id}`);
         if (typeof price !== 'number')
             throw new Error(`Price not number for ${name}`);
         if (price < 0)

--- a/src/context/SaleContext.js
+++ b/src/context/SaleContext.js
@@ -153,9 +153,19 @@ export const SaleProvider = (props) => {
                     headers: makeAuthHeader(),
                 });
 
+            // Extract only the necessary items for sale parameters
+            const transformedSaleListCards = saleListCards.map((saleCard) => ({
+                id: saleCard.id,
+                name: saleCard.name,
+                set_name: saleCard.set_name,
+                qtyToSell: saleCard.qtyToSell,
+                finishCondition: saleCard.finishCondition,
+                price: saleCard.price || 0,
+            }));
+
             const { data } = await axios.post(
                 FINISH_SALE,
-                { cards: saleListCards },
+                { cards: transformedSaleListCards },
                 { headers: makeAuthHeader() }
             );
 


### PR DESCRIPTION
Large lists of 70 or more cards tend to fail when selling or receiving. This is an early solution to condense the amount of JSON we're passing over the wire. A good start, but needs more investigation.

Make sure to rebuild both ends before deploying.