### PR TITLE
Schema validation roundup

### DIFF
--- a/frontend/src/DeckboxClone/DeckboxCloneForm.js
+++ b/frontend/src/DeckboxClone/DeckboxCloneForm.js
@@ -268,14 +268,14 @@ export default class DeckboxCloneForm extends React.Component {
                                     title: title || null,
                                     setName: setName || null,
                                     format: format || null,
-                                    priceNum: priceNum || null,
+                                    price: priceNum || null,
                                     finish: finish || null,
                                     colors: colors || null,
                                     colorSpecificity: colorSpecificity || null,
                                     type: typeLine || null,
                                     frame: frame || null,
                                     sortByDirection: sortByDirection,
-                                    priceFilter: priceFilter,
+                                    priceOperator: priceFilter,
                                     sortBy: sortBy,
                                 })
                             }

--- a/frontend/src/DeckboxClone/DeckboxCloneForm.js
+++ b/frontend/src/DeckboxClone/DeckboxCloneForm.js
@@ -265,18 +265,18 @@ export default class DeckboxCloneForm extends React.Component {
                             primary
                             onClick={() =>
                                 this.props.handleSubmit({
-                                    title,
-                                    setName,
-                                    format,
-                                    priceNum,
-                                    priceFilter,
-                                    finish,
-                                    sortBy,
-                                    sortByDirection,
-                                    colors,
-                                    colorSpecificity,
-                                    type: typeLine,
-                                    frame,
+                                    title: title || null,
+                                    setName: setName || null,
+                                    format: format || null,
+                                    priceNum: priceNum || null,
+                                    finish: finish || null,
+                                    colors: colors || null,
+                                    colorSpecificity: colorSpecificity || null,
+                                    type: typeLine || null,
+                                    frame: frame || null,
+                                    sortByDirection: sortByDirection,
+                                    priceFilter: priceFilter,
+                                    sortBy: sortBy,
                                 })
                             }
                         >

--- a/monolith/common/types.ts
+++ b/monolith/common/types.ts
@@ -8,12 +8,12 @@ export enum Trade {
     Credit = 'CREDIT',
 }
 
-export interface DecodedToken {
-    userId: string;
-    currentLocation: ClubhouseLocation;
-}
+export const locations: Readonly<[ClubhouseLocation, ClubhouseLocation]> = [
+    'ch1',
+    'ch2',
+] as const;
 
-export const finishes = [
+export const finishConditions = [
     'NONFOIL_NM',
     'NONFOIL_LP',
     'NONFOIL_MP',
@@ -24,12 +24,67 @@ export const finishes = [
     'FOIL_HP',
 ] as const;
 
-export const locations: Readonly<[ClubhouseLocation, ClubhouseLocation]> = [
-    'ch1',
-    'ch2',
+export type FinishCondition = typeof finishConditions[number];
+
+export const priceFilters = ['gte', 'lte', 'gt', 'lt'] as const;
+
+export type PriceFilter = typeof priceFilters[number];
+
+export const formatLegalities = [
+    'standard',
+    'future',
+    'historic',
+    'pioneer',
+    'modern',
+    'legacy',
+    'pauper',
+    'vintage',
+    'penny',
+    'commander',
+    'brawl',
+    'duel',
+    'oldschool',
 ] as const;
 
-export type FinishCondition = typeof finishes[number];
+export type FormatLegality = typeof formatLegalities[number];
+
+export const finish = ['FOIL', 'NONFOIL'] as const;
+
+export type Finish = typeof finish[number];
+
+export const sortBy = ['price', 'name'] as const;
+
+export type SortBy = typeof sortBy[number];
+
+export const sortByDirection = [-1, 1] as const;
+
+export type SortByDirection = typeof sortByDirection[number];
+
+export const colorSpecificity = ['colorless', 'mono', 'multi'] as const;
+
+export type ColorSpecificity = typeof colorSpecificity[number];
+
+export const typeLines = [
+    'Artifact',
+    'Creature',
+    'Enchantment',
+    'Instant',
+    'Land',
+    'Planeswalker',
+    'Sorcery',
+    'Tribal',
+] as const;
+
+export type TypeLine = typeof typeLines[number];
+
+export const frames = ['borderless', 'extendedArt', 'showcase'] as const;
+
+export type Frame = typeof frames[number];
+
+export interface DecodedToken {
+    userId: string;
+    currentLocation: ClubhouseLocation;
+}
 
 export interface QOH {
     FOIL_NM?: number;

--- a/monolith/common/types.ts
+++ b/monolith/common/types.ts
@@ -24,6 +24,11 @@ export const finishes = [
     'FOIL_HP',
 ] as const;
 
+export const locations: Readonly<[ClubhouseLocation, ClubhouseLocation]> = [
+    'ch1',
+    'ch2',
+] as const;
+
 export type FinishCondition = typeof finishes[number];
 
 export interface QOH {
@@ -114,12 +119,6 @@ export interface JwtBody {
 
 export interface JwtRequest extends Request {
     body: JwtBody;
-}
-
-export interface RequestWithQuery extends Request {
-    query: {
-        title: string;
-    };
 }
 
 export type JoiValidation<T> = {

--- a/monolith/common/types.ts
+++ b/monolith/common/types.ts
@@ -1,4 +1,5 @@
 import { Request } from 'express';
+import { ValidationError } from 'joi';
 
 export type ClubhouseLocation = 'ch1' | 'ch2';
 
@@ -120,3 +121,8 @@ export interface RequestWithQuery extends Request {
         title: string;
     };
 }
+
+export type JoiValidation<T> = {
+    error?: ValidationError;
+    value: T;
+};

--- a/monolith/common/types.ts
+++ b/monolith/common/types.ts
@@ -105,12 +105,6 @@ export interface ReqWithSuspendSale extends RequestWithUserInfo {
     body: SuspendSaleBody;
 }
 
-export interface ReceivedCardQuery {
-    startDate: string | null;
-    endDate: string | null;
-    cardName: string | null;
-}
-
 export interface JwtBody {
     username: string;
     password: string;

--- a/monolith/interactors/getCardsByFilter.ts
+++ b/monolith/interactors/getCardsByFilter.ts
@@ -46,7 +46,7 @@ const getCardsByFilter = async (
             collectionFromLocation(location).cardInventory
         );
 
-        const SKIP = LIMIT * (Math.abs(Number(page) || 1) - 1); // `page` starts at 1 for clarity
+        const SKIP = LIMIT * (page - 1); // `page` starts at 1 for clarity
 
         // Create aggregation
         const aggregation = [];
@@ -267,14 +267,14 @@ const getCardsByFilter = async (
 
         // Price filtering logic
         if (priceNum && priceFilter) {
-            endMatch.price = { [`$${priceFilter}`]: Number(priceNum) };
+            endMatch.price = { [`$${priceFilter}`]: priceNum };
         }
 
         aggregation.push({ $match: endMatch });
 
         const sortByFilter = {};
-        const sortByProp = sortBy || 'price';
-        const sortByDirectionProp = Number(sortByDirection) || -1;
+        const sortByProp = sortBy;
+        const sortByDirectionProp = sortByDirection;
         sortByFilter[sortByProp] = sortByDirectionProp;
 
         aggregation.push({ $sort: sortByFilter });

--- a/monolith/interactors/getCardsByFilter.ts
+++ b/monolith/interactors/getCardsByFilter.ts
@@ -1,23 +1,8 @@
 import { ClubhouseLocation } from '../common/types';
 import getDatabaseConnection from '../database';
 import collectionFromLocation from '../lib/collectionFromLocation';
+import { GetCardsByFilterQuery } from '../routes/auth';
 const LIMIT = 100;
-
-export interface Arguments {
-    title: string;
-    setName: string;
-    format: string;
-    priceNum: string;
-    priceFilter: string;
-    finish: string;
-    colors: string;
-    sortBy: string;
-    sortByDirection: string;
-    colorSpecificity: string;
-    page: string;
-    type: string;
-    frame: string;
-}
 
 /**
  * Uses the Mongo Aggregation Pipeline to gather relevant cards in an itemized list
@@ -51,7 +36,7 @@ const getCardsByFilter = async (
         page,
         type,
         frame,
-    }: Arguments,
+    }: GetCardsByFilterQuery,
     location: ClubhouseLocation
 ) => {
     try {

--- a/monolith/interactors/getCardsByFilter.ts
+++ b/monolith/interactors/getCardsByFilter.ts
@@ -1,3 +1,4 @@
+import { ClubhouseLocation } from '../common/types';
 import getDatabaseConnection from '../database';
 import collectionFromLocation from '../lib/collectionFromLocation';
 const LIMIT = 100;
@@ -16,7 +17,6 @@ export interface Arguments {
     page: string;
     type: string;
     frame: string;
-    location: 'ch1' | 'ch2';
 }
 
 /**
@@ -36,22 +36,24 @@ export interface Arguments {
  * type - the typeline search, like `Artifact` or `Creature`
  * frame - the desired frame effect filter (borderless, extended-art, showcase, etc)
  */
-const getCardsByFilter = async ({
-    title,
-    setName,
-    format,
-    priceNum,
-    priceFilter,
-    finish,
-    colors,
-    sortBy,
-    sortByDirection,
-    colorSpecificity,
-    page,
-    type,
-    frame,
-    location,
-}: Arguments) => {
+const getCardsByFilter = async (
+    {
+        title,
+        setName,
+        format,
+        priceNum,
+        priceFilter,
+        finish,
+        colors,
+        sortBy,
+        sortByDirection,
+        colorSpecificity,
+        page,
+        type,
+        frame,
+    }: Arguments,
+    location: ClubhouseLocation
+) => {
     try {
         const db = await getDatabaseConnection();
 

--- a/monolith/interactors/getCardsByFilter.ts
+++ b/monolith/interactors/getCardsByFilter.ts
@@ -26,8 +26,8 @@ const getCardsByFilter = async (
         title,
         setName,
         format,
-        priceNum,
-        priceFilter,
+        price,
+        priceOperator,
         finish,
         colors,
         sortBy,
@@ -266,8 +266,8 @@ const getCardsByFilter = async (
         endMatch[`inventory.v`] = { $gt: 0 };
 
         // Price filtering logic
-        if (priceNum && priceFilter) {
-            endMatch.price = { [`$${priceFilter}`]: priceNum };
+        if (price && priceOperator) {
+            endMatch.price = { [`$${priceOperator}`]: price };
         }
 
         aggregation.push({ $match: endMatch });

--- a/monolith/interactors/getSalesFromCardname.ts
+++ b/monolith/interactors/getSalesFromCardname.ts
@@ -2,7 +2,10 @@ import { ClubhouseLocation } from '../common/types';
 import getDatabaseConnection from '../database';
 import collectionFromLocation from '../lib/collectionFromLocation';
 
-async function getSalesFromCardname(cardName, location: ClubhouseLocation) {
+async function getSalesFromCardname(
+    cardName: string,
+    location: ClubhouseLocation
+) {
     try {
         const db = await getDatabaseConnection();
 

--- a/monolith/routes/auth.ts
+++ b/monolith/routes/auth.ts
@@ -402,14 +402,14 @@ export interface GetCardsByFilterQuery {
     title?: string;
     setName?: string;
     format?: FormatLegality;
-    priceNum?: number;
+    price?: number;
     finish?: Finish;
     colors?: string;
     sortBy?: SortBy;
     colorSpecificity?: ColorSpecificity;
     type?: TypeLine;
     frame?: Frame;
-    priceFilter: PriceFilter;
+    priceOperator: PriceFilter;
     sortByDirection: SortByDirection;
     page: number;
 }
@@ -419,14 +419,14 @@ router.get('/getCardsByFilter', async (req: RequestWithUserInfo, res) => {
         title: Joi.string(),
         setName: Joi.string(),
         format: Joi.string().valid(...formatLegalities),
-        priceNum: Joi.number().positive().allow(0),
+        price: Joi.number().positive().allow(0),
         finish: Joi.string().valid(...finish),
         colors: Joi.string(),
         sortBy: Joi.string().valid(...sortBy),
         colorSpecificity: Joi.string().valid(...colorSpecificity),
         type: Joi.string().valid(...typeLines),
         frame: Joi.string().valid(...frames),
-        priceFilter: Joi.string()
+        priceOperator: Joi.string()
             .valid(...priceFilters)
             .required(),
         sortByDirection: Joi.number()

--- a/monolith/routes/auth.ts
+++ b/monolith/routes/auth.ts
@@ -26,6 +26,7 @@ import {
     finishes,
     FinishSaleCard,
     JoiValidation,
+    locations,
     ReceivingCard,
     RequestWithUserInfo,
     ReqWithFinishSaleCards,
@@ -382,10 +383,52 @@ router.delete('/suspendSale/:id', async (req: RequestWithUserInfo, res) => {
     }
 });
 
+interface GetCardsByFilterQuery {
+    title?: string;
+    setName?: string;
+    format?: string;
+    priceNum?: string;
+    priceFilter?: string;
+    finish?: string;
+    colors?: string;
+    sortBy?: string;
+    sortByDirection?: string;
+    colorSpecificity?: string;
+    page?: string;
+    type?: string;
+    frame?: string;
+}
+
 // TODO: this
 router.get('/getCardsByFilter', async (req: RequestWithUserInfo, res) => {
+    const schema = Joi.object<GetCardsByFilterQuery>({
+        title: Joi.string(),
+        setName: Joi.string(),
+        format: Joi.string(),
+        priceNum: Joi.string(),
+        priceFilter: Joi.string(),
+        finish: Joi.string(),
+        colors: Joi.string(),
+        sortBy: Joi.string(),
+        sortByDirection: Joi.string(),
+        colorSpecificity: Joi.string(),
+        type: Joi.string(),
+        frame: Joi.string(),
+        page: Joi.number().required(),
+    });
+
+    const { error, value }: JoiValidation<GetCardsByFilterQuery> =
+        schema.validate(req.query, {
+            abortEarly: false,
+        });
+
+    if (error) {
+        return res.status(400).json(error);
+    }
+
     try {
-        const { currentLocation: location } = req;
+        const { currentLocation } = req;
+
         const {
             title,
             setName,
@@ -400,24 +443,26 @@ router.get('/getCardsByFilter', async (req: RequestWithUserInfo, res) => {
             page,
             type,
             frame,
-        }: Partial<Arguments> = req.query;
+        }: GetCardsByFilterQuery = value;
 
-        const message = await getCardsByFilter({
-            title,
-            setName,
-            format,
-            priceNum,
-            priceFilter,
-            finish,
-            colors,
-            colorSpecificity,
-            sortBy,
-            sortByDirection,
-            page,
-            type,
-            frame,
-            location,
-        });
+        const message = await getCardsByFilter(
+            {
+                title,
+                setName,
+                format,
+                priceNum,
+                priceFilter,
+                finish,
+                colors,
+                colorSpecificity,
+                sortBy,
+                sortByDirection,
+                page,
+                type,
+                frame,
+            },
+            currentLocation
+        );
 
         res.status(200).json(message);
     } catch (err) {

--- a/monolith/routes/auth.ts
+++ b/monolith/routes/auth.ts
@@ -25,6 +25,7 @@ import {
     DecodedToken,
     finishes,
     FinishSaleCard,
+    JoiValidation,
     ReceivedCardQuery,
     ReceivingCard,
     RequestWithUserInfo,
@@ -100,10 +101,13 @@ router.post('/addCardToInventory', (req: AddCardToInventoryReq, res, next) => {
         }).required(),
     });
 
-    const { error } = schema.validate(req.body, {
-        abortEarly: false,
-        allowUnknown: true,
-    });
+    const { error }: JoiValidation<AddCardToInventoryReqBody> = schema.validate(
+        req.body,
+        {
+            abortEarly: false,
+            allowUnknown: true,
+        }
+    );
 
     if (error) {
         return res.status(400).json(error);
@@ -151,10 +155,13 @@ router.post('/finishSale', (req: ReqWithFinishSaleCards, res, next) => {
 
     try {
         for (let card of cards) {
-            const { error } = schema.validate(card, {
-                abortEarly: false,
-                allowUnknown: true,
-            });
+            const { error }: JoiValidation<FinishSaleCard> = schema.validate(
+                card,
+                {
+                    abortEarly: false,
+                    allowUnknown: true,
+                }
+            );
 
             if (error) {
                 return res.status(400).json(error);
@@ -239,10 +246,13 @@ router.post('/receiveCards', (req: ReqWithReceivingCards, res, next) => {
 
     try {
         for (let card of cards) {
-            const { error } = schema.validate(card, {
-                abortEarly: false,
-                allowUnknown: true,
-            });
+            const { error }: JoiValidation<ReceivingCard> = schema.validate(
+                card,
+                {
+                    abortEarly: false,
+                    allowUnknown: true,
+                }
+            );
 
             if (error) {
                 return res.status(400).json(error);
@@ -319,10 +329,13 @@ router.post('/suspendSale', async (req: ReqWithSuspendSale, res) => {
 
     const { customerName = '', notes = '', saleList = [] } = req.body;
 
-    const { error } = schema.validate(req.body, {
-        abortEarly: false,
-        allowUnknown: true,
-    });
+    const { error }: JoiValidation<SuspendSaleBody> = schema.validate(
+        req.body,
+        {
+            abortEarly: false,
+            allowUnknown: true,
+        }
+    );
 
     if (error) {
         return res.status(400).json(error);
@@ -435,10 +448,12 @@ router.get('/getReceivedCards', async (req: RequestWithUserInfo, res) => {
         cardName: Joi.string().allow(null),
     });
 
-    const { error, value }: { error?: Error; value: ReceivedCardQuery } =
-        schema.validate(req.query, {
+    const { error, value }: JoiValidation<ReceivedCardQuery> = schema.validate(
+        req.query,
+        {
             abortEarly: false,
-        });
+        }
+    );
 
     if (error) {
         return res.status(400).json(error);

--- a/monolith/routes/auth.ts
+++ b/monolith/routes/auth.ts
@@ -22,18 +22,33 @@ import Joi from 'joi';
 import {
     AddCardToInventoryReq,
     AddCardToInventoryReqBody,
+    ColorSpecificity,
+    colorSpecificity,
     DecodedToken,
-    finishes,
+    finish,
+    Finish,
+    finishConditions,
     FinishSaleCard,
+    formatLegalities,
+    FormatLegality,
+    Frame,
+    frames,
     JoiValidation,
-    locations,
+    PriceFilter,
+    priceFilters,
     ReceivingCard,
     RequestWithUserInfo,
     ReqWithFinishSaleCards,
     ReqWithReceivingCards,
     ReqWithSuspendSale,
+    SortBy,
+    sortBy,
+    sortByDirection,
+    SortByDirection,
     SuspendSaleBody,
     Trade,
+    TypeLine,
+    typeLines,
 } from '../common/types';
 
 /**
@@ -91,7 +106,7 @@ router.post('/addCardToInventory', (req: AddCardToInventoryReq, res, next) => {
     const schema = Joi.object<AddCardToInventoryReqBody>({
         quantity: Joi.number().integer().required(),
         finishCondition: Joi.string()
-            .valid(...finishes)
+            .valid(...finishConditions)
             .required(),
         cardInfo: Joi.object({
             id: Joi.string().required(),
@@ -147,7 +162,7 @@ router.post('/finishSale', (req: ReqWithFinishSaleCards, res, next) => {
         name: Joi.string().required(),
         set_name: Joi.string().required(),
         finishCondition: Joi.string()
-            .valid(...finishes)
+            .valid(...finishConditions)
             .required(),
     });
 
@@ -249,7 +264,7 @@ router.post('/receiveCards', (req: ReqWithReceivingCards, res, next) => {
         name: Joi.string().required(),
         set_name: Joi.string().required(),
         finishCondition: Joi.string()
-            .valid(...finishes)
+            .valid(...finishConditions)
             .required(),
         set: Joi.string().required(),
         creditPrice: Joi.number().min(0).required(),
@@ -337,7 +352,7 @@ router.post('/suspendSale', async (req: ReqWithSuspendSale, res) => {
                 name: Joi.string().required(),
                 set_name: Joi.string().required(),
                 finishCondition: Joi.string()
-                    .valid(...finishes)
+                    .valid(...finishConditions)
                     .required(),
             })
         ),
@@ -386,35 +401,38 @@ router.delete('/suspendSale/:id', async (req: RequestWithUserInfo, res) => {
 export interface GetCardsByFilterQuery {
     title?: string;
     setName?: string;
-    format?: string;
-    priceNum?: string;
-    finish?: string;
+    format?: FormatLegality;
+    priceNum?: number;
+    finish?: Finish;
     colors?: string;
-    sortBy?: string;
-    colorSpecificity?: string;
-    type?: string;
-    frame?: string;
-    priceFilter: string;
-    sortByDirection: number;
+    sortBy?: SortBy;
+    colorSpecificity?: ColorSpecificity;
+    type?: TypeLine;
+    frame?: Frame;
+    priceFilter: PriceFilter;
+    sortByDirection: SortByDirection;
     page: number;
 }
 
-// TODO: this
 router.get('/getCardsByFilter', async (req: RequestWithUserInfo, res) => {
     const schema = Joi.object<GetCardsByFilterQuery>({
         title: Joi.string(),
         setName: Joi.string(),
-        format: Joi.string(),
-        priceNum: Joi.string(),
-        finish: Joi.string(),
+        format: Joi.string().valid(...formatLegalities),
+        priceNum: Joi.number().positive().allow(0),
+        finish: Joi.string().valid(...finish),
         colors: Joi.string(),
-        sortBy: Joi.string(),
-        colorSpecificity: Joi.string(),
-        type: Joi.string(),
-        frame: Joi.string(),
-        priceFilter: Joi.string().required(),
-        sortByDirection: Joi.number().required(),
-        page: Joi.number().required(),
+        sortBy: Joi.string().valid(...sortBy),
+        colorSpecificity: Joi.string().valid(...colorSpecificity),
+        type: Joi.string().valid(...typeLines),
+        frame: Joi.string().valid(...frames),
+        priceFilter: Joi.string()
+            .valid(...priceFilters)
+            .required(),
+        sortByDirection: Joi.number()
+            .valid(...sortByDirection)
+            .required(),
+        page: Joi.number().integer().min(1).required(),
     });
 
     const { error, value }: JoiValidation<GetCardsByFilterQuery> =

--- a/monolith/routes/auth.ts
+++ b/monolith/routes/auth.ts
@@ -2,7 +2,7 @@ import express from 'express';
 const router = express.Router();
 require('dotenv').config();
 import jwt from 'jsonwebtoken';
-import getCardsByFilter, { Arguments } from '../interactors/getCardsByFilter';
+import getCardsByFilter from '../interactors/getCardsByFilter';
 import addCardToInventory from '../interactors/addCardToInventory';
 import getDistinctSetNames from '../interactors/getDistinctSetNames';
 import getCardsWithInfo from '../interactors/getCardsWithInfo';
@@ -383,20 +383,20 @@ router.delete('/suspendSale/:id', async (req: RequestWithUserInfo, res) => {
     }
 });
 
-interface GetCardsByFilterQuery {
+export interface GetCardsByFilterQuery {
     title?: string;
     setName?: string;
     format?: string;
     priceNum?: string;
-    priceFilter?: string;
     finish?: string;
     colors?: string;
     sortBy?: string;
-    sortByDirection?: string;
     colorSpecificity?: string;
-    page?: string;
     type?: string;
     frame?: string;
+    priceFilter: string;
+    sortByDirection: number;
+    page: number;
 }
 
 // TODO: this
@@ -406,14 +406,14 @@ router.get('/getCardsByFilter', async (req: RequestWithUserInfo, res) => {
         setName: Joi.string(),
         format: Joi.string(),
         priceNum: Joi.string(),
-        priceFilter: Joi.string(),
         finish: Joi.string(),
         colors: Joi.string(),
         sortBy: Joi.string(),
-        sortByDirection: Joi.string(),
         colorSpecificity: Joi.string(),
         type: Joi.string(),
         frame: Joi.string(),
+        priceFilter: Joi.string().required(),
+        sortByDirection: Joi.number().required(),
         page: Joi.number().required(),
     });
 
@@ -429,40 +429,7 @@ router.get('/getCardsByFilter', async (req: RequestWithUserInfo, res) => {
     try {
         const { currentLocation } = req;
 
-        const {
-            title,
-            setName,
-            format,
-            priceNum,
-            priceFilter,
-            finish,
-            colors,
-            sortBy,
-            sortByDirection,
-            colorSpecificity,
-            page,
-            type,
-            frame,
-        }: GetCardsByFilterQuery = value;
-
-        const message = await getCardsByFilter(
-            {
-                title,
-                setName,
-                format,
-                priceNum,
-                priceFilter,
-                finish,
-                colors,
-                colorSpecificity,
-                sortBy,
-                sortByDirection,
-                page,
-                type,
-                frame,
-            },
-            currentLocation
-        );
+        const message = await getCardsByFilter(value, currentLocation);
 
         res.status(200).json(message);
     } catch (err) {

--- a/monolith/routes/index.ts
+++ b/monolith/routes/index.ts
@@ -5,7 +5,12 @@ import getCardsWithInfo from '../interactors/getCardsWithInfo';
 import getCardFromAllLocations from '../interactors/getCardFromAllLocations';
 import autocomplete from '../interactors/autocomplete';
 import Joi from 'joi';
-import { JwtBody, JwtRequest, RequestWithQuery } from '../common/types';
+import {
+    JoiValidation,
+    JwtBody,
+    JwtRequest,
+    RequestWithQuery,
+} from '../common/types';
 
 router.post('/jwt', async (req: JwtRequest, res) => {
     const schema = Joi.object<JwtBody>({
@@ -14,7 +19,7 @@ router.post('/jwt', async (req: JwtRequest, res) => {
         currentLocation: Joi.string().valid('ch1', 'ch2').required(),
     });
 
-    const { error, value } = schema.validate(req.body, {
+    const { error }: JoiValidation<JwtBody> = schema.validate(req.body, {
         abortEarly: false,
         allowUnknown: true,
     });
@@ -35,9 +40,28 @@ router.post('/jwt', async (req: JwtRequest, res) => {
     }
 });
 
+interface AutocompleteQuery {
+    title: string;
+}
+
 router.get('/autocomplete', async (req: RequestWithQuery, res) => {
+    const schema = Joi.object<AutocompleteQuery>({
+        title: Joi.string().required(),
+    });
+
+    const { error, value }: JoiValidation<AutocompleteQuery> = schema.validate(
+        req.query,
+        {
+            abortEarly: false,
+        }
+    );
+
+    if (error) {
+        return res.status(400).json(error);
+    }
+
     try {
-        const { title } = req.query;
+        const { title } = value;
         const results = await autocomplete(title);
         res.status(200).send(results);
     } catch (err) {


### PR DESCRIPTION
## Summary
We finally have full schema validation for our routes' `req.query` and `req.body` objects. I've done my best to model these as specifically as possible, especially surrounding the `getCardsByFilter` controller and interactor, which required some refactoring after we became more confident about the shape and types of data it accepts. There have been major additions to `common/types`, which may be broken up at a later time.

This also adds a minor refactor to the frontend to align query variables. We should deploy both halves simultaneously after the close of business today to reduce the possibility of conflicts.