### PR TITLE
Receiving customer info

### DIFF
--- a/frontend/src/BrowseReceiving/ReceivingListDialog.tsx
+++ b/frontend/src/BrowseReceiving/ReceivingListDialog.tsx
@@ -11,12 +11,15 @@ import {
     List,
     ListItem,
     ListItemText,
+    Typography,
 } from '@material-ui/core';
-import { ReceivedCard } from './browseReceivingQuery';
+import { Received } from './browseReceivingQuery';
 import MetaData from '../ui/MetaData';
+import formatDate from '../utils/formatDate';
+import displayEmpty from '../utils/displayEmpty';
 
 interface Props {
-    receivingList: ReceivedCard[];
+    received: Received;
     onClose: () => void;
 }
 
@@ -29,59 +32,90 @@ function displayTrade(trade: Trade) {
     else if (trade === Trade.Cash) return 'Cash';
 }
 
-const ReceivingListDialog: FC<Props> = ({ receivingList, onClose }) => {
+const ReceivingListDialog: FC<Props> = ({ received, onClose }) => {
+    const {
+        received_card_list: receivingList,
+        created_at,
+        created_by,
+        customer_name,
+        customer_contact,
+    } = received;
+
     return (
-        <Dialog open onClose={onClose} maxWidth="sm" fullWidth>
-            <DialogTitle>Received cards</DialogTitle>
+        <Dialog open onClose={onClose} maxWidth="md" fullWidth>
+            <DialogTitle>
+                Received cards
+                <Typography color="textSecondary">
+                    <MetaData>
+                        <span>{formatDate(created_at)}</span>
+                        <span>Received by {created_by.username}</span>
+                        <span>Customer: {displayEmpty(customer_name)}</span>
+                        <span>
+                            Customer contact: {displayEmpty(customer_contact)}
+                        </span>
+                    </MetaData>
+                </Typography>
+            </DialogTitle>
             <DialogContent>
                 <List>
-                    {alphaSort(receivingList).map((c) => {
+                    {alphaSort(receivingList).map((card) => {
+                        const {
+                            name,
+                            set,
+                            set_name,
+                            finishCondition,
+                            tradeType,
+                            creditPrice,
+                            cashPrice,
+                            marketPrice,
+                        } = card;
+
                         return (
                             <ListItem>
                                 <ListItemText
                                     primary={
                                         <>
-                                            <span>{c.name}</span>
+                                            <span>{name}</span>
                                             <i
-                                                className={`ss ss-fw ss-${c.set}`}
+                                                className={`ss ss-fw ss-${set}`}
                                                 style={{
                                                     fontSize: '20px',
                                                 }}
                                             />
-                                            <span>({c.set_name})</span>
+                                            <span>({set_name})</span>
                                         </>
                                     }
                                     secondary={
                                         <MetaData>
                                             <span>
                                                 {displayFinishCondition(
-                                                    c.finishCondition
+                                                    finishCondition
                                                 )}
                                             </span>
                                             <span>
-                                                {displayTrade(c.tradeType)}
+                                                {displayTrade(tradeType)}
                                             </span>
-                                            {c.tradeType === Trade.Credit && (
+                                            {tradeType === Trade.Credit && (
                                                 <span>
                                                     Credit price:{' '}
-                                                    {price(c.creditPrice)}
+                                                    {price(creditPrice)}
                                                 </span>
                                             )}
-                                            {c.tradeType === Trade.Cash && (
+                                            {tradeType === Trade.Cash && (
                                                 <>
                                                     <span>
                                                         Cash price:{' '}
-                                                        {price(c.cashPrice)}
+                                                        {price(cashPrice)}
                                                     </span>
                                                     <span>
                                                         Market price:{' '}
-                                                        {price(c.marketPrice)}
+                                                        {price(marketPrice)}
                                                     </span>
                                                 </>
                                             )}
                                         </MetaData>
                                     }
-                                ></ListItemText>
+                                />
                             </ListItem>
                         );
                     })}

--- a/frontend/src/BrowseReceiving/ReceivingListDialog.tsx
+++ b/frontend/src/BrowseReceiving/ReceivingListDialog.tsx
@@ -17,6 +17,7 @@ import { Received } from './browseReceivingQuery';
 import MetaData from '../ui/MetaData';
 import formatDate from '../utils/formatDate';
 import displayEmpty from '../utils/displayEmpty';
+import SetIcon from '../ui/SetIcon';
 
 interface Props {
     received: Received;
@@ -76,12 +77,7 @@ const ReceivingListDialog: FC<Props> = ({ received, onClose }) => {
                                     primary={
                                         <>
                                             <span>{name}</span>
-                                            <i
-                                                className={`ss ss-fw ss-${set}`}
-                                                style={{
-                                                    fontSize: '20px',
-                                                }}
-                                            />
+                                            <SetIcon set={set} />
                                             <span>({set_name})</span>
                                         </>
                                     }

--- a/frontend/src/BrowseReceiving/ReceivingListItem.tsx
+++ b/frontend/src/BrowseReceiving/ReceivingListItem.tsx
@@ -15,6 +15,7 @@ import { sum } from 'lodash';
 import { getPrice } from '../common/Price';
 import MetaData from '../ui/MetaData';
 import { Trade } from '../context/ReceivingContext';
+import displayEmpty from '../utils/displayEmpty';
 
 interface Props {
     received: Received;
@@ -22,7 +23,12 @@ interface Props {
 
 const ReceivingListItem: FC<Props> = ({ received }) => {
     const [dialogOpen, setDialogOpen] = useState<boolean>(false);
-    const { received_card_list, created_at, created_by } = received;
+    const {
+        received_card_list,
+        created_at,
+        created_by,
+        customer_name,
+    } = received;
 
     const cashPrice = sum(
         received_card_list
@@ -40,7 +46,7 @@ const ReceivingListItem: FC<Props> = ({ received }) => {
         <>
             {dialogOpen && (
                 <ReceivingListDialog
-                    receivingList={received_card_list}
+                    received={received}
                     onClose={() => setDialogOpen(false)}
                 />
             )}
@@ -68,6 +74,10 @@ const ReceivingListItem: FC<Props> = ({ received }) => {
                                         <span>{formatDate(created_at)}</span>
                                         <span>
                                             Received by {created_by.username}
+                                        </span>
+                                        <span>
+                                            Customer:{' '}
+                                            {displayEmpty(customer_name)}
                                         </span>
                                     </MetaData>
                                 </Typography>

--- a/frontend/src/BrowseReceiving/browseReceivingQuery.ts
+++ b/frontend/src/BrowseReceiving/browseReceivingQuery.ts
@@ -31,6 +31,8 @@ export interface Received {
     employee_number: string;
     received_card_list: ReceivedCard[];
     created_by: ReceivedUser;
+    customer_name: string | null;
+    customer_contact: string | null;
 }
 
 interface Payload {

--- a/frontend/src/DeckboxClone/DeckboxCloneRow.tsx
+++ b/frontend/src/DeckboxClone/DeckboxCloneRow.tsx
@@ -2,6 +2,7 @@ import React, { FC, useState, MouseEvent } from 'react';
 import { Table, Icon } from 'semantic-ui-react';
 import Price from '../common/Price';
 import TooltipImage from '../common/TooltipImage';
+import SetIcon from '../ui/SetIcon';
 import { ResponseCard } from './filteredCardsQuery';
 
 const conditionMap = {
@@ -81,10 +82,7 @@ const DeckboxCloneRow: FC<Props> = ({
                 )}
             </Table.Cell>
             <Table.Cell>
-                <i
-                    className={`ss ss-fw ss-${set} ss-${rarity}`}
-                    style={{ fontSize: '20px' }}
-                />{' '}
+                <SetIcon set={set} rarity={rarity} />
                 {set_name}
             </Table.Cell>
             <Table.Cell>{conditionMap[condition]}</Table.Cell>

--- a/frontend/src/NewSale/SaleLineItem.tsx
+++ b/frontend/src/NewSale/SaleLineItem.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import { SaleContext, SaleListCard } from '../context/SaleContext';
 import Price from '../common/Price';
 import TooltipImage from '../common/TooltipImage';
+import SetIcon from '../ui/SetIcon';
 
 interface Props {
     card: SaleListCard;
@@ -68,10 +69,7 @@ const SaleLineItem: FC<Props> = ({
                             )}
                         </span>
                     </div>
-                    <i
-                        className={`ss ss-fw ss-${set} ss-${rarity}`}
-                        style={{ fontSize: '20px' }}
-                    />
+                    <SetIcon set={set} rarity={rarity} />
                     <Label color="grey">{set.toUpperCase()}</Label>
                     <div className="line-item-price">
                         {qtyToSell}x @ <Price num={price} />

--- a/frontend/src/Receiving/ReceivingListItem.tsx
+++ b/frontend/src/Receiving/ReceivingListItem.tsx
@@ -8,6 +8,7 @@ import {
     Trade,
 } from '../context/ReceivingContext';
 import TooltipImage from '../common/TooltipImage';
+import SetIcon from '../ui/SetIcon';
 
 interface Props {
     card: ReceivingCard;
@@ -77,10 +78,7 @@ const ReceivingListItem: FC<Props> = ({
                             )}
                         </span>
                     </div>
-                    <i
-                        className={`ss ss-fw ss-${set} ss-${rarity}`}
-                        style={{ fontSize: '20px' }}
-                    />
+                    <SetIcon set={set} rarity={rarity} />
                     <Label color="grey">{set.toUpperCase()}</Label>
                     {finishCondition && (
                         <span>

--- a/frontend/src/ui/CardHeader.tsx
+++ b/frontend/src/ui/CardHeader.tsx
@@ -5,7 +5,7 @@ import QohLabels from '../common/QohLabels';
 import Language from '../common/Language';
 import MarketPrice from '../common/MarketPrice';
 import { Finish } from '../utils/checkCardFinish';
-import styled from 'styled-components';
+import SetIcon from './SetIcon';
 
 interface Props {
     card: ScryfallCard;
@@ -13,10 +13,6 @@ interface Props {
     showMid?: boolean;
     round?: boolean;
 }
-
-const SetIcon = styled('i')({
-    fontSize: '30px',
-});
 
 // TODO: remove this shim after TCG api approval and integration
 const TcgPriceButton: FC<{ tcgId: number | null }> = ({ tcgId }) => {
@@ -59,7 +55,7 @@ const CardHeader: FC<Props> = ({
     return (
         <Item.Header as="h3">
             {display_name}
-            <SetIcon className={`ss ss-fw ss-${set} ss-${rarity}`} />
+            <SetIcon set={set} rarity={rarity} />
             <Label color="grey">
                 {set_name} ({set.toUpperCase()})
             </Label>

--- a/frontend/src/ui/SetIcon.tsx
+++ b/frontend/src/ui/SetIcon.tsx
@@ -1,0 +1,18 @@
+import React, { FC } from 'react';
+import styled from 'styled-components';
+
+interface Props {
+    set: string;
+    rarity?: string;
+}
+
+const StyledIcon = styled('i')({
+    fontSize: '20px',
+});
+
+const SetIcon: FC<Props> = ({ set, rarity }) => {
+    const rarityClass = rarity ? `ss-${rarity}` : '';
+    return <StyledIcon className={`ss ss-fw ss-${set} ${rarityClass}`} />;
+};
+
+export default SetIcon;

--- a/frontend/src/utils/displayEmpty.ts
+++ b/frontend/src/utils/displayEmpty.ts
@@ -1,0 +1,8 @@
+/**
+ * Used for old entities did not have certain fields
+ */
+const displayEmpty = (str: string | null): string => {
+    return str ? str : '—';
+};
+
+export default displayEmpty;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/15024562/123313312-41668c80-d4de-11eb-908d-62122035de45.png)

## Summary
This PR brings the last feature release full circle; we're now able to display customer information on Browse Receiving. Of note, we created `displayEmpty`, which will render an emdash in place of `null` strings (legacy receiving entities do not have `customer_name` fields, and were migrated to `null`).

Additionally, I extracted `SetIcon` here. It was repeated throughout.