### PR TITLE
Refactored bulk update script

### DIFF
--- a/gc_functions/db_scripts/update_scryfall_bulk/getLanguageCards.js
+++ b/gc_functions/db_scripts/update_scryfall_bulk/getLanguageCards.js
@@ -1,5 +1,5 @@
-const fs = require('fs');
-const JSONStream = require('JSONStream');
+const fs = require("fs");
+const JSONStream = require("JSONStream");
 
 /**
  * Yields paper-only cards from the source bulk for a single language using JSON streams
@@ -7,29 +7,42 @@ const JSONStream = require('JSONStream');
  * @param {String} language - language code used by Scryfall. See https://scryfall.com/docs/api/languages
  */
 function getLanguageCards(bulkUri, language) {
-    const lang = language || 'en';
+    const lang = language || "en";
 
     return new Promise((resolve, reject) => {
-        const stream = fs.createReadStream(bulkUri, { encoding: 'utf8' });
+        const stream = fs.createReadStream(bulkUri, { encoding: "utf8" });
 
-        const parser = JSONStream.parse('*');
+        const parser = JSONStream.parse("*");
 
         stream.pipe(parser);
 
         let cards = [];
 
-        parser.on('data', card => {
-            if (card.lang === lang && card.games.includes('paper')) cards.push(card);
+        parser.on("data", (card) => {
+            if (card.lang === lang) {
+                /**
+                 * Sometimes early releases do not have an updated "card.games" array.
+                 *
+                 * We cannot be confident that Scryfall will maintain this with 100% accuracy,
+                 * so in the interim, we simply include all cards that do _not_ have any games, as well.
+                 *
+                 * It's assumed that they are freshly added and will soon be updated to include "paper" as
+                 * a game type.
+                 */
+                if (card.games.length === 0 || card.games.includes("paper")) {
+                    cards.push(card);
+                }
+            }
         });
 
-        parser.on('end', () => {
+        parser.on("end", () => {
             resolve(cards);
         });
 
-        parser.on('error', err => {
+        parser.on("error", (err) => {
             reject(err);
         });
-    })
+    });
 }
 
 module.exports = getLanguageCards;

--- a/gc_functions/db_scripts/update_scryfall_bulk/index.js
+++ b/gc_functions/db_scripts/update_scryfall_bulk/index.js
@@ -12,17 +12,22 @@ async function init() {
     try {
         console.time("bulkUpdate");
 
-        await saveScryfallBulk("all_cards"); // Save all_cards to the machine
+        await saveScryfallBulk("all_cards"); // Save all_cards locally
 
         console.log("Collating English cards...");
         const sourceEnglish = await getLanguageCards(SOURCE_JSON_URI, "en"); // Grab all English cards
         console.log(`Updating bulk for ${sourceEnglish.length} cards...`);
         await mongoBulkImport(sourceEnglish, database); // Persist them
 
-        console.log("Collating Japanese cards...");
-        const sourceJapanese = await getLanguageCards(SOURCE_JSON_URI, "ja"); // Grab all Japanese cards
-        console.log(`Updating bulk for ${sourceJapanese.length} cards...`);
-        await mongoBulkImport(sourceJapanese, database); // Persist them
+        /**
+         * Uncomment this if Japanese cards are required
+         *
+         * We might think about separating this out as another package.json command, but it's rarely used
+         */
+        // console.log("Collating Japanese cards...");
+        // const sourceJapanese = await getLanguageCards(SOURCE_JSON_URI, "ja"); // Grab all Japanese cards
+        // console.log(`Updating bulk for ${sourceJapanese.length} cards...`);
+        // await mongoBulkImport(sourceJapanese, database); // Persist them
 
         console.timeEnd("bulkUpdate");
         console.log(


### PR DESCRIPTION
## Summary
Our data provider seems to release incomplete data. Certain cards that are part of a spoiler season cannot be trusted to contain an up-to-date `card.games` array that includes `paper`. So, I've elected to push those cards that _do_ contain `paper` as well as those cards that do not have any game types in their `card.games` array.

Also commented out Japanese updates, as those are more of an as-needed basis. It's quite rare that we need a JPN update.