### PR TITLE
Joi integration

### DIFF
--- a/monolith/app.ts
+++ b/monolith/app.ts
@@ -35,8 +35,7 @@ app.use(function (err, req, res, next) {
     res.locals.error = req.app.get('env') === 'development' ? err : {};
 
     // render the error page
-    res.status(err.status || 500);
-    res.render('error');
+    res.status(err.status || 500).json(err.message);
 });
 
 export default app;

--- a/monolith/common/types.ts
+++ b/monolith/common/types.ts
@@ -1,0 +1,108 @@
+import { Request } from 'express';
+
+export type ClubhouseLocation = 'ch1' | 'ch2';
+
+export enum Trade {
+    Cash = 'CASH',
+    Credit = 'CREDIT',
+}
+
+export interface DecodedToken {
+    userId: string;
+    currentLocation: ClubhouseLocation;
+}
+
+export const finishes = [
+    'NONFOIL_NM',
+    'NONFOIL_LP',
+    'NONFOIL_MP',
+    'NONFOIL_HP',
+    'FOIL_NM',
+    'FOIL_LP',
+    'FOIL_MP',
+    'FOIL_HP',
+] as const;
+
+export type FinishCondition = typeof finishes[number];
+
+export interface QOH {
+    FOIL_NM?: number;
+    FOIL_LP?: number;
+    FOIL_MP?: number;
+    FOIL_HP?: number;
+    NONFOIL_NM?: number;
+    NONFOIL_LP?: number;
+    NONFOIL_MP?: number;
+    NONFOIL_HP?: number;
+}
+
+export interface RequestWithUserInfo extends Request {
+    locations: string[];
+    currentLocation: ClubhouseLocation;
+    isAdmin: boolean;
+    lightspeedEmployeeNumber: number;
+    userId: string;
+}
+
+export interface AddCardToInventoryReqBody {
+    quantity: number;
+    finishCondition: FinishCondition;
+    cardInfo: {
+        id: string;
+        name: string;
+        set_name: string;
+        set: string;
+    };
+}
+
+export interface AddCardToInventoryReq extends RequestWithUserInfo {
+    body: AddCardToInventoryReqBody;
+}
+
+export interface FinishSaleCard {
+    id: string;
+    price: number;
+    qtyToSell: number;
+    finishCondition: FinishCondition;
+    name: string;
+    set_name: string;
+}
+
+export interface ReqWithFinishSaleCards extends RequestWithUserInfo {
+    body: { cards: FinishSaleCard[] };
+}
+
+export interface ReceivingCard {
+    id: string;
+    quantity: number;
+    name: string;
+    set_name: string;
+    finishCondition: FinishCondition;
+    set: string;
+    creditPrice: number;
+    cashPrice: number;
+    marketPrice: number;
+    tradeType: Trade;
+}
+
+export interface ReqWithReceivingCards extends RequestWithUserInfo {
+    body: { cards: ReceivingCard[] };
+}
+
+export interface SuspendSaleBody {
+    customerName: string;
+    notes: string;
+    saleList: FinishSaleCard[];
+}
+
+export interface ReqWithSuspendSale extends RequestWithUserInfo {
+    body: SuspendSaleBody;
+}
+
+export interface GetReceivedCardsReq extends RequestWithUserInfo {
+    query: {
+        startDate: string | null;
+        endDate: string | null;
+        cardName: string | null;
+    };
+}

--- a/monolith/common/types.ts
+++ b/monolith/common/types.ts
@@ -106,3 +106,19 @@ export interface GetReceivedCardsReq extends RequestWithUserInfo {
         cardName: string | null;
     };
 }
+
+export interface JwtBody {
+    username: string;
+    password: string;
+    currentLocation: ClubhouseLocation;
+}
+
+export interface JwtRequest extends Request {
+    body: JwtBody;
+}
+
+export interface RequestWithQuery extends Request {
+    query: {
+        title: string;
+    };
+}

--- a/monolith/interactors/addCardToInventory.ts
+++ b/monolith/interactors/addCardToInventory.ts
@@ -1,7 +1,6 @@
 import collectionFromLocation from '../lib/collectionFromLocation';
-import { ClubhouseLocation } from './getJwt';
-import { QOH } from '../lib/parseQoh';
 import getDatabaseConnection from '../database';
+import { ClubhouseLocation, QOH } from '../common/types';
 
 type Card = {
     quantity: number;

--- a/monolith/interactors/addCardToInventoryReceiving.ts
+++ b/monolith/interactors/addCardToInventoryReceiving.ts
@@ -1,12 +1,7 @@
 import { Collection } from 'mongodb';
-import { ClubhouseLocation } from './getJwt';
 import collectionFromLocation from '../lib/collectionFromLocation';
 import getDatabaseConnection from '../database';
-
-export enum Trade {
-    Cash = 'CASH',
-    Credit = 'CREDIT',
-}
+import { ClubhouseLocation, Trade } from '../common/types';
 
 export type ReceivingCard = {
     quantity: number;

--- a/monolith/interactors/addCardToInventoryReceiving.ts
+++ b/monolith/interactors/addCardToInventoryReceiving.ts
@@ -15,9 +15,9 @@ export type ReceivingCard = {
     name: string;
     set_name: string;
     set: string;
-    credit_price: number | null;
-    cash_price: number | null;
-    market_price: number | null;
+    creditPrice: number | null;
+    cashPrice: number | null;
+    marketPrice: number | null;
     tradeType: Trade;
 };
 

--- a/monolith/interactors/addCardsToReceivingRecords.ts
+++ b/monolith/interactors/addCardsToReceivingRecords.ts
@@ -1,7 +1,7 @@
-import { ClubhouseLocation } from './getJwt';
 import collectionFromLocation from '../lib/collectionFromLocation';
 import getDatabaseConnection from '../database';
 import { ReceivingCard } from './addCardToInventoryReceiving';
+import { ClubhouseLocation } from '../common/types';
 
 async function addCardsToReceivingRecords(
     cards: ReceivingCard[],

--- a/monolith/interactors/createLightspeedSale.ts
+++ b/monolith/interactors/createLightspeedSale.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { ClubhouseLocation } from './getJwt';
+import { ClubhouseLocation } from '../common/types';
 
 /**
  * Helper fn used to create employee-readable note lines in the Lightspeed POS system

--- a/monolith/interactors/createSuspendedSale.ts
+++ b/monolith/interactors/createSuspendedSale.ts
@@ -1,6 +1,6 @@
+import { ClubhouseLocation } from '../common/types';
 import getDatabaseConnection from '../database';
 import collectionFromLocation from '../lib/collectionFromLocation';
-import { ClubhouseLocation } from './getJwt';
 import updateCardInventoryWithFlag from './updateCardInventoryWithFlag';
 
 /**

--- a/monolith/interactors/getAllSales.ts
+++ b/monolith/interactors/getAllSales.ts
@@ -1,6 +1,6 @@
+import { ClubhouseLocation } from '../common/types';
 import getDatabaseConnection from '../database';
 import collectionFromLocation from '../lib/collectionFromLocation';
-import { ClubhouseLocation } from './getJwt';
 
 async function getAllSales(location: ClubhouseLocation) {
     try {

--- a/monolith/interactors/getCardFromAllLocations.ts
+++ b/monolith/interactors/getCardFromAllLocations.ts
@@ -1,7 +1,7 @@
+import { ClubhouseLocation } from '../common/types';
 import getDatabaseConnection from '../database';
 import collectionFromLocation from '../lib/collectionFromLocation';
 import parseQoh from '../lib/parseQoh';
-import { ClubhouseLocation } from './getJwt';
 
 async function getSingleLocationCard(
     title: string,

--- a/monolith/interactors/getCardQuantitiesFromInventory.ts
+++ b/monolith/interactors/getCardQuantitiesFromInventory.ts
@@ -1,6 +1,6 @@
+import { ClubhouseLocation } from '../common/types';
 import getDatabaseConnection from '../database';
 import collectionFromLocation from '../lib/collectionFromLocation';
-import { ClubhouseLocation } from './getJwt';
 
 async function getCardQuantitiesFromInventory(
     scryfallIds: string[],

--- a/monolith/interactors/getCardsFromReceiving.ts
+++ b/monolith/interactors/getCardsFromReceiving.ts
@@ -1,6 +1,6 @@
+import { ClubhouseLocation } from '../common/types';
 import getDatabaseConnection from '../database';
 import collectionFromLocation from '../lib/collectionFromLocation';
-import { ClubhouseLocation } from './getJwt';
 
 interface Args {
     location: ClubhouseLocation;

--- a/monolith/interactors/getCardsWithInfo.ts
+++ b/monolith/interactors/getCardsWithInfo.ts
@@ -1,6 +1,6 @@
+import { ClubhouseLocation } from '../common/types';
 import getDatabaseConnection from '../database';
 import collectionFromLocation from '../lib/collectionFromLocation';
-import { ClubhouseLocation } from './getJwt';
 
 async function getCardsWithInfo(
     title: string,

--- a/monolith/interactors/getDistinctSetNames.ts
+++ b/monolith/interactors/getDistinctSetNames.ts
@@ -1,6 +1,6 @@
+import { ClubhouseLocation } from '../common/types';
 import getDatabaseConnection from '../database';
 import collectionFromLocation from '../lib/collectionFromLocation';
-import { ClubhouseLocation } from './getJwt';
 
 /**
  * Gets a list of all set names, for use in the Deckbox frontend dropdown selection

--- a/monolith/interactors/getFormatLegalities.ts
+++ b/monolith/interactors/getFormatLegalities.ts
@@ -1,6 +1,6 @@
-import { ClubhouseLocation } from './getJwt';
 import collectionFromLocation from '../lib/collectionFromLocation';
 import getDatabaseConnection from '../database';
+import { ClubhouseLocation } from '../common/types';
 
 async function getFormatLegalities(location: ClubhouseLocation) {
     try {

--- a/monolith/interactors/getJwt.ts
+++ b/monolith/interactors/getJwt.ts
@@ -1,8 +1,7 @@
 const bcrypt = require('bcrypt');
 const jwt = require('jsonwebtoken');
+import { ClubhouseLocation } from '../common/types';
 import getUserByName, { User } from './getUserByName';
-
-export type ClubhouseLocation = 'ch1' | 'ch2';
 
 async function getJwt(
     username: string,

--- a/monolith/interactors/getSalesFromCardname.ts
+++ b/monolith/interactors/getSalesFromCardname.ts
@@ -1,6 +1,6 @@
+import { ClubhouseLocation } from '../common/types';
 import getDatabaseConnection from '../database';
 import collectionFromLocation from '../lib/collectionFromLocation';
-import { ClubhouseLocation } from './getJwt';
 
 async function getSalesFromCardname(cardName, location: ClubhouseLocation) {
     try {

--- a/monolith/interactors/getSuspendedSales.ts
+++ b/monolith/interactors/getSuspendedSales.ts
@@ -1,6 +1,6 @@
-import { ClubhouseLocation } from './getJwt';
 import collectionFromLocation from '../lib/collectionFromLocation';
 import getDatabaseConnection from '../database';
+import { ClubhouseLocation } from '../common/types';
 
 /**
  * Returns all suspended sales' ids, customer names, and notes (omitting card lists)

--- a/monolith/interactors/updateCardInventoryWithFlag.ts
+++ b/monolith/interactors/updateCardInventoryWithFlag.ts
@@ -1,6 +1,6 @@
-import { ClubhouseLocation } from './getJwt';
 import collectionFromLocation from '../lib/collectionFromLocation';
 import getDatabaseConnection from '../database';
+import { ClubhouseLocation } from '../common/types';
 
 /**
  * Updates card inventory based on the card's passed properties (qtyToSell, finishCondition, id, name) and CHANGE_FLAG

--- a/monolith/interactors/updateInventoryCards.ts
+++ b/monolith/interactors/updateInventoryCards.ts
@@ -1,8 +1,8 @@
 import collectionFromLocation from '../lib/collectionFromLocation';
-import { ClubhouseLocation } from './getJwt';
 import request from 'request-promise-native';
 import createLightspeedSale from './createLightspeedSale';
 import getDatabaseConnection from '../database';
+import { ClubhouseLocation } from '../common/types';
 
 /**
  * Updates a single card's QOH based on qtyToSell, finishCondition, id, name

--- a/monolith/lib/collectionFromLocation.ts
+++ b/monolith/lib/collectionFromLocation.ts
@@ -1,4 +1,4 @@
-import { ClubhouseLocation } from '../interactors/getJwt';
+import { ClubhouseLocation } from '../common/types';
 
 interface Ch1Collection {
     cardInventory: 'card_inventory';

--- a/monolith/lib/parseQoh.ts
+++ b/monolith/lib/parseQoh.ts
@@ -1,20 +1,12 @@
-export interface QOH {
-    FOIL_NM?: number;
-    FOIL_LP?: number;
-    FOIL_MP?: number;
-    FOIL_HP?: number;
-    NONFOIL_NM?: number;
-    NONFOIL_LP?: number;
-    NONFOIL_MP?: number;
-    NONFOIL_HP?: number;
-}
+import { QOH } from '../common/types';
 
 /**
  * This function parses the `qoh` object from mongo into something more presentable
  */
-export default function parseQoh(
-    qoh: QOH
-): { foilQty: number; nonfoilQty: number } {
+export default function parseQoh(qoh: QOH): {
+    foilQty: number;
+    nonfoilQty: number;
+} {
     let foilQty = 0;
     let nonfoilQty = 0;
 

--- a/monolith/package-lock.json
+++ b/monolith/package-lock.json
@@ -454,6 +454,19 @@
         "minimist": "^1.2.0"
       }
     },
+    "@hapi/hoek": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
+      "integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug=="
+    },
+    "@hapi/topo": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.0.0.tgz",
+      "integrity": "sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -977,6 +990,24 @@
           }
         }
       }
+    },
+    "@sideway/address": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.2.tgz",
+      "integrity": "sha512-idTz8ibqWFrPU8kMirL0CoPH/A29XOzzAzpyN3zQ4kAWnzmNfFmRaoMNN6VI8ske5M73HZyhIaW4OuSFIdM4oA==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "@sideway/formula": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
+      "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg=="
+    },
+    "@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
     "@sinonjs/commons": {
       "version": "1.8.2",
@@ -4969,6 +5000,18 @@
             "has-flag": "^4.0.0"
           }
         }
+      }
+    },
+    "joi": {
+      "version": "17.4.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.4.0.tgz",
+      "integrity": "sha512-F4WiW2xaV6wc1jxete70Rw4V/VuMd6IN+a5ilZsxG4uYtUXWu2kq9W5P2dz30e7Gmw8RCbY/u/uk+dMPma9tAg==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/topo": "^5.0.0",
+        "@sideway/address": "^4.1.0",
+        "@sideway/formula": "^3.0.0",
+        "@sideway/pinpoint": "^2.0.0"
       }
     },
     "js-tokens": {

--- a/monolith/package.json
+++ b/monolith/package.json
@@ -19,6 +19,7 @@
         "express": "^4.17.1",
         "http-errors": "^1.8.0",
         "jade": "~1.11.0",
+        "joi": "^17.4.0",
         "jsonwebtoken": "^8.5.1",
         "mongodb": "^3.6.3",
         "morgan": "^1.10.0",

--- a/monolith/package.json
+++ b/monolith/package.json
@@ -7,7 +7,8 @@
         "gcp-build": "tsc -p .",
         "start-dev": "rm -r ./built && tsc -p . && echo \"Built TS source\" && PORT=7331 ENVIRONMENT=development node ./built/bin/www",
         "deploy": "gcloud app deploy app.yaml --stop-previous-version",
-        "test": "ENVIRONMENT=localtest jest"
+        "test": "ENVIRONMENT=localtest jest",
+        "typecheck": "tsc --noEmit"
     },
     "dependencies": {
         "axios": "^0.21.1",

--- a/monolith/routes/index.ts
+++ b/monolith/routes/index.ts
@@ -1,21 +1,11 @@
-import express, { Request } from 'express';
+import express from 'express';
 const router = express.Router();
 import getJwt from '../interactors/getJwt';
 import getCardsWithInfo from '../interactors/getCardsWithInfo';
 import getCardFromAllLocations from '../interactors/getCardFromAllLocations';
 import autocomplete from '../interactors/autocomplete';
 import Joi from 'joi';
-import { ClubhouseLocation } from '../common/types';
-
-interface JwtBody {
-    username: string;
-    password: string;
-    currentLocation: ClubhouseLocation;
-}
-
-interface JwtRequest extends Request {
-    body: JwtBody;
-}
+import { JwtBody, JwtRequest, RequestWithQuery } from '../common/types';
 
 router.post('/jwt', async (req: JwtRequest, res) => {
     const schema = Joi.object<JwtBody>({
@@ -44,12 +34,6 @@ router.post('/jwt', async (req: JwtRequest, res) => {
         res.status(500).send(err);
     }
 });
-
-interface RequestWithQuery extends Request {
-    query: {
-        title: string;
-    };
-}
 
 router.get('/autocomplete', async (req: RequestWithQuery, res) => {
     try {

--- a/monolith/routes/index.ts
+++ b/monolith/routes/index.ts
@@ -1,10 +1,11 @@
 import express, { Request } from 'express';
 const router = express.Router();
-import getJwt, { ClubhouseLocation } from '../interactors/getJwt';
+import getJwt from '../interactors/getJwt';
 import getCardsWithInfo from '../interactors/getCardsWithInfo';
 import getCardFromAllLocations from '../interactors/getCardFromAllLocations';
 import autocomplete from '../interactors/autocomplete';
 import Joi from 'joi';
+import { ClubhouseLocation } from '../common/types';
 
 interface JwtBody {
     username: string;


### PR DESCRIPTION
## Summary
This diff is huge, but it can be broken down into two intents:
1. To ensure that we properly validate request bodies so that controllers do not receive unsanitary data
2. Extracting commonly-used types to `common/` for import elsewhere

Previous implementations of request sanitization were incomplete and hackish at best. Joi provides us with much-needed confidence, and extremely granular error responses for faster development on the client when testing.

We could further extract our controllers into atomic files, but I see that as an organizational PR down the line. Right now, colocating controller and validation logic still makes sense here. 