### PR TITLE
Remove redundant functionality

### DIFF
--- a/monolith/interactors/getCardFromAllLocations.ts
+++ b/monolith/interactors/getCardFromAllLocations.ts
@@ -1,100 +1,10 @@
-import { ClubhouseLocation } from '../common/types';
-import getDatabaseConnection from '../database';
-import collectionFromLocation from '../lib/collectionFromLocation';
 import parseQoh from '../lib/parseQoh';
-
-async function getSingleLocationCard(
-    title: string,
-    location: ClubhouseLocation
-) {
-    const db = await getDatabaseConnection();
-
-    const pipeline = [];
-
-    // Fetch by title
-    const match = {
-        $match: {
-            name: title,
-            $or: [
-                /**
-                 * Some cards with _no_ `games` array, we want to include
-                 *
-                 * ex. World Championship cards, and freshly-added cards are in this list
-                 */
-                {
-                    'games.0': {
-                        $exists: false,
-                    },
-                },
-                /**
-                 * We also want to include cards that, if they _do_ have a `games` array,
-                 * include "paper" as a game type
-                 */
-                {
-                    games: {
-                        $in: ['paper'],
-                    },
-                },
-            ],
-        },
-    };
-
-    // Zip up bulk with qoh
-    const lookup = {
-        $lookup: {
-            from: collectionFromLocation(location).cardInventory,
-            localField: 'id',
-            foreignField: '_id',
-            as: 'qoh',
-        },
-    };
-
-    // $lookup yields an array - replace the new qoh with the nested card value
-    const addFields = {
-        $addFields: {
-            qoh: { $arrayElemAt: ['$qoh.qoh', 0] },
-        },
-    };
-
-    // Only yield cards that are in-stock, if needed
-    const inventoryMatch = {
-        $match: {
-            $or: [
-                { 'qoh.FOIL_NM': { $gt: 0 } },
-                { 'qoh.FOIL_LP': { $gt: 0 } },
-                { 'qoh.FOIL_MP': { $gt: 0 } },
-                { 'qoh.FOIL_HP': { $gt: 0 } },
-                { 'qoh.NONFOIL_NM': { $gt: 0 } },
-                { 'qoh.NONFOIL_LP': { $gt: 0 } },
-                { 'qoh.NONFOIL_MP': { $gt: 0 } },
-                { 'qoh.NONFOIL_HP': { $gt: 0 } },
-            ],
-        },
-    };
-
-    const project = {
-        $project: {
-            qoh: 1,
-            name: 1,
-        },
-    };
-
-    pipeline.push(match);
-    pipeline.push(lookup);
-    pipeline.push(addFields);
-    pipeline.push(inventoryMatch);
-    pipeline.push(project);
-
-    return await db
-        .collection('scryfall_bulk_cards')
-        .aggregate(pipeline)
-        .toArray();
-}
+import getCardsWithInfo from './getCardsWithInfo';
 
 async function getCardFromAllLocations(title: string) {
     try {
-        const ch1 = await getSingleLocationCard(title, 'ch1');
-        const ch2 = await getSingleLocationCard(title, 'ch2');
+        const ch1 = await getCardsWithInfo(title, true, 'ch1');
+        const ch2 = await getCardsWithInfo(title, true, 'ch2');
 
         // Add up the [foil, nonfoil] quantities of each card's QOH
         const ch1Combined = ch1.reduce(


### PR DESCRIPTION
## Summary
`getCardFromAllLocations` redeclared an existing interactor's functionality (it re-wrote `getCardsWithInfo`), so I decided to reuse it.