### PR TITLE
Receiving date pickers

### DIFF
--- a/frontend/src/BrowseReceiving/BrowseReceiving.tsx
+++ b/frontend/src/BrowseReceiving/BrowseReceiving.tsx
@@ -43,15 +43,17 @@ const BrowseReceiving: FC = () => {
 
     return (
         <div>
-            <Box display="flex">
-                <Box pr={2} width={1}>
-                    <Formik
-                        initialValues={initialFormValues}
-                        onSubmit={onSubmit}
-                    >
+            <Box pb={2}>
+                <Typography variant="h5">
+                    <strong>Browse Receiving</strong>
+                </Typography>
+            </Box>
+            <Box pb={2}>
+                <Formik initialValues={initialFormValues} onSubmit={onSubmit}>
+                    {({ values }) => (
                         <FormikForm>
                             <Form>
-                                <Form.Group widths="4">
+                                <Form.Group widths="6">
                                     <Field
                                         name="cardName"
                                         label="Card name"
@@ -64,26 +66,23 @@ const BrowseReceiving: FC = () => {
                                             initialFormValues.startDate
                                         }
                                         component={FormikNativeDatePicker}
+                                        max={values.endDate}
                                     />
                                     <Field
                                         name="endDate"
                                         label="End date"
                                         defaultValue={initialFormValues.endDate}
                                         component={FormikNativeDatePicker}
+                                        max={initialFormValues.endDate}
                                     />
-                                    <Form.Button type="submit" primary>
-                                        Search
-                                    </Form.Button>
                                 </Form.Group>
+                                <Form.Button type="submit" primary>
+                                    Search
+                                </Form.Button>
                             </Form>
                         </FormikForm>
-                    </Formik>
-                </Box>
-            </Box>
-            <Box py={2}>
-                <Typography variant="h5">
-                    <strong>Browse Receiving</strong>
-                </Typography>
+                    )}
+                </Formik>
             </Box>
             {loading ? (
                 <CircularProgress />

--- a/frontend/src/BrowseReceiving/BrowseReceiving.tsx
+++ b/frontend/src/BrowseReceiving/BrowseReceiving.tsx
@@ -4,8 +4,9 @@ import { Grid, Typography, Box, CircularProgress } from '@material-ui/core';
 import ReceivingListItem from './ReceivingListItem';
 import moment from 'moment';
 import { Formik, Form as FormikForm, Field } from 'formik';
-import { Form, Input } from 'semantic-ui-react';
+import { Form } from 'semantic-ui-react';
 import FormikSearchBar from '../ui/FormikSearchBar';
+import FormikNativeDatePicker from '../ui/FormikNativeDatePicker';
 
 interface FormValues {
     cardName: string;
@@ -48,48 +49,34 @@ const BrowseReceiving: FC = () => {
                         initialValues={initialFormValues}
                         onSubmit={onSubmit}
                     >
-                        {({ handleChange }) => (
-                            <FormikForm>
-                                <Form>
-                                    <Form.Group widths="4">
-                                        <Form.Field>
-                                            <Field
-                                                name="cardName"
-                                                label="Card name"
-                                                component={FormikSearchBar}
-                                            />
-                                        </Form.Field>
-                                        <Form.Field>
-                                            <label>Start date</label>
-                                            <Input
-                                                id="startDate"
-                                                name="startDate"
-                                                type="date"
-                                                onChange={handleChange}
-                                                defaultValue={
-                                                    initialFormValues.startDate
-                                                }
-                                            />
-                                        </Form.Field>
-                                        <Form.Field>
-                                            <label>End date</label>
-                                            <Input
-                                                id="endDate"
-                                                name="endDate"
-                                                type="date"
-                                                onChange={handleChange}
-                                                defaultValue={
-                                                    initialFormValues.endDate
-                                                }
-                                            />
-                                        </Form.Field>
-                                        <Form.Button type="submit" primary>
-                                            Search
-                                        </Form.Button>
-                                    </Form.Group>
-                                </Form>
-                            </FormikForm>
-                        )}
+                        <FormikForm>
+                            <Form>
+                                <Form.Group widths="4">
+                                    <Field
+                                        name="cardName"
+                                        label="Card name"
+                                        component={FormikSearchBar}
+                                    />
+                                    <Field
+                                        name="startDate"
+                                        label="Start date"
+                                        defaultValue={
+                                            initialFormValues.startDate
+                                        }
+                                        component={FormikNativeDatePicker}
+                                    />
+                                    <Field
+                                        name="endDate"
+                                        label="End date"
+                                        defaultValue={initialFormValues.endDate}
+                                        component={FormikNativeDatePicker}
+                                    />
+                                    <Form.Button type="submit" primary>
+                                        Search
+                                    </Form.Button>
+                                </Form.Group>
+                            </Form>
+                        </FormikForm>
                     </Formik>
                 </Box>
             </Box>

--- a/frontend/src/BrowseReceiving/browseReceivingQuery.ts
+++ b/frontend/src/BrowseReceiving/browseReceivingQuery.ts
@@ -33,10 +33,6 @@ export interface Received {
     created_by: ReceivedUser;
 }
 
-interface Response {
-    data: Received[];
-}
-
 interface Payload {
     cardName: string | null;
     startDate: string | null;
@@ -49,9 +45,8 @@ const browseReceivingQuery = async ({
     endDate,
 }: Payload) => {
     try {
-        const { data }: Response = await axios.get(GET_RECEIVING_LIST, {
-            // TODO: pass date params
-            params: { cardName },
+        const { data } = await axios.get<Received[]>(GET_RECEIVING_LIST, {
+            params: { cardName, startDate, endDate },
             headers: makeAuthHeader(),
         });
         return data;

--- a/frontend/src/ui/FormikDropdown.tsx
+++ b/frontend/src/ui/FormikDropdown.tsx
@@ -10,15 +10,15 @@ type FormikFieldProps<T, O> = {
 } & Omit<FormFieldProps, 'label' | 'name' | 'options'>;
 
 /**
- * This is meant to be wrapped by a <Form /> component.
+ * This is meant to be wrapped by a <Field /> component.
  *
  * The generics are inferred by passed prop values.
  */
 function FormikDropdown<T, O>({
     options,
-    /** Injected by <Form /> */
+    /** Injected by <Field /> */
     field,
-    /** Injected by <Form /> */
+    /** Injected by <Field /> */
     form,
     ...props
 }: FormikFieldProps<T, O>) {

--- a/frontend/src/ui/FormikNativeDatePicker.tsx
+++ b/frontend/src/ui/FormikNativeDatePicker.tsx
@@ -6,6 +6,8 @@ type FormikFieldProps<T> = {
     form: FormikProps<T>;
     label: string;
     defaultValue?: string;
+    min?: string;
+    max?: string;
 } & Omit<FormFieldProps, 'label' | 'name'>;
 
 /**
@@ -20,6 +22,8 @@ function FormikNativeDatePicker<T>({
     /** Injected by <Field /> */
     form,
     defaultValue,
+    min,
+    max,
 }: FormikFieldProps<T>) {
     return (
         <Form.Field>
@@ -30,6 +34,8 @@ function FormikNativeDatePicker<T>({
                 type="date"
                 onChange={form.handleChange}
                 defaultValue={defaultValue}
+                min={min}
+                max={max}
             />
         </Form.Field>
     );

--- a/frontend/src/ui/FormikNativeDatePicker.tsx
+++ b/frontend/src/ui/FormikNativeDatePicker.tsx
@@ -1,0 +1,38 @@
+import { Form, FormFieldProps, Input } from 'semantic-ui-react';
+import { FieldConfig, FormikProps } from 'formik';
+
+type FormikFieldProps<T> = {
+    field: FieldConfig;
+    form: FormikProps<T>;
+    label: string;
+    defaultValue?: string;
+} & Omit<FormFieldProps, 'label' | 'name'>;
+
+/**
+ * This is meant to be wrapped by a <Field /> component.
+ *
+ * The generics are inferred by passed prop values.
+ */
+function FormikNativeDatePicker<T>({
+    label,
+    /** Injected by <Field /> */
+    field,
+    /** Injected by <Field /> */
+    form,
+    defaultValue,
+}: FormikFieldProps<T>) {
+    return (
+        <Form.Field>
+            <label>{label}</label>
+            <Input
+                id={field.name}
+                name={field.name}
+                type="date"
+                onChange={form.handleChange}
+                defaultValue={defaultValue}
+            />
+        </Form.Field>
+    );
+}
+
+export default FormikNativeDatePicker;

--- a/frontend/src/ui/FormikSearchBar.tsx
+++ b/frontend/src/ui/FormikSearchBar.tsx
@@ -1,0 +1,41 @@
+import { Form, FormFieldProps } from 'semantic-ui-react';
+import { FieldConfig, FormikProps } from 'formik';
+import SearchBar from '../common/SearchBar';
+import { SyntheticEvent } from 'react';
+
+type FormikFieldProps<T> = {
+    field: FieldConfig;
+    form: FormikProps<T>;
+    label: string;
+} & Omit<FormFieldProps, 'label' | 'name'>;
+
+/**
+ * This is meant to be wrapped by a <Field /> component.
+ *
+ * The generics are inferred by passed prop values.
+ */
+function FormikSearchBar<T>({
+    label,
+    /** Injected by <Field /> */
+    field,
+    /** Injected by <Field /> */
+    form,
+}: FormikFieldProps<T>) {
+    return (
+        <Form.Field>
+            <label>{label}</label>
+            <SearchBar
+                handleSearchSelect={(value) => {
+                    form.setFieldValue(field.name, value);
+                }}
+                // Reset form state after user blurs cardName
+                onBlur={(event: SyntheticEvent<Element, Event>) => {
+                    const element = event.target as HTMLInputElement;
+                    form.setFieldValue(field.name, element.value);
+                }}
+            />
+        </Form.Field>
+    );
+}
+
+export default FormikSearchBar;

--- a/frontend/src/ui/FormikSelectField.tsx
+++ b/frontend/src/ui/FormikSelectField.tsx
@@ -9,16 +9,16 @@ type FormikFieldProps<T, O> = {
 } & Omit<FormFieldProps, 'label' | 'name' | 'options'>;
 
 /**
- * This is meant to be wrapped by a <Form /> component.
+ * This is meant to be wrapped by a <Field /> component.
  *
  * The generics are inferred by passed prop values.
  */
 function FormikSelectField<T, O>({
     label,
     options,
-    /** Injected by <Form /> */
+    /** Injected by <Field /> */
     field,
-    /** Injected by <Form /> */
+    /** Injected by <Field /> */
     form,
     ...props
 }: FormikFieldProps<T, O>) {

--- a/monolith/interactors/getCardsFromReceiving.ts
+++ b/monolith/interactors/getCardsFromReceiving.ts
@@ -4,8 +4,8 @@ import collectionFromLocation from '../lib/collectionFromLocation';
 
 interface Args {
     location: ClubhouseLocation;
-    startDate: Date | null;
-    endDate: Date | null;
+    startDate: Date;
+    endDate: Date;
     cardName: string | null;
 }
 

--- a/monolith/routes/auth.ts
+++ b/monolith/routes/auth.ts
@@ -509,8 +509,8 @@ interface ReceivedCardQuery {
 
 router.get('/getReceivedCards', async (req: RequestWithUserInfo, res) => {
     const schema = Joi.object<ReceivedCardQuery>({
-        startDate: Joi.date().iso().allow(null),
-        endDate: Joi.date().iso().allow(null),
+        startDate: Joi.date().iso().required(),
+        endDate: Joi.date().iso().required(),
         cardName: Joi.string().allow(null),
     });
 
@@ -530,8 +530,8 @@ router.get('/getReceivedCards', async (req: RequestWithUserInfo, res) => {
     try {
         const message = await getCardsFromReceiving({
             location: req.currentLocation,
-            startDate: startDate ? new Date(startDate) : null,
-            endDate: endDate ? new Date(endDate) : null,
+            startDate: new Date(startDate),
+            endDate: new Date(endDate),
             cardName: cardName || null,
         });
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/15024562/122458165-5bdfb980-cf64-11eb-9dd4-a9b9b2e0edd1.png)

## Summary
This PR integrates native date pickers into the Browse Receiving UI. While they're not as robust or rich as an MUI-pickers or third-party Semantic-UI options, they do the job just fine as admin users only use Chrome. I don't believe browser incompatibility here is a worthwhile tradeoff to increasing the (already large) bundle size via yet another npm module.

The API no longer accepts nullable dates when fetching receiving records; it must receive a start and end date. Admittedly this is a bandaid over pagination support which should come later. This functionality was needed now to prevent massive queries/response objects and scaling issues on the client via repeated Receiving usage.

Additionally, it extracts `FormikNativeDatePicker`.