### PR TITLE
Receiving customer information

### DIFF
--- a/frontend/src/Receiving/ReceivingListModal.tsx
+++ b/frontend/src/Receiving/ReceivingListModal.tsx
@@ -48,7 +48,10 @@ const ReceivingListModal: FC<Props> = () => {
 
     const onSubmit = async ({ customerName, customerContact }: FormValues) => {
         setLoading(true);
-        await commitToInventory(customerName, customerContact);
+        await commitToInventory(
+            customerName,
+            customerContact ? customerContact : null
+        );
         setLoading(false);
     };
 

--- a/frontend/src/Receiving/ReceivingListModal.tsx
+++ b/frontend/src/Receiving/ReceivingListModal.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useContext, FC } from 'react';
-import { Modal, Button, Form } from 'semantic-ui-react';
+import { Modal, Button, Form, List, Header } from 'semantic-ui-react';
 import { ReceivingContext, Trade } from '../context/ReceivingContext';
 import Price from '../common/Price';
 import { Form as FormikForm, Formik } from 'formik';
@@ -81,45 +81,38 @@ const ReceivingListModal: FC<Props> = () => {
                     closeOnDimmerClick={false}
                     open={showModal}
                     onClose={() => setShowModal(false)}
-                    style={{ marginTop: '50px' }}
                 >
                     <Modal.Header>Receiving confirmation</Modal.Header>
-                    <Modal.Content>
-                        <p>
-                            <b>
-                                Pressing 'Submit' will commit the following
-                                items to inventory:
-                            </b>
-                        </p>
-                        <ul>
+                    <Modal.Content scrolling>
+                        <Header as="h5">
+                            Pressing 'Submit' will commit the following items to
+                            inventory:
+                        </Header>
+                        <List>
                             {receivingList.map((c) => {
                                 return (
-                                    <li key={c.uuid_key}>
-                                        {c.name} | {c.set_name}(
+                                    <List.Item key={c.uuid_key}>
+                                        ● {c.name} | {c.set_name}(
                                         {c.set.toUpperCase()})
-                                    </li>
+                                    </List.Item>
                                 );
                             })}
-                        </ul>
-                        <div>
-                            <p>
-                                <b>The customer is owed: </b>
-                            </p>
-                            <ul>
-                                {cashTotal > 0 ? (
-                                    <li>
-                                        <Price num={cashTotal} /> in cold, hard
-                                        cash
-                                    </li>
-                                ) : null}
-                                {creditTotal > 0 ? (
-                                    <li>
-                                        <Price num={creditTotal} /> in store
-                                        credit
-                                    </li>
-                                ) : null}
-                            </ul>
-                        </div>
+                        </List>
+                        <Header as="h5">The customer is owed:</Header>
+                        <List>
+                            {cashTotal > 0 ? (
+                                <List.Item>
+                                    ● <Price num={cashTotal} /> in cold, hard
+                                    cash
+                                </List.Item>
+                            ) : null}
+                            {creditTotal > 0 ? (
+                                <List.Item>
+                                    ● <Price num={creditTotal} /> in store
+                                    credit
+                                </List.Item>
+                            ) : null}
+                        </List>
                     </Modal.Content>
                     <Formik
                         initialValues={initialFormValues}
@@ -131,26 +124,31 @@ const ReceivingListModal: FC<Props> = () => {
                                 <Modal.Content>
                                     <FormikForm>
                                         <Form>
-                                            <Form.Field>
-                                                <label>Customer name</label>
-                                                <Form.Input
-                                                    onChange={handleChange}
-                                                    name="customerName"
-                                                    error={errors.customerName}
-                                                />
-                                            </Form.Field>
-                                            <Form.Field>
-                                                <label>
-                                                    Customer contact (optional)
-                                                </label>
-                                                <Form.Input
-                                                    onChange={handleChange}
-                                                    name="customerContact"
-                                                    error={
-                                                        errors.customerContact
-                                                    }
-                                                />
-                                            </Form.Field>
+                                            <Form.Group widths="equal">
+                                                <Form.Field>
+                                                    <label>Customer name</label>
+                                                    <Form.Input
+                                                        onChange={handleChange}
+                                                        name="customerName"
+                                                        error={
+                                                            errors.customerName
+                                                        }
+                                                    />
+                                                </Form.Field>
+                                                <Form.Field>
+                                                    <label>
+                                                        Customer contact
+                                                        (optional)
+                                                    </label>
+                                                    <Form.Input
+                                                        onChange={handleChange}
+                                                        name="customerContact"
+                                                        error={
+                                                            errors.customerContact
+                                                        }
+                                                    />
+                                                </Form.Field>
+                                            </Form.Group>
                                         </Form>
                                     </FormikForm>
                                 </Modal.Content>

--- a/frontend/src/Receiving/ReceivingListModal.tsx
+++ b/frontend/src/Receiving/ReceivingListModal.tsx
@@ -2,7 +2,7 @@ import React, { useState, useContext, FC } from 'react';
 import { Modal, Button, Form, List, Header } from 'semantic-ui-react';
 import { ReceivingContext, Trade } from '../context/ReceivingContext';
 import Price from '../common/Price';
-import { Form as FormikForm, Formik } from 'formik';
+import { useFormik } from 'formik';
 import sum from '../utils/sum';
 
 interface Props {}
@@ -54,6 +54,12 @@ const ReceivingListModal: FC<Props> = () => {
         );
         setLoading(false);
     };
+
+    const { handleChange, handleSubmit, errors } = useFormik({
+        initialValues: initialFormValues,
+        validate,
+        onSubmit,
+    });
 
     const cashTotal = sum(
         receivingList
@@ -114,61 +120,42 @@ const ReceivingListModal: FC<Props> = () => {
                             ) : null}
                         </List>
                     </Modal.Content>
-                    <Formik
-                        initialValues={initialFormValues}
-                        onSubmit={onSubmit}
-                        validate={validate}
-                    >
-                        {({ handleChange, handleSubmit, errors }) => (
-                            <>
-                                <Modal.Content>
-                                    <FormikForm>
-                                        <Form>
-                                            <Form.Group widths="equal">
-                                                <Form.Field>
-                                                    <label>Customer name</label>
-                                                    <Form.Input
-                                                        onChange={handleChange}
-                                                        name="customerName"
-                                                        error={
-                                                            errors.customerName
-                                                        }
-                                                    />
-                                                </Form.Field>
-                                                <Form.Field>
-                                                    <label>
-                                                        Customer contact
-                                                        (optional)
-                                                    </label>
-                                                    <Form.Input
-                                                        onChange={handleChange}
-                                                        name="customerContact"
-                                                        error={
-                                                            errors.customerContact
-                                                        }
-                                                    />
-                                                </Form.Field>
-                                            </Form.Group>
-                                        </Form>
-                                    </FormikForm>
-                                </Modal.Content>
-                                <Modal.Actions>
-                                    <Button onClick={() => setShowModal(false)}>
-                                        Cancel
-                                    </Button>
-                                    <Button
-                                        color="blue"
-                                        type="submit"
-                                        loading={loading}
-                                        disabled={loading}
-                                        onClick={() => handleSubmit()}
-                                    >
-                                        Submit
-                                    </Button>
-                                </Modal.Actions>
-                            </>
-                        )}
-                    </Formik>
+                    <Modal.Content>
+                        <Form>
+                            <Form.Group widths="equal">
+                                <Form.Field>
+                                    <label>Customer name</label>
+                                    <Form.Input
+                                        onChange={handleChange}
+                                        name="customerName"
+                                        error={errors.customerName}
+                                    />
+                                </Form.Field>
+                                <Form.Field>
+                                    <label>Customer contact (optional)</label>
+                                    <Form.Input
+                                        onChange={handleChange}
+                                        name="customerContact"
+                                        error={errors.customerContact}
+                                    />
+                                </Form.Field>
+                            </Form.Group>
+                        </Form>
+                    </Modal.Content>
+                    <Modal.Actions>
+                        <Button onClick={() => setShowModal(false)}>
+                            Cancel
+                        </Button>
+                        <Button
+                            color="blue"
+                            type="submit"
+                            loading={loading}
+                            disabled={loading}
+                            onClick={() => handleSubmit()}
+                        >
+                            Submit
+                        </Button>
+                    </Modal.Actions>
                 </Modal>
             )}
         </>

--- a/frontend/src/Receiving/ReceivingListModal.tsx
+++ b/frontend/src/Receiving/ReceivingListModal.tsx
@@ -1,12 +1,23 @@
 import React, { useState, useContext, FC } from 'react';
-import { Modal, Header, Button } from 'semantic-ui-react';
+import { Modal, Button, Form } from 'semantic-ui-react';
 import { ReceivingContext } from '../context/ReceivingContext';
 import Price from '../common/Price';
+import { Form as FormikForm, Formik } from 'formik';
 
 interface Props {
     cashTotal: number;
     creditTotal: number;
 }
+
+interface FormValues {
+    customerName: string;
+    customerContact: string;
+}
+
+const initialFormValues: FormValues = {
+    customerName: '',
+    customerContact: '',
+};
 
 const ReceivingListModal: FC<Props> = ({ cashTotal, creditTotal }) => {
     const [loading, setLoading] = useState(false);
@@ -14,86 +25,117 @@ const ReceivingListModal: FC<Props> = ({ cashTotal, creditTotal }) => {
 
     const { receivingList, commitToInventory } = useContext(ReceivingContext);
 
-    const submitToInventory = async () => {
+    const onSubmit = async ({ customerName, customerContact }: FormValues) => {
         setLoading(true);
-        await commitToInventory();
+        await commitToInventory(customerName, customerContact);
         setLoading(false);
     };
 
     return (
-        <Modal
-            closeOnDimmerClick={false}
-            trigger={
-                <Button
-                    id="commit-to-inv"
-                    color="blue"
-                    disabled={receivingList.length === 0}
-                    onClick={() => setShowModal(true)}
+        <>
+            <Button
+                color="blue"
+                disabled={receivingList.length === 0}
+                onClick={() => setShowModal(true)}
+            >
+                Commit to inventory
+            </Button>
+            {setShowModal && (
+                <Modal
+                    closeOnDimmerClick={false}
+                    open={showModal}
+                    onClose={() => setShowModal(false)}
+                    style={{ marginTop: '50px' }}
                 >
-                    Commit to inventory
-                </Button>
-            }
-            open={showModal}
-            onClose={() => setShowModal(false)}
-            basic
-            style={{ marginTop: '50px' }}
-        >
-            <Header>Confirm receipt of new inventory?</Header>
-            <Modal.Content>
-                <p>
-                    <b>
-                        Pressing 'Submit' will commit the following items to
-                        inventory:
-                    </b>
-                </p>
-                <ul>
-                    {receivingList.map((c) => {
-                        return (
-                            <li key={c.uuid_key}>
-                                {c.name} | {c.set_name}({c.set.toUpperCase()})
-                            </li>
-                        );
-                    })}
-                </ul>
-                <div>
-                    <p>
-                        <b>The customer is owed: </b>
-                    </p>
-                    <ul>
-                        {cashTotal > 0 ? (
-                            <li>
-                                <Price num={cashTotal} /> in cold, hard cash
-                            </li>
-                        ) : null}
-                        {creditTotal > 0 ? (
-                            <li>
-                                <Price num={creditTotal} /> in store credit
-                            </li>
-                        ) : null}
-                    </ul>
-                </div>
-            </Modal.Content>
-            <Modal.Actions>
-                <Button
-                    basic
-                    color="red"
-                    inverted
-                    onClick={() => setShowModal(false)}
-                >
-                    Cancel
-                </Button>
-                <Button
-                    id="submit-to-inv"
-                    color="green"
-                    inverted
-                    loading={loading}
-                    disabled={loading}
-                    onClick={submitToInventory}
-                >
-                    Submit
-                </Button>
-            </Modal.Actions>
-        </Modal>
+                    <Modal.Header>Receiving confirmation</Modal.Header>
+                    <Modal.Content>
+                        <p>
+                            <b>
+                                Pressing 'Submit' will commit the following
+                                items to inventory:
+                            </b>
+                        </p>
+                        <ul>
+                            {receivingList.map((c) => {
+                                return (
+                                    <li key={c.uuid_key}>
+                                        {c.name} | {c.set_name}(
+                                        {c.set.toUpperCase()})
+                                    </li>
+                                );
+                            })}
+                        </ul>
+                        <div>
+                            <p>
+                                <b>The customer is owed: </b>
+                            </p>
+                            <ul>
+                                {cashTotal > 0 ? (
+                                    <li>
+                                        <Price num={cashTotal} /> in cold, hard
+                                        cash
+                                    </li>
+                                ) : null}
+                                {creditTotal > 0 ? (
+                                    <li>
+                                        <Price num={creditTotal} /> in store
+                                        credit
+                                    </li>
+                                ) : null}
+                            </ul>
+                        </div>
+                    </Modal.Content>
+                    <Formik
+                        initialValues={initialFormValues}
+                        onSubmit={onSubmit}
+                    >
+                        {({ values, handleChange, handleSubmit }) => (
+                            <>
+                                <Modal.Content>
+                                    <FormikForm>
+                                        <pre>
+                                            {JSON.stringify(values, null, 2)}
+                                        </pre>
+                                        <Form>
+                                            <Form.Field>
+                                                <label>Customer name</label>
+                                                <Form.Input
+                                                    onChange={handleChange}
+                                                    name="customerName"
+                                                />
+                                            </Form.Field>
+                                            <Form.Field>
+                                                <label>
+                                                    Customer contact (optional)
+                                                </label>
+                                                <Form.Input
+                                                    onChange={handleChange}
+                                                    name="customerContact"
+                                                />
+                                            </Form.Field>
+                                        </Form>
+                                    </FormikForm>
+                                </Modal.Content>
+                                <Modal.Actions>
+                                    <Button onClick={() => setShowModal(false)}>
+                                        Cancel
+                                    </Button>
+                                    <Button
+                                        color="blue"
+                                        type="submit"
+                                        loading={loading}
+                                        disabled={loading}
+                                        onClick={() => handleSubmit()}
+                                    >
+                                        Submit
+                                    </Button>
+                                </Modal.Actions>
+                            </>
+                        )}
+                    </Formik>
+                </Modal>
+            )}
+        </>
     );
 };
 

--- a/frontend/src/Receiving/ReceivingListModal.tsx
+++ b/frontend/src/Receiving/ReceivingListModal.tsx
@@ -91,15 +91,14 @@ const ReceivingListModal: FC<Props> = () => {
                     <Modal.Header>Receiving confirmation</Modal.Header>
                     <Modal.Content scrolling>
                         <Header as="h5">
-                            Pressing 'Submit' will commit the following items to
-                            inventory:
+                            Committing the following cards to inventory:
                         </Header>
                         <List>
                             {receivingList.map((c) => {
                                 return (
                                     <List.Item key={c.uuid_key}>
-                                        ● {c.name} | {c.set_name}(
-                                        {c.set.toUpperCase()})
+                                        {`● ${c.name} | ${c.set_name} (
+                                        ${c.set.toUpperCase()})`}
                                     </List.Item>
                                 );
                             })}

--- a/frontend/src/Receiving/ReceivingListTotals.tsx
+++ b/frontend/src/Receiving/ReceivingListTotals.tsx
@@ -115,10 +115,7 @@ const ReceivingListTotals: FC<Props> = () => {
                                 </Statistic.Value>
                             </Statistic>
                         </div>
-                        <ReceivingListModal
-                            cashTotal={cashTotal}
-                            creditTotal={creditTotal}
-                        />
+                        <ReceivingListModal />
                     </Segment>
                 </FlexCol>
             </FlexRow>

--- a/frontend/src/context/ReceivingContext.tsx
+++ b/frontend/src/context/ReceivingContext.tsx
@@ -37,7 +37,10 @@ interface Context {
     removeFromList: (uuid: string) => void;
     activeTradeType: (uuid: string, tradeType: Trade) => void;
     selectAll: (trade: Trade) => void;
-    commitToInventory: () => void;
+    commitToInventory: (
+        customerName: string,
+        customerContact: string | null
+    ) => void;
     resetSearchResults: () => void;
 }
 
@@ -156,14 +159,21 @@ const ReceivingProvider: FC<Props> = ({ children }) => {
     /**
      * Persists all passed cards to inventory
      */
-    const commitToInventory = async () => {
+    const commitToInventory = async (
+        customerName: string,
+        customerContact: string | null
+    ) => {
         try {
             const cardsToCommit = receivingList.map((card) => ({
                 ...card,
                 quantity: 1, // Only committing one per line-item
             }));
 
-            await receivingQuery({ cards: cardsToCommit });
+            await receivingQuery({
+                cards: cardsToCommit,
+                customerName,
+                customerContact,
+            });
 
             setSearchResults([]);
             setReceivingList([]);

--- a/frontend/src/context/receivingQuery.tsx
+++ b/frontend/src/context/receivingQuery.tsx
@@ -18,14 +18,20 @@ interface ReceivingQueryCard {
 
 interface Payload {
     cards: ReceivingQueryCard[];
+    customerName: string;
+    customerContact: string | null;
 }
 
-const receivingQuery = async ({ cards }: Payload) => {
+const receivingQuery = async ({
+    cards,
+    customerName,
+    customerContact,
+}: Payload) => {
     try {
         // We do not expect to use the return type, so we designate it `void`
         const { data } = await axios.post<void>(
             RECEIVE_CARDS,
-            { cards },
+            { cards, customerName, customerContact },
             { headers: makeAuthHeader() }
         );
 

--- a/monolith/common/types.ts
+++ b/monolith/common/types.ts
@@ -148,7 +148,7 @@ export interface ReceivingCard {
 
 export interface ReceivingBody {
     customerName: string;
-    customerContact: string;
+    customerContact: string | null;
     cards: ReceivingCard[];
 }
 

--- a/monolith/common/types.ts
+++ b/monolith/common/types.ts
@@ -146,8 +146,14 @@ export interface ReceivingCard {
     tradeType: Trade;
 }
 
+export interface ReceivingBody {
+    customerName: string;
+    customerContact: string;
+    cards: ReceivingCard[];
+}
+
 export interface ReqWithReceivingCards extends RequestWithUserInfo {
-    body: { cards: ReceivingCard[] };
+    body: ReceivingBody;
 }
 
 export interface SuspendSaleBody {

--- a/monolith/interactors/addCardsToReceivingRecords.ts
+++ b/monolith/interactors/addCardsToReceivingRecords.ts
@@ -9,7 +9,7 @@ interface Args {
     location: ClubhouseLocation;
     userId: string;
     customerName: string;
-    customerContact?: string;
+    customerContact: string | null;
 }
 
 async function addCardsToReceivingRecords({

--- a/monolith/interactors/addCardsToReceivingRecords.ts
+++ b/monolith/interactors/addCardsToReceivingRecords.ts
@@ -17,6 +17,8 @@ async function addCardsToReceivingRecords({
     employeeNumber,
     location,
     userId,
+    customerName,
+    customerContact,
 }: Args) {
     try {
         const db = await getDatabaseConnection();
@@ -28,6 +30,8 @@ async function addCardsToReceivingRecords({
                 employee_number: employeeNumber,
                 received_card_list: cards,
                 created_by: userId,
+                customer_name: customerName,
+                customer_contact: customerContact,
             });
 
         console.log(`Recorded ${cards.length} received cards at ${location}`);

--- a/monolith/interactors/addCardsToReceivingRecords.ts
+++ b/monolith/interactors/addCardsToReceivingRecords.ts
@@ -3,12 +3,21 @@ import getDatabaseConnection from '../database';
 import { ReceivingCard } from './addCardToInventoryReceiving';
 import { ClubhouseLocation } from '../common/types';
 
-async function addCardsToReceivingRecords(
-    cards: ReceivingCard[],
-    employeeNumber: number,
-    location: ClubhouseLocation,
-    userId: string
-) {
+interface Args {
+    cards: ReceivingCard[];
+    employeeNumber: number;
+    location: ClubhouseLocation;
+    userId: string;
+    customerName: string;
+    customerContact?: string;
+}
+
+async function addCardsToReceivingRecords({
+    cards,
+    employeeNumber,
+    location,
+    userId,
+}: Args) {
     try {
         const db = await getDatabaseConnection();
 

--- a/monolith/routes/auth.ts
+++ b/monolith/routes/auth.ts
@@ -301,18 +301,20 @@ router.post('/receiveCards', (req: ReqWithReceivingCards, res, next) => {
 
 router.post('/receiveCards', async (req: ReqWithReceivingCards, res) => {
     try {
-        const { cards } = req.body;
+        const { cards, customerName, customerContact } = req.body;
         const messages = await addCardToInventoryReceiving(
             cards,
             req.currentLocation
         );
 
-        await addCardsToReceivingRecords(
+        await addCardsToReceivingRecords({
             cards,
-            req.lightspeedEmployeeNumber,
-            req.currentLocation,
-            req.userId
-        );
+            employeeNumber: req.lightspeedEmployeeNumber,
+            location: req.currentLocation,
+            userId: req.userId,
+            customerName,
+            customerContact,
+        });
 
         res.status(200).send(messages);
     } catch (err) {

--- a/monolith/routes/auth.ts
+++ b/monolith/routes/auth.ts
@@ -36,6 +36,7 @@ import {
     JoiValidation,
     PriceFilter,
     priceFilters,
+    ReceivingBody,
     ReceivingCard,
     RequestWithUserInfo,
     ReqWithFinishSaleCards,
@@ -258,7 +259,7 @@ router.get('/getSaleByTitle', async (req: RequestWithUserInfo, res) => {
  * Sanitizes card object properties so nothing funky is committed to the database
  */
 router.post('/receiveCards', (req: ReqWithReceivingCards, res, next) => {
-    const schema = Joi.object<ReceivingCard>({
+    const receivingCardSchema = Joi.object<ReceivingCard>({
         id: Joi.string().required(),
         quantity: Joi.number().integer().required(),
         name: Joi.string().required(),
@@ -273,21 +274,23 @@ router.post('/receiveCards', (req: ReqWithReceivingCards, res, next) => {
         tradeType: Joi.string().valid(Trade.Cash, Trade.Credit).required(),
     });
 
-    const { cards } = req.body;
+    const schema = Joi.object<ReceivingBody>({
+        customerName: Joi.string().min(3).max(50).required(),
+        customerContact: Joi.string().max(50),
+        cards: Joi.array().items(receivingCardSchema),
+    });
 
     try {
-        for (let card of cards) {
-            const { error }: JoiValidation<ReceivingCard> = schema.validate(
-                card,
-                {
-                    abortEarly: false,
-                    allowUnknown: true,
-                }
-            );
-
-            if (error) {
-                return res.status(400).json(error);
+        const { error }: JoiValidation<ReceivingCard> = schema.validate(
+            req.body,
+            {
+                abortEarly: false,
+                allowUnknown: true,
             }
+        );
+
+        if (error) {
+            return res.status(400).json(error);
         }
 
         return next();

--- a/monolith/routes/auth.ts
+++ b/monolith/routes/auth.ts
@@ -276,7 +276,7 @@ router.post('/receiveCards', (req: ReqWithReceivingCards, res, next) => {
 
     const schema = Joi.object<ReceivingBody>({
         customerName: Joi.string().min(3).max(50).required(),
-        customerContact: Joi.string().max(50),
+        customerContact: Joi.string().max(50).allow(null),
         cards: Joi.array().items(receivingCardSchema),
     });
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/15024562/123176115-bcc13300-d437-11eb-890e-6c06ef6281d4.png)

## Summary
This PR allows us to persist customer information to each receiving entry. Notable allstar here was the `useFormik` hook! A much cleaner development experience rather than using antiquated render props.

## Considerations
Users cannot view this data yet in the receiving history. We need to migrate the database, and then make a PR to display this data on the receiving history page. 