### PR TITLE
Tcg price link shim

### DIFF
--- a/frontend/src/ui/CardHeader.tsx
+++ b/frontend/src/ui/CardHeader.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react';
 import { InventoryCard } from '../utils/ScryfallCard';
-import { Label, Item } from 'semantic-ui-react';
+import { Label, Item, Button, Icon } from 'semantic-ui-react';
 import QohLabels from '../common/QohLabels';
 import Language from '../common/Language';
 import MarketPrice from '../common/MarketPrice';
@@ -18,13 +18,60 @@ const SetIcon = styled('i')({
     fontSize: '30px',
 });
 
+// TODO: remove this shim after TCG api approval and integration
+const TcgPriceButton: FC<{ tcgId: number | null }> = ({ tcgId }) => {
+    const tcgUrl = `https://www.tcgplayer.com/product/${tcgId}`;
+
+    if (!tcgId) {
+        return (
+            <Button
+                icon
+                disabled
+                color="twitter"
+                labelPosition="right"
+                size="mini"
+                as="a"
+                href={tcgUrl}
+                target="_blank"
+            >
+                Link unavailable
+                <Icon name="external share" />
+            </Button>
+        );
+    }
+
+    return (
+        <Button
+            icon
+            color="twitter"
+            labelPosition="right"
+            size="mini"
+            as="a"
+            href={tcgUrl}
+            target="_blank"
+        >
+            View on TCG
+            <Icon name="external share" />
+        </Button>
+    );
+};
+
 const CardHeader: FC<Props> = ({
     card,
     selectedFinish,
     showMid = false,
     round = false,
 }) => {
-    const { id, display_name, set, rarity, set_name, qoh, lang } = card;
+    const {
+        id,
+        display_name,
+        set,
+        rarity,
+        set_name,
+        qoh,
+        lang,
+        tcgplayer_id,
+    } = card;
 
     return (
         <Item.Header as="h3">
@@ -41,6 +88,7 @@ const CardHeader: FC<Props> = ({
                 round={round}
             />
             <Language languageCode={lang} />
+            <TcgPriceButton tcgId={tcgplayer_id} />
         </Item.Header>
     );
 };

--- a/frontend/src/ui/CardHeader.tsx
+++ b/frontend/src/ui/CardHeader.tsx
@@ -22,27 +22,10 @@ const SetIcon = styled('i')({
 const TcgPriceButton: FC<{ tcgId: number | null }> = ({ tcgId }) => {
     const tcgUrl = `https://www.tcgplayer.com/product/${tcgId}`;
 
-    if (!tcgId) {
-        return (
-            <Button
-                icon
-                disabled
-                color="twitter"
-                labelPosition="right"
-                size="mini"
-                as="a"
-                href={tcgUrl}
-                target="_blank"
-            >
-                Link unavailable
-                <Icon name="external share" />
-            </Button>
-        );
-    }
-
     return (
         <Button
             icon
+            disabled={!tcgId}
             color="twitter"
             labelPosition="right"
             size="mini"
@@ -50,7 +33,7 @@ const TcgPriceButton: FC<{ tcgId: number | null }> = ({ tcgId }) => {
             href={tcgUrl}
             target="_blank"
         >
-            View on TCG
+            {!tcgId ? 'Link unavailable' : 'View on TCG'}
             <Icon name="external share" />
         </Button>
     );

--- a/frontend/src/utils/ScryfallCard.ts
+++ b/frontend/src/utils/ScryfallCard.ts
@@ -77,6 +77,7 @@ export interface ScryfallApiCard {
     finishCondition?: string;
     price?: number;
     promo_types?: string[];
+    tcgplayer_id?: number;
 }
 
 /**
@@ -104,6 +105,7 @@ export class ScryfallCard {
     public cardImage: string;
     public color_identity: string[];
     public promo_types: string[];
+    public tcgplayer_id: number | null;
 
     public constructor(card: ScryfallApiCard) {
         this.id = card.id;
@@ -125,6 +127,7 @@ export class ScryfallCard {
         this.promo_types = card.promo_types || [];
         this.cardImage = this._getCardImage();
         this.display_name = this._createDisplayName();
+        this.tcgplayer_id = card.tcgplayer_id || null;
     }
 
     // Computes the proper displayName for a card, depending on its properties


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/15024562/121816593-5c5d1500-cc31-11eb-8250-be4e1207820e.png)

## Summary
Until we have approval to integrate with TCGplayer's API, this shim will have to do. It allows staff to open the card in a new tab using TCGplayer's unique SKU.

## Changes
- Extend the `ScryfallCard` class with `tcgplayer_id`
- Create the button, and disable it if none is provided