### PR TITLE
Pass user entity id as currentUser 

### DIFF
--- a/monolith/interactors/addCardsToReceivingRecords.ts
+++ b/monolith/interactors/addCardsToReceivingRecords.ts
@@ -6,7 +6,8 @@ import { ReceivingCard } from './addCardToInventoryReceiving';
 async function addCardsToReceivingRecords(
     cards: ReceivingCard[],
     employeeNumber: number,
-    location: ClubhouseLocation
+    location: ClubhouseLocation,
+    userId: string
 ) {
     try {
         const db = await getDatabaseConnection();
@@ -17,6 +18,7 @@ async function addCardsToReceivingRecords(
                 created_at: new Date(),
                 employee_number: employeeNumber,
                 received_card_list: cards,
+                created_by: userId,
             });
 
         console.log(`Recorded ${cards.length} received cards at ${location}`);

--- a/monolith/interactors/getJwt.ts
+++ b/monolith/interactors/getJwt.ts
@@ -1,13 +1,13 @@
 const bcrypt = require('bcrypt');
 const jwt = require('jsonwebtoken');
-import getDatabaseConnection from '../database';
+import getUserByName from './getUserByName';
 
 export type ClubhouseLocation = 'ch1' | 'ch2';
 
 export type User = {
     _id: string;
     password: string;
-    username: symbol;
+    username: string;
     locations: string[];
     currentLocation: ClubhouseLocation;
     lightspeedEmployeeNumber: number;
@@ -19,16 +19,12 @@ async function getJwt(
     currentLocation: ClubhouseLocation
 ): Promise<{ token: string } | string> {
     try {
-        const db = await getDatabaseConnection();
-
-        const user: User = await db.collection('users').findOne({
-            username: username,
-        });
+        const user: User = await getUserByName(username);
 
         if (!user) return 'Not authorized';
 
         // Retrieve the Clubhouse location permissions and employee number for the user
-        const { _id, locations, lightspeedEmployeeNumber, password } = user;
+        const { _id, locations, password } = user;
 
         // Check if the user is allowed in the location
         if (!locations.includes(currentLocation)) {
@@ -42,10 +38,7 @@ async function getJwt(
             const token: string = jwt.sign(
                 {
                     userId: _id,
-                    username,
-                    locations,
                     currentLocation,
-                    lightspeedEmployeeNumber,
                 },
                 process.env.PRIVATE_KEY
             );

--- a/monolith/interactors/getJwt.ts
+++ b/monolith/interactors/getJwt.ts
@@ -1,17 +1,8 @@
 const bcrypt = require('bcrypt');
 const jwt = require('jsonwebtoken');
-import getUserByName from './getUserByName';
+import getUserByName, { User } from './getUserByName';
 
 export type ClubhouseLocation = 'ch1' | 'ch2';
-
-export type User = {
-    _id: string;
-    password: string;
-    username: string;
-    locations: string[];
-    currentLocation: ClubhouseLocation;
-    lightspeedEmployeeNumber: number;
-};
 
 async function getJwt(
     username: string,

--- a/monolith/interactors/getJwt.ts
+++ b/monolith/interactors/getJwt.ts
@@ -5,6 +5,7 @@ import getDatabaseConnection from '../database';
 export type ClubhouseLocation = 'ch1' | 'ch2';
 
 export type User = {
+    _id: string;
     password: string;
     username: symbol;
     locations: string[];
@@ -27,7 +28,7 @@ async function getJwt(
         if (!user) return 'Not authorized';
 
         // Retrieve the Clubhouse location permissions and employee number for the user
-        const { locations, lightspeedEmployeeNumber } = user;
+        const { _id, locations, lightspeedEmployeeNumber, password } = user;
 
         // Check if the user is allowed in the location
         if (!locations.includes(currentLocation)) {
@@ -35,11 +36,12 @@ async function getJwt(
         }
 
         // Determine if the fetched user's credentials are authorized
-        const match = await bcrypt.compareSync(submittedPass, user.password);
+        const match = await bcrypt.compareSync(submittedPass, password);
 
         if (match) {
             const token: string = jwt.sign(
                 {
+                    userId: _id,
                     username,
                     locations,
                     currentLocation,

--- a/monolith/interactors/getUserById.ts
+++ b/monolith/interactors/getUserById.ts
@@ -1,15 +1,13 @@
-import { ClubhouseLocation } from './getJwt';
 import getDatabaseConnection from '../database';
 import { ObjectID } from 'mongodb';
 
-type User = {
+export interface User {
     _id: string;
     password: string;
     username: string;
     locations: string[];
-    currentLocation: ClubhouseLocation;
     lightspeedEmployeeNumber: number;
-};
+}
 
 export default async function getUserById(id: string): Promise<User> {
     try {

--- a/monolith/interactors/getUserById.ts
+++ b/monolith/interactors/getUserById.ts
@@ -1,0 +1,27 @@
+import { ClubhouseLocation } from './getJwt';
+import getDatabaseConnection from '../database';
+import { ObjectID } from 'mongodb';
+
+type User = {
+    _id: string;
+    password: string;
+    username: string;
+    locations: string[];
+    currentLocation: ClubhouseLocation;
+    lightspeedEmployeeNumber: number;
+};
+
+export default async function getUserById(id: string): Promise<User> {
+    try {
+        const db = await getDatabaseConnection();
+
+        const user: User = await db.collection('users').findOne({
+            _id: new ObjectID(id),
+        });
+
+        return user;
+    } catch (err) {
+        console.log(err);
+        throw err;
+    }
+}

--- a/monolith/interactors/getUserByName.ts
+++ b/monolith/interactors/getUserByName.ts
@@ -1,0 +1,26 @@
+import { ClubhouseLocation } from './getJwt';
+import getDatabaseConnection from '../database';
+
+type User = {
+    _id: string;
+    password: string;
+    username: string;
+    locations: string[];
+    currentLocation: ClubhouseLocation;
+    lightspeedEmployeeNumber: number;
+};
+
+export default async function getUserByName(username: string): Promise<User> {
+    try {
+        const db = await getDatabaseConnection();
+
+        const user: User = await db.collection('users').findOne({
+            username,
+        });
+
+        return user;
+    } catch (err) {
+        console.log(err);
+        throw err;
+    }
+}

--- a/monolith/interactors/getUserByName.ts
+++ b/monolith/interactors/getUserByName.ts
@@ -1,14 +1,12 @@
-import { ClubhouseLocation } from './getJwt';
 import getDatabaseConnection from '../database';
 
-type User = {
+export interface User {
     _id: string;
     password: string;
     username: string;
     locations: string[];
-    currentLocation: ClubhouseLocation;
     lightspeedEmployeeNumber: number;
-};
+}
 
 export default async function getUserByName(username: string): Promise<User> {
     try {

--- a/monolith/routes/auth.ts
+++ b/monolith/routes/auth.ts
@@ -4,7 +4,7 @@ require('dotenv').config();
 import jwt from 'jsonwebtoken';
 import getCardsByFilter, { Arguments } from '../interactors/getCardsByFilter';
 import addCardToInventory from '../interactors/addCardToInventory';
-import { ClubhouseLocation, User } from '../interactors/getJwt';
+import { ClubhouseLocation } from '../interactors/getJwt';
 import getDistinctSetNames from '../interactors/getDistinctSetNames';
 import getCardsWithInfo from '../interactors/getCardsWithInfo';
 import finishSale from '../interactors/updateInventoryCards';
@@ -18,7 +18,7 @@ import createSuspendedSale from '../interactors/createSuspendedSale';
 import deleteSuspendedSale from '../interactors/deleteSuspendedSale';
 import addCardsToReceivingRecords from '../interactors/addCardsToReceivingRecords';
 import getCardsFromReceiving from '../interactors/getCardsFromReceiving';
-import getUserById from '../interactors/getUserById';
+import getUserById, { User } from '../interactors/getUserById';
 
 interface RequestWithUserInfo extends Request {
     locations: string[];

--- a/monolith/routes/auth.ts
+++ b/monolith/routes/auth.ts
@@ -252,7 +252,8 @@ router.post('/receiveCards', async (req: RequestWithUserInfo, res) => {
         await addCardsToReceivingRecords(
             cards,
             req.lightspeedEmployeeNumber,
-            req.currentLocation
+            req.currentLocation,
+            req.userId
         );
 
         res.status(200).send(messages);


### PR DESCRIPTION
## Summary
Our strategy of attaching various `currentUser` _properties_ of the user entity to the JWT, and decoding them on requests, is unsustainable because property names are subject to change, and it means the client is tied up in too much entity state management.

Instead we pass the entity `id` (user id) into the token during signing, and then all we have to do is perform a lookup when the request is decoded via top-level middleware. From there we can pass any relevant properties for downstream use, and users are never expected to sign out and sign back in to ensure that JWT's are compatible with current versions of the API.

Additionally, this passes the user id to `addCardsToReceivingRecords` for the `created_by` field, to be integrated into the client at a later date.