### PR TITLE
Refactor out `Object.assign`

### DIFF
--- a/frontend/src/context/ReceivingContext.tsx
+++ b/frontend/src/context/ReceivingContext.tsx
@@ -153,35 +153,23 @@ const ReceivingProvider: FC<Props> = ({ children }) => {
         setReceivingList(newState);
     };
 
-    /** We want to filter out cards with possible `null` finishConditions, this is the target type */
-    type DefinedFinishCondition = Omit<ReceivingCard, 'finishCondition'> & {
-        finishCondition: string;
-    };
-
-    /** This allows us to filter out finishConditions that are `null` */
-    const isDefined = (card: ReceivingCard): card is DefinedFinishCondition => {
-        return card.finishCondition !== null;
-    };
-
     /**
      * Persists all passed cards to inventory
      */
     const commitToInventory = async () => {
         try {
-            const cardsToCommit = receivingList
-                .filter(isDefined)
-                .map((card) => ({
-                    quantity: 1, // Only committing one per line-item
-                    marketPrice: card.marketPrice,
-                    cashPrice: card.cashPrice,
-                    creditPrice: card.creditPrice,
-                    tradeType: card.tradeType,
-                    finishCondition: card.finishCondition,
-                    id: card.id,
-                    name: card.name,
-                    set_name: card.set_name,
-                    set: card.set,
-                }));
+            const cardsToCommit = receivingList.map((card) => ({
+                quantity: 1, // Only committing one per line-item
+                marketPrice: card.marketPrice,
+                cashPrice: card.cashPrice,
+                creditPrice: card.creditPrice,
+                tradeType: card.tradeType,
+                finishCondition: card.finishCondition,
+                id: card.id,
+                name: card.name,
+                set_name: card.set_name,
+                set: card.set,
+            }));
 
             await receivingQuery({ cards: cardsToCommit });
 

--- a/frontend/src/context/ReceivingContext.tsx
+++ b/frontend/src/context/ReceivingContext.tsx
@@ -85,24 +85,23 @@ const ReceivingProvider: FC<Props> = ({ children }) => {
     ) => {
         const previousState = [...receivingList];
 
-        // Each line-item represents one card. Use _.times() to repeat
+        // Each line-item represents one card
         const cardsToAdd: ReceivingCard[] = [...new Array(quantity)].map(() => {
-            // TODO: This is funky as hell. We have to clone() to create a new object
-            // or object.assign retains a reference to the merging object
-            return _.clone(
-                Object.assign(card, {
-                    cashPrice,
-                    marketPrice,
-                    creditPrice,
-                    finishCondition,
-                    // Set to cash if customer doesn't want credit
-                    tradeType: creditPrice === 0 ? Trade.Cash : Trade.Credit,
-                    uuid_key: uuid(),
-                })
-            );
+            const newCard: ReceivingCard = {
+                ...card,
+                cashPrice,
+                marketPrice,
+                creditPrice,
+                finishCondition,
+                // Set to cash if customer doesn't want credit
+                tradeType: creditPrice === 0 ? Trade.Cash : Trade.Credit,
+                uuid_key: uuid(),
+            };
+
+            return newCard;
         });
 
-        setReceivingList(_.sortBy([...previousState, ...cardsToAdd], 'name'));
+        setReceivingList(sortBy([...previousState, ...cardsToAdd], 'name'));
     };
 
     /**

--- a/frontend/src/context/ReceivingContext.tsx
+++ b/frontend/src/context/ReceivingContext.tsx
@@ -1,5 +1,5 @@
 import React, { useState, createContext, FC } from 'react';
-import _ from 'lodash';
+import { sortBy } from 'lodash';
 import { v4 as uuid } from 'uuid';
 import createToast from '../common/createToast';
 import receivingQuery from './receivingQuery';
@@ -109,8 +109,7 @@ const ReceivingProvider: FC<Props> = ({ children }) => {
      */
     const removeFromList = (uuid_key: string) => {
         const copiedState = [...receivingList];
-        _.remove(copiedState, (e) => e.uuid_key === uuid_key); // Mutates array
-        setReceivingList(copiedState);
+        setReceivingList(copiedState.filter((e) => e.uuid_key !== uuid_key));
     };
 
     /**

--- a/frontend/src/context/ReceivingContext.tsx
+++ b/frontend/src/context/ReceivingContext.tsx
@@ -159,16 +159,8 @@ const ReceivingProvider: FC<Props> = ({ children }) => {
     const commitToInventory = async () => {
         try {
             const cardsToCommit = receivingList.map((card) => ({
+                ...card,
                 quantity: 1, // Only committing one per line-item
-                marketPrice: card.marketPrice,
-                cashPrice: card.cashPrice,
-                creditPrice: card.creditPrice,
-                tradeType: card.tradeType,
-                finishCondition: card.finishCondition,
-                id: card.id,
-                name: card.name,
-                set_name: card.set_name,
-                set: card.set,
             }));
 
             await receivingQuery({ cards: cardsToCommit });

--- a/frontend/src/context/SaleContext.tsx
+++ b/frontend/src/context/SaleContext.tsx
@@ -74,14 +74,12 @@ export const SaleProvider: FC<Props> = ({ children }) => {
     ) => {
         const oldState = [...saleListCards];
 
-        // TODO: is this stable? We have to use Object.assign() to preserve getter and setter methods
-        const newCard = _.clone(
-            Object.assign(card, {
-                finishCondition,
-                qtyToSell,
-                price,
-            })
-        );
+        const newCard: SaleListCard = {
+            ...card,
+            finishCondition,
+            qtyToSell,
+            price,
+        };
 
         // Need to make sure same ID's with differing conditions are separate line-items
         const idx = oldState.findIndex((el) => {

--- a/frontend/src/context/SaleContext.tsx
+++ b/frontend/src/context/SaleContext.tsx
@@ -1,5 +1,4 @@
 import React, { useState, createContext, FC } from 'react';
-import _ from 'lodash';
 import sortSaleList from '../utils/sortSaleList';
 import createToast from '../common/createToast';
 import getSuspendedSaleQuery, { SuspendedSale } from './getSuspendedSaleQuery';


### PR DESCRIPTION
## Summary
Legacy versions of modeled context card objects were class instances with getter and setter (the old `InventoryCard` class) methods, which could not cleanly be destructured and failed TS compilation if we tried. Recently those `get`/`set` methods were refactored away, and this PR restores creating new objects using commonplace means of destructuring rather than using fancy (and buggy?) `Object.assign` tricks.