### PR TITLE
Receiving records api

### DIFF
--- a/frontend/src/context/ReceivingContext.tsx
+++ b/frontend/src/context/ReceivingContext.tsx
@@ -169,15 +169,29 @@ const ReceivingProvider: FC<Props> = ({ children }) => {
     const commitToInventory = async () => {
         try {
             const cardsToCommit = receivingList.map((card) => {
-                const { finishCondition, id, name, set_name, set } = card;
-                return {
-                    quantity: 1,
+                const {
                     finishCondition,
                     id,
                     name,
                     set_name,
                     set,
-                }; // Only committing one per line-item
+                    marketPrice,
+                    cashPrice,
+                    creditPrice,
+                    tradeType,
+                } = card;
+                return {
+                    quantity: 1, // Only committing one per line-item
+                    finishCondition,
+                    id,
+                    name,
+                    set_name,
+                    set,
+                    creditPrice,
+                    cashPrice,
+                    marketPrice,
+                    tradeType,
+                };
             });
 
             await axios.post(

--- a/frontend/src/context/receivingQuery.tsx
+++ b/frontend/src/context/receivingQuery.tsx
@@ -1,0 +1,42 @@
+import axios from 'axios';
+import makeAuthHeader from '../utils/makeAuthHeader';
+import { RECEIVE_CARDS } from '../utils/api_resources';
+import { Trade } from './ReceivingContext';
+
+// TODO: We should type this
+interface Response {
+    data: any;
+}
+
+interface ReceivingQueryCard {
+    quantity: number;
+    finishCondition: string;
+    id: string;
+    name: string;
+    set_name: string;
+    set: string;
+    marketPrice: number | null;
+    cashPrice: number | null;
+    creditPrice: number | null;
+    tradeType: Trade;
+}
+
+interface Payload {
+    cards: ReceivingQueryCard[];
+}
+
+const receivingQuery = async (payload: Payload) => {
+    try {
+        const { data }: Response = await axios.post(
+            RECEIVE_CARDS,
+            { cards: payload.cards },
+            { headers: makeAuthHeader() }
+        );
+
+        return data;
+    } catch (err) {
+        throw err;
+    }
+};
+
+export default receivingQuery;

--- a/frontend/src/utils/ScryfallCard.ts
+++ b/frontend/src/utils/ScryfallCard.ts
@@ -162,6 +162,7 @@ export class InventoryCard extends ScryfallCard {
         this._qoh = card.qoh ? card.qoh : {};
         // `quantity` and `qtyToSell` are redundant transaction props, unify them down the line
         // TODO: remove quantity as it seems to be unused
+        // TODO: Never mind, it's used in Receiving briefly
         this.quantity = card.quantity || null;
         this.qtyToSell = card.qtyToSell || null;
         this.finishCondition = card.finishCondition || null;

--- a/frontend/src/utils/ScryfallCard.ts
+++ b/frontend/src/utils/ScryfallCard.ts
@@ -151,7 +151,7 @@ export class ScryfallCard {
  * Models the data and makes writing cards to Mongo a more confident process.
  */
 export class InventoryCard extends ScryfallCard {
-    private _qoh: Partial<QOH>;
+    public qoh: Partial<QOH>;
     public quantity: number | null;
     public qtyToSell: number | null;
     public finishCondition: string | null;
@@ -159,7 +159,7 @@ export class InventoryCard extends ScryfallCard {
 
     public constructor(card: ScryfallApiCard) {
         super(card);
-        this._qoh = card.qoh ? card.qoh : {};
+        this.qoh = card.qoh ? card.qoh : {};
         // `quantity` and `qtyToSell` are redundant transaction props, unify them down the line
         // TODO: remove quantity as it seems to be unused
         // TODO: Never mind, it's used in Receiving briefly
@@ -167,13 +167,5 @@ export class InventoryCard extends ScryfallCard {
         this.qtyToSell = card.qtyToSell || null;
         this.finishCondition = card.finishCondition || null;
         this.price = card.price && card.price >= 0 ? card.price : null;
-    }
-
-    get qoh() {
-        return this._qoh;
-    }
-
-    set qoh(quantities) {
-        this._qoh = quantities ? quantities : {};
     }
 }

--- a/monolith/interactors/addCardToInventoryReceiving.ts
+++ b/monolith/interactors/addCardToInventoryReceiving.ts
@@ -2,19 +2,23 @@ import { Collection } from 'mongodb';
 import { ClubhouseLocation } from './getJwt';
 import collectionFromLocation from '../lib/collectionFromLocation';
 import getDatabaseConnection from '../database';
+import addCardsToReceivingRecords from './addCardsToReceivingRecords';
 
-type Card = {
+export type ReceivingCard = {
     quantity: number;
     finishCondition: string;
     id: string;
     name: string;
     set_name: string;
     set: string;
+    credit_price: number | null;
+    cash_price: number | null;
+    market_price: number | null;
 };
 
 // `finishCondition` Refers to the configuration of Finishes and Conditions ex. NONFOIL_NM or FOIL_LP
 async function addCardToInventoryReceiving(
-    { quantity, finishCondition, id, name, set_name, set }: Card,
+    { quantity, finishCondition, id, name, set_name, set }: ReceivingCard,
     collection: Collection
 ) {
     try {
@@ -41,7 +45,7 @@ async function addCardToInventoryReceiving(
 
 // Wraps the database connection and exposes addCardToInventoryReceiving to the db connection
 async function wrapAddCardToInventoryReceiving(
-    cards: Card[],
+    cards: ReceivingCard[],
     location: ClubhouseLocation
 ) {
     try {
@@ -56,6 +60,8 @@ async function wrapAddCardToInventoryReceiving(
         );
 
         const messages = await Promise.all(promises);
+
+        await addCardsToReceivingRecords(cards, location);
 
         console.log(`Receiving cards at ${location}`);
 

--- a/monolith/interactors/addCardToInventoryReceiving.ts
+++ b/monolith/interactors/addCardToInventoryReceiving.ts
@@ -4,6 +4,11 @@ import collectionFromLocation from '../lib/collectionFromLocation';
 import getDatabaseConnection from '../database';
 import addCardsToReceivingRecords from './addCardsToReceivingRecords';
 
+export enum Trade {
+    Cash = 'CASH',
+    Credit = 'CREDIT',
+}
+
 export type ReceivingCard = {
     quantity: number;
     finishCondition: string;
@@ -14,6 +19,7 @@ export type ReceivingCard = {
     credit_price: number | null;
     cash_price: number | null;
     market_price: number | null;
+    tradeType: Trade;
 };
 
 // `finishCondition` Refers to the configuration of Finishes and Conditions ex. NONFOIL_NM or FOIL_LP

--- a/monolith/interactors/addCardToInventoryReceiving.ts
+++ b/monolith/interactors/addCardToInventoryReceiving.ts
@@ -2,7 +2,6 @@ import { Collection } from 'mongodb';
 import { ClubhouseLocation } from './getJwt';
 import collectionFromLocation from '../lib/collectionFromLocation';
 import getDatabaseConnection from '../database';
-import addCardsToReceivingRecords from './addCardsToReceivingRecords';
 
 export enum Trade {
     Cash = 'CASH',
@@ -66,8 +65,6 @@ async function wrapAddCardToInventoryReceiving(
         );
 
         const messages = await Promise.all(promises);
-
-        await addCardsToReceivingRecords(cards, location);
 
         console.log(`Receiving cards at ${location}`);
 

--- a/monolith/interactors/addCardsToReceivingRecords.ts
+++ b/monolith/interactors/addCardsToReceivingRecords.ts
@@ -1,0 +1,29 @@
+import { ClubhouseLocation } from './getJwt';
+import collectionFromLocation from '../lib/collectionFromLocation';
+import getDatabaseConnection from '../database';
+import { ReceivingCard } from './addCardToInventoryReceiving';
+
+async function addCardsToReceivingRecords(
+    cards: ReceivingCard[],
+    location: ClubhouseLocation
+) {
+    try {
+        const db = await getDatabaseConnection();
+
+        // TODO: test to make sure cards at ch2 get received
+
+        await db
+            .collection(collectionFromLocation(location).receivedCards)
+            .insertOne({
+                created_at: new Date(),
+                received_card_list: cards,
+            });
+
+        console.log(`Recorded ${cards.length} received cards at ${location}`);
+    } catch (err) {
+        console.log(err);
+        throw err;
+    }
+}
+
+export default addCardsToReceivingRecords;

--- a/monolith/interactors/addCardsToReceivingRecords.ts
+++ b/monolith/interactors/addCardsToReceivingRecords.ts
@@ -5,6 +5,7 @@ import { ReceivingCard } from './addCardToInventoryReceiving';
 
 async function addCardsToReceivingRecords(
     cards: ReceivingCard[],
+    employeeNumber: number,
     location: ClubhouseLocation
 ) {
     try {
@@ -14,6 +15,7 @@ async function addCardsToReceivingRecords(
             .collection(collectionFromLocation(location).receivedCards)
             .insertOne({
                 created_at: new Date(),
+                employee_number: employeeNumber,
                 received_card_list: cards,
             });
 

--- a/monolith/interactors/addCardsToReceivingRecords.ts
+++ b/monolith/interactors/addCardsToReceivingRecords.ts
@@ -10,8 +10,6 @@ async function addCardsToReceivingRecords(
     try {
         const db = await getDatabaseConnection();
 
-        // TODO: test to make sure cards at ch2 get received
-
         await db
             .collection(collectionFromLocation(location).receivedCards)
             .insertOne({

--- a/monolith/lib/collectionFromLocation.ts
+++ b/monolith/lib/collectionFromLocation.ts
@@ -4,12 +4,14 @@ interface Ch1Collection {
     cardInventory: 'card_inventory';
     salesData: 'sales_data';
     suspendedSales: 'suspended_sales';
+    receivedCards: 'received_cards';
 }
 
 interface Ch2Collection {
     cardInventory: 'card_inventory_ch2';
     salesData: 'sales_data_ch2';
     suspendedSales: 'suspended_sales_ch2';
+    receivedCards: 'received_cards_ch2';
 }
 
 export default function collectionFromLocation(
@@ -20,6 +22,7 @@ export default function collectionFromLocation(
             cardInventory: 'card_inventory',
             salesData: 'sales_data',
             suspendedSales: 'suspended_sales',
+            receivedCards: 'received_cards',
         };
     }
     if (location === 'ch2') {
@@ -27,6 +30,7 @@ export default function collectionFromLocation(
             cardInventory: 'card_inventory_ch2',
             salesData: 'sales_data_ch2',
             suspendedSales: 'suspended_sales_ch2',
+            receivedCards: 'received_cards_ch2',
         };
     }
 }

--- a/monolith/routes/auth.ts
+++ b/monolith/routes/auth.ts
@@ -16,6 +16,7 @@ import getSuspendedSales from '../interactors/getSuspendedSales';
 import getSuspendedSale from '../interactors/getSuspendedSale';
 import createSuspendedSale from '../interactors/createSuspendedSale';
 import deleteSuspendedSale from '../interactors/deleteSuspendedSale';
+import addCardsToReceivingRecords from '../interactors/addCardsToReceivingRecords';
 
 interface RequestWithUserInfo extends Request {
     locations: string[];
@@ -235,6 +236,12 @@ router.post('/receiveCards', async (req: RequestWithUserInfo, res) => {
         const { cards } = req.body;
         const messages = await addCardToInventoryReceiving(
             cards,
+            req.currentLocation
+        );
+
+        await addCardsToReceivingRecords(
+            cards,
+            req.lightspeedEmployeeNumber,
             req.currentLocation
         );
 


### PR DESCRIPTION
## Summary

This PR adds support for persisting received cards to a new collection for future querying.

- Creates an interactor for adding to the `received_cards` collection along with collection name
- Extracts `receiveCards` query
- Makes minor improvements to `ScryfallCard` by removing the private property `_qoh` and its associated getters and setters