### PR TITLE
Sale list fix

### DIFF
--- a/frontend/src/context/SaleContext.tsx
+++ b/frontend/src/context/SaleContext.tsx
@@ -81,11 +81,13 @@ export const SaleProvider: FC<Props> = ({ children }) => {
     ) => {
         // TODO: is this stable? We have to use
         // Object.assign() to preserve getter and setter methods
-        const newCard = Object.assign(card, {
-            finishCondition,
-            qtyToSell,
-            price,
-        });
+        const newCard = _.clone(
+            Object.assign(card, {
+                finishCondition,
+                qtyToSell,
+                price,
+            })
+        );
 
         const oldState = [...saleListCards];
         // TODO: do we have to re-model this??

--- a/frontend/src/utils/ScryfallCard.ts
+++ b/frontend/src/utils/ScryfallCard.ts
@@ -151,6 +151,7 @@ export class InventoryCard extends ScryfallCard {
         super(card);
         this._qoh = card.qoh ? card.qoh : {};
         // `quantity` and `qtyToSell` are redundant transaction props, unify them down the line
+        // TODO: remove quantity as it seems to be unused
         this.quantity = card.quantity || null;
         this.qtyToSell = card.qtyToSell || null;
         this.finishCondition = card.finishCondition || null;


### PR DESCRIPTION
## Summary
Fixes a bug that prevented users from adding identical card printings of varying condition and foil types. 

Turned out I had to use lodash to solve it, in the most unintuitive way possible via copying an assigned object. Definitely something to improve upon and test.