### PR TITLE
Correctly model api data before passing to components

### DIFF
--- a/frontend/src/PublicInventory/publicCardSearchQuery.ts
+++ b/frontend/src/PublicInventory/publicCardSearchQuery.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { ScryfallCard } from '../utils/ScryfallCard';
+import { ScryfallCard, ScryfallApiCard } from '../utils/ScryfallCard';
 import { GET_CARDS_WITH_INFO_PUBLIC } from '../utils/api_resources';
 import { ClubhouseLocation } from '../context/AuthProvider';
 
@@ -15,14 +15,14 @@ interface Params {
  */
 const publicCardSearchQuery = async (params: Params) => {
     try {
-        const { data } = await axios.get<ScryfallCard[]>(
+        const { data } = await axios.get<ScryfallApiCard[]>(
             GET_CARDS_WITH_INFO_PUBLIC,
             {
                 params,
             }
         );
 
-        return data;
+        return data.map((d) => new ScryfallCard(d));
     } catch (err) {
         throw err;
     }

--- a/frontend/src/context/cardSearchQuery.ts
+++ b/frontend/src/context/cardSearchQuery.ts
@@ -1,9 +1,9 @@
 import axios from 'axios';
 import makeAuthHeader from '../utils/makeAuthHeader';
-import { ScryfallCard } from '../utils/ScryfallCard';
+import { ScryfallApiCard, ScryfallCard } from '../utils/ScryfallCard';
 import { GET_CARDS_WITH_INFO } from '../utils/api_resources';
 
-interface Payload {
+interface Params {
     cardName: string;
     inStockOnly: boolean;
 }
@@ -12,17 +12,20 @@ interface Payload {
  * Fetches cards from the DB by title when a user selects a title after querying.
  * This function merges the data (inventory quantity and card objects) from two endpoints into one array.
  */
-const cardSearchQuery = async ({ cardName, inStockOnly }: Payload) => {
+const cardSearchQuery = async ({ cardName, inStockOnly }: Params) => {
     try {
-        const { data } = await axios.get<ScryfallCard[]>(GET_CARDS_WITH_INFO, {
-            params: {
-                title: cardName,
-                matchInStock: inStockOnly,
-            },
-            headers: makeAuthHeader(),
-        });
+        const { data } = await axios.get<ScryfallApiCard[]>(
+            GET_CARDS_WITH_INFO,
+            {
+                params: {
+                    title: cardName,
+                    matchInStock: inStockOnly,
+                },
+                headers: makeAuthHeader(),
+            }
+        );
 
-        return data;
+        return data.map((d) => new ScryfallCard(d));
     } catch (err) {
         throw err;
     }


### PR DESCRIPTION
## Summary
The previous PR left out a critical concept: `ScryfallCard` is modeled from raw API data, not returned from the API. Here we fix this bug in the inventory search by modeling the raw API response using the correct class.