### PR TITLE
Curate filtered return types

### DIFF
--- a/frontend/src/DeckboxClone/DeckboxClone.tsx
+++ b/frontend/src/DeckboxClone/DeckboxClone.tsx
@@ -182,7 +182,7 @@ const DeckboxClone: FC = () => {
                     <Table.Body>
                         {cards.map((card) => (
                             <DeckboxCloneRow
-                                key={`${card._id}${card.inventory.k}`}
+                                key={`${card._id}-${card.finishCondition}`}
                                 card={card}
                             />
                         ))}

--- a/frontend/src/DeckboxClone/DeckboxCloneRow.tsx
+++ b/frontend/src/DeckboxClone/DeckboxCloneRow.tsx
@@ -24,7 +24,16 @@ interface Props {
 }
 
 const DeckboxCloneRow: FC<Props> = ({
-    card: { inventory, name, set_name, price, set, rarity, image_uri },
+    card: {
+        finishCondition,
+        quantityInStock,
+        name,
+        set_name,
+        price,
+        set,
+        rarity,
+        image_uri,
+    },
 }) => {
     const [state, setState] = useState<State>({
         mouseInside: false,
@@ -52,8 +61,8 @@ const DeckboxCloneRow: FC<Props> = ({
     };
 
     const { mouseInside, mouseX } = state;
-    const finish = inventory.k.split('_')[0];
-    const condition = inventory.k.split('_')[1] as Condition;
+    const finish = finishCondition.split('_')[0];
+    const condition = finishCondition.split('_')[1] as Condition;
 
     return (
         <Table.Row>
@@ -79,7 +88,7 @@ const DeckboxCloneRow: FC<Props> = ({
                 {set_name}
             </Table.Cell>
             <Table.Cell>{conditionMap[condition]}</Table.Cell>
-            <Table.Cell>{inventory.v}</Table.Cell>
+            <Table.Cell>{quantityInStock}</Table.Cell>
             <Table.Cell>
                 <Price num={price} />
             </Table.Cell>

--- a/frontend/src/DeckboxClone/filteredCardsQuery.ts
+++ b/frontend/src/DeckboxClone/filteredCardsQuery.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import { GET_CARDS_BY_FILTER } from '../utils/api_resources';
 import makeAuthHeader from '../utils/makeAuthHeader';
+import { FinishCondition } from '../utils/ScryfallCard';
 
 export interface Filters {
     title?: string;
@@ -21,21 +22,14 @@ type Params = Filters & { page: number };
 
 export interface ResponseCard {
     _id: string;
-    border_color: string;
-    colors_string: string;
-    colors_string_length: number;
     image_uri: string;
-    inventory: {
-        k: string;
-        v: number;
-    };
-    legalities: Record<string, string>;
     name: string;
     price: number;
     rarity: string;
     set: string;
     set_name: string;
-    type_line: string;
+    finishCondition: FinishCondition;
+    quantityInStock: number;
 }
 
 interface Response {

--- a/monolith/interactors/getCardsByFilter.ts
+++ b/monolith/interactors/getCardsByFilter.ts
@@ -272,6 +272,26 @@ const getCardsByFilter = async (
 
         aggregation.push({ $match: endMatch });
 
+        // Add sane inventory fields
+        aggregation.push({
+            $addFields: {
+                finishCondition: `$inventory.k`,
+                quantityInStock: `$inventory.v`,
+            },
+        });
+
+        // Final projection to curate return types
+        aggregation.push({
+            $project: {
+                border_color: 0,
+                colors_string: 0,
+                colors_string_length: 0,
+                legalities: 0,
+                type_line: 0,
+                inventory: 0,
+            },
+        });
+
         const sortByFilter = {};
         const sortByProp = sortBy;
         const sortByDirectionProp = sortByDirection;


### PR DESCRIPTION
## Summary
This PR fixes some incongruence around return types from the `getCardsByFilter` response type. Much of it was unused on the frontend, and `inventory` was incomprehensible. I took this opportunity to use `$addFields` to express finish condition and quantity in stock as much more aptly-named properties 😆 