### PR TITLE
`useFormik` hook

### DIFF
--- a/frontend/src/BrowseReceiving/BrowseReceiving.tsx
+++ b/frontend/src/BrowseReceiving/BrowseReceiving.tsx
@@ -1,12 +1,13 @@
-import React, { FC, SyntheticEvent, useEffect, useState } from 'react';
+import React, { FC, useEffect, useState } from 'react';
 import browseReceivingQuery, { Received } from './browseReceivingQuery';
 import { Grid, Typography, Box } from '@material-ui/core';
 import ReceivingListItem from './ReceivingListItem';
 import moment from 'moment';
 import { useFormik } from 'formik';
-import { Form, Input } from 'semantic-ui-react';
+import { Form } from 'semantic-ui-react';
 import Loading from '../ui/Loading';
-import SearchBar from '../common/SearchBar';
+import { FormSearchBar } from '../ui/FormikSearchBar';
+import { FormNativeDatePicker } from '../ui/FormikNativeDatePicker';
 
 interface FormValues {
     cardName: string;
@@ -63,43 +64,24 @@ const BrowseReceiving: FC = () => {
             <Box pb={2}>
                 <Form>
                     <Form.Group widths="6">
-                        <Form.Field>
-                            <label>Card name</label>
-                            <SearchBar
-                                handleSearchSelect={(value) => {
-                                    setFieldValue('cardName', value);
-                                }}
-                                // Reset form state after user blurs cardName
-                                onBlur={(
-                                    event: SyntheticEvent<Element, Event>
-                                ) => {
-                                    const element = event.target as HTMLInputElement;
-                                    setFieldValue('cardName', element.value);
-                                }}
-                            />
-                        </Form.Field>
-                        <Form.Field>
-                            <label>Start date</label>
-                            <Input
-                                id="startDate"
-                                name="startDate"
-                                type="date"
-                                onChange={handleChange}
-                                defaultValue={initialFormValues.startDate}
-                                max={values.endDate}
-                            />
-                        </Form.Field>
-                        <Form.Field>
-                            <label>End date</label>
-                            <Input
-                                id="endDate"
-                                name="endDate"
-                                type="date"
-                                onChange={handleChange}
-                                defaultValue={initialFormValues.endDate}
-                                max={initialFormValues.endDate}
-                            />
-                        </Form.Field>
+                        <FormSearchBar
+                            label="Card name"
+                            onChange={(v) => setFieldValue('cardName', v)}
+                        />
+                        <FormNativeDatePicker
+                            label="Start date"
+                            name="startDate"
+                            defaultValue={initialFormValues.startDate}
+                            handleChange={handleChange}
+                            max={values.endDate}
+                        />
+                        <FormNativeDatePicker
+                            label="End date"
+                            name="endDate"
+                            defaultValue={initialFormValues.endDate}
+                            handleChange={handleChange}
+                            max={initialFormValues.endDate}
+                        />
                     </Form.Group>
                     <Form.Button
                         type="submit"

--- a/frontend/src/BrowseReceiving/BrowseReceiving.tsx
+++ b/frontend/src/BrowseReceiving/BrowseReceiving.tsx
@@ -6,8 +6,8 @@ import moment from 'moment';
 import { useFormik } from 'formik';
 import { Form } from 'semantic-ui-react';
 import Loading from '../ui/Loading';
-import { FormSearchBar } from '../ui/FormikSearchBar';
-import { FormNativeDatePicker } from '../ui/FormikNativeDatePicker';
+import { FormikSearchBar } from '../ui/FormikSearchBar';
+import { FormikNativeDatePicker } from '../ui/FormikNativeDatePicker';
 
 interface FormValues {
     cardName: string;
@@ -53,7 +53,6 @@ const BrowseReceiving: FC = () => {
         })();
     }, []);
 
-    // TODO: Extract relevant inputs for hook use
     return (
         <div>
             <Box pb={2}>
@@ -64,18 +63,18 @@ const BrowseReceiving: FC = () => {
             <Box pb={2}>
                 <Form>
                     <Form.Group widths="6">
-                        <FormSearchBar
+                        <FormikSearchBar
                             label="Card name"
                             onChange={(v) => setFieldValue('cardName', v)}
                         />
-                        <FormNativeDatePicker
+                        <FormikNativeDatePicker
                             label="Start date"
                             name="startDate"
                             defaultValue={initialFormValues.startDate}
                             handleChange={handleChange}
                             max={values.endDate}
                         />
-                        <FormNativeDatePicker
+                        <FormikNativeDatePicker
                             label="End date"
                             name="endDate"
                             defaultValue={initialFormValues.endDate}

--- a/frontend/src/BrowseReceiving/BrowseReceiving.tsx
+++ b/frontend/src/BrowseReceiving/BrowseReceiving.tsx
@@ -21,7 +21,7 @@ const initialFormValues: FormValues = {
     endDate: moment().format('YYYY-MM-DD'),
 };
 
-// Not validations needed for now
+// No validations needed for now
 const validate = () => {
     return {};
 };

--- a/frontend/src/BrowseReceiving/BrowseReceiving.tsx
+++ b/frontend/src/BrowseReceiving/BrowseReceiving.tsx
@@ -1,13 +1,12 @@
-import React, { FC, useEffect, useState } from 'react';
+import React, { FC, SyntheticEvent, useEffect, useState } from 'react';
 import browseReceivingQuery, { Received } from './browseReceivingQuery';
 import { Grid, Typography, Box } from '@material-ui/core';
 import ReceivingListItem from './ReceivingListItem';
 import moment from 'moment';
-import { Formik, Form as FormikForm, Field } from 'formik';
-import { Form } from 'semantic-ui-react';
-import FormikSearchBar from '../ui/FormikSearchBar';
-import FormikNativeDatePicker from '../ui/FormikNativeDatePicker';
+import { useFormik } from 'formik';
+import { Form, Input } from 'semantic-ui-react';
 import Loading from '../ui/Loading';
+import SearchBar from '../common/SearchBar';
 
 interface FormValues {
     cardName: string;
@@ -19,6 +18,11 @@ const initialFormValues: FormValues = {
     cardName: '',
     startDate: moment().subtract(30, 'days').format('YYYY-MM-DD'),
     endDate: moment().format('YYYY-MM-DD'),
+};
+
+// Not validations needed for now
+const validate = () => {
+    return {};
 };
 
 const BrowseReceiving: FC = () => {
@@ -36,12 +40,19 @@ const BrowseReceiving: FC = () => {
         setReceivedList(received);
     };
 
+    const { handleChange, values, setFieldValue, handleSubmit } = useFormik({
+        initialValues: initialFormValues,
+        validate,
+        onSubmit,
+    });
+
     useEffect(() => {
         (async () => {
             await onSubmit(initialFormValues);
         })();
     }, []);
 
+    // TODO: Extract relevant inputs for hook use
     return (
         <div>
             <Box pb={2}>
@@ -50,40 +61,54 @@ const BrowseReceiving: FC = () => {
                 </Typography>
             </Box>
             <Box pb={2}>
-                <Formik initialValues={initialFormValues} onSubmit={onSubmit}>
-                    {({ values }) => (
-                        <FormikForm>
-                            <Form>
-                                <Form.Group widths="6">
-                                    <Field
-                                        name="cardName"
-                                        label="Card name"
-                                        component={FormikSearchBar}
-                                    />
-                                    <Field
-                                        name="startDate"
-                                        label="Start date"
-                                        defaultValue={
-                                            initialFormValues.startDate
-                                        }
-                                        component={FormikNativeDatePicker}
-                                        max={values.endDate}
-                                    />
-                                    <Field
-                                        name="endDate"
-                                        label="End date"
-                                        defaultValue={initialFormValues.endDate}
-                                        component={FormikNativeDatePicker}
-                                        max={initialFormValues.endDate}
-                                    />
-                                </Form.Group>
-                                <Form.Button type="submit" primary>
-                                    Search
-                                </Form.Button>
-                            </Form>
-                        </FormikForm>
-                    )}
-                </Formik>
+                <Form>
+                    <Form.Group widths="6">
+                        <Form.Field>
+                            <label>Card name</label>
+                            <SearchBar
+                                handleSearchSelect={(value) => {
+                                    setFieldValue('cardName', value);
+                                }}
+                                // Reset form state after user blurs cardName
+                                onBlur={(
+                                    event: SyntheticEvent<Element, Event>
+                                ) => {
+                                    const element = event.target as HTMLInputElement;
+                                    setFieldValue('cardName', element.value);
+                                }}
+                            />
+                        </Form.Field>
+                        <Form.Field>
+                            <label>Start date</label>
+                            <Input
+                                id="startDate"
+                                name="startDate"
+                                type="date"
+                                onChange={handleChange}
+                                defaultValue={initialFormValues.startDate}
+                                max={values.endDate}
+                            />
+                        </Form.Field>
+                        <Form.Field>
+                            <label>End date</label>
+                            <Input
+                                id="endDate"
+                                name="endDate"
+                                type="date"
+                                onChange={handleChange}
+                                defaultValue={initialFormValues.endDate}
+                                max={initialFormValues.endDate}
+                            />
+                        </Form.Field>
+                    </Form.Group>
+                    <Form.Button
+                        type="submit"
+                        onClick={() => handleSubmit()}
+                        primary
+                    >
+                        Search
+                    </Form.Button>
+                </Form>
             </Box>
             {loading ? (
                 <Loading />

--- a/frontend/src/DeckboxClone/DeckboxCloneForm.tsx
+++ b/frontend/src/DeckboxClone/DeckboxCloneForm.tsx
@@ -1,11 +1,11 @@
-import React, { FC, SyntheticEvent, useEffect, useState } from 'react';
-import SearchBar from '../common/SearchBar';
+import React, { FC, useEffect, useState } from 'react';
 import { Form, Input, Segment } from 'semantic-ui-react';
-import { Formik, FormikHelpers, Form as FormikForm, Field } from 'formik';
-import FormikSelectField from '../ui/FormikSelectField';
-import FormikDropdown from '../ui/FormikDropdown';
+import { FormikHelpers, useFormik } from 'formik';
+import FormSelectField from '../ui/FormikSelectField';
 import setNameQuery from './setNameQuery';
 import { Filters } from './filteredCardsQuery';
+import FormikSearchBar from '../ui/FormikSearchBar';
+import FormikDropdown from '../ui/FormikDropdown';
 
 const formatDropdownOptions: DropdownOption[] = [
     { key: 'qw', value: '', text: 'None' },
@@ -117,6 +117,11 @@ export const initialFilters: FormValues = {
     frame: '',
 };
 
+// No validations needed for now
+const validate = () => {
+    return {};
+};
+
 interface Props {
     doSubmit: (v: Filters, page: number) => Promise<void>;
 }
@@ -176,130 +181,116 @@ const DeckboxCloneForm: FC<Props> = ({ doSubmit }) => {
         })();
     }, []);
 
+    const { handleChange, setFieldValue, handleSubmit } = useFormik({
+        initialValues: initialFilters,
+        validate,
+        onSubmit,
+    });
+
     return (
         <Segment>
             <h3>Filters</h3>
-            <Formik initialValues={initialFilters} onSubmit={onSubmit}>
-                {({ handleChange, setFieldValue }) => (
-                    <FormikForm>
-                        <Form>
-                            <Form.Group widths="4">
-                                <Form.Field>
-                                    <label>Card Name</label>
-                                    <SearchBar
-                                        handleSearchSelect={(value) => {
-                                            setFieldValue('title', value);
-                                        }}
-                                        // Reset form state after user blurs title
-                                        onBlur={(
-                                            event: SyntheticEvent<
-                                                Element,
-                                                Event
-                                            >
-                                        ) => {
-                                            const element = event.target as HTMLInputElement;
-                                            setFieldValue(
-                                                'title',
-                                                element.value
-                                            );
-                                        }}
-                                    />
-                                </Form.Field>
-                                <Field
-                                    name="format"
-                                    label="Format"
-                                    options={formatDropdownOptions}
-                                    component={FormikSelectField}
-                                />
-                                <Field
-                                    name="setName"
-                                    label="Edition"
-                                    options={editionDropdownOptions}
-                                    component={FormikSelectField}
-                                    search
-                                />
-                                <Field
-                                    name="finish"
-                                    label="Finish"
-                                    options={finishDropdownOptions}
-                                    component={FormikSelectField}
-                                />
-                            </Form.Group>
-                            <Form.Group widths="4">
-                                <Field
-                                    name="colorsArray"
-                                    label="Colors"
-                                    options={sortByColorDropdownOptions}
-                                    component={FormikSelectField}
-                                    multiple
-                                />
-                                <Field
-                                    name="colorSpecificity"
-                                    label="Color specificity"
-                                    options={colorSpecificityDropdownOptions}
-                                    component={FormikSelectField}
-                                />
-                                <Field
-                                    name="typeLine"
-                                    label="Type Line"
-                                    options={typeLineOptions}
-                                    component={FormikSelectField}
-                                />
-                                <Field
-                                    name="frame"
-                                    label="Frame Effects"
-                                    options={frameOptions}
-                                    component={FormikSelectField}
-                                />
-                                <Form.Field>
-                                    <label>Price Filter</label>
-                                    <Input
-                                        label={
-                                            <Field
-                                                name="priceOperator"
-                                                options={
-                                                    priceOperatorDropdownOptions
-                                                }
-                                                component={FormikDropdown}
-                                                defaultValue="gte"
-                                            />
-                                        }
-                                        placeholder="Enter a price"
-                                        labelPosition="left"
-                                        name="price"
-                                        type="number"
-                                        onChange={handleChange}
-                                    />
-                                </Form.Field>
-                            </Form.Group>
-                            <h3>{'Sort & Order'}</h3>
-                            <Form.Group>
-                                <Field
-                                    name="sortBy"
-                                    label="Sort by"
-                                    options={sortByDropdownOptions}
-                                    component={FormikSelectField}
-                                    defaultValue={initialFilters.price}
-                                />
-                                <Field
-                                    name="sortByDirection"
-                                    label="Order"
-                                    options={sortByDirectionDropdownOptions}
-                                    component={FormikSelectField}
-                                    defaultValue={
-                                        initialFilters.sortByDirection
+
+            <Form>
+                <Form.Group widths="4">
+                    <FormikSearchBar
+                        label="Card name"
+                        onChange={(v) => setFieldValue('title', v)}
+                    />
+                    <FormSelectField
+                        name="format"
+                        label="Format"
+                        options={formatDropdownOptions}
+                        onChange={(v) => setFieldValue('format', v)}
+                    />
+                    <FormSelectField
+                        name="setName"
+                        label="Edition"
+                        options={editionDropdownOptions}
+                        onChange={(v) => setFieldValue('setName', v)}
+                        search
+                    />
+                    <FormSelectField
+                        name="finish"
+                        label="Finish"
+                        options={finishDropdownOptions}
+                        onChange={(v) => setFieldValue('finish', v)}
+                    />
+                </Form.Group>
+                <Form.Group widths="4">
+                    <FormSelectField
+                        name="colorsArray"
+                        label="Colors"
+                        options={sortByColorDropdownOptions}
+                        onChange={(v) => setFieldValue('colorsArray', v)}
+                        multiple
+                    />
+                    <FormSelectField
+                        name="colorSpecificity"
+                        label="Color specificity"
+                        options={colorSpecificityDropdownOptions}
+                        onChange={(v) => setFieldValue('colorSpecificity', v)}
+                    />
+                    <FormSelectField
+                        name="typeLine"
+                        label="Type Line"
+                        options={typeLineOptions}
+                        onChange={(v) => setFieldValue('typeLine', v)}
+                    />
+                    <FormSelectField
+                        name="frame"
+                        label="Frame Effects"
+                        options={frameOptions}
+                        onChange={(v) => setFieldValue('frame', v)}
+                    />
+                    <Form.Field>
+                        <label>Price Filter</label>
+                        <Input
+                            label={
+                                <FormikDropdown
+                                    name="priceOperator"
+                                    options={priceOperatorDropdownOptions}
+                                    onChange={(v) =>
+                                        setFieldValue('priceOperator', v)
                                     }
+                                    defaultValue="gte"
                                 />
-                            </Form.Group>
-                            <Form.Group>
-                                <Form.Button type="submit" primary>
-                                    Submit
-                                </Form.Button>
-                            </Form.Group>
-                        </Form>
-                    </FormikForm>
-                )}
-            </Formik>
+                            }
+                            placeholder="Enter a price"
+                            labelPosition="left"
+                            name="price"
+                            type="number"
+                            onChange={handleChange}
+                        />
+                    </Form.Field>
+                </Form.Group>
+                <h3>{'Sort & Order'}</h3>
+                <Form.Group>
+                    <FormSelectField
+                        name="sortBy"
+                        label="Sort by"
+                        options={sortByDropdownOptions}
+                        defaultValue={initialFilters.price}
+                        onChange={(v) => setFieldValue('sortBy', v)}
+                    />
+                    <FormSelectField
+                        name="sortByDirection"
+                        label="Order"
+                        options={sortByDirectionDropdownOptions}
+                        defaultValue={initialFilters.sortByDirection}
+                        onChange={(v) => setFieldValue('sortByDirection', v)}
+                    />
+                </Form.Group>
+                <Form.Group>
+                    <Form.Button
+                        type="submit"
+                        onClick={() => handleSubmit()}
+                        primary
+                    >
+                        Submit
+                    </Form.Button>
+                </Form.Group>
+            </Form>
         </Segment>
     );
 };

--- a/frontend/src/Login/Login.tsx
+++ b/frontend/src/Login/Login.tsx
@@ -43,7 +43,6 @@ const locationDropdownOptions = [
     },
 ];
 
-// No validations needed for now
 const validate = ({ username, password, location }: FormValues) => {
     const errors: FormikErrors<FormValues> = {};
 

--- a/frontend/src/Login/Login.tsx
+++ b/frontend/src/Login/Login.tsx
@@ -4,7 +4,7 @@ import { Form, Button, Segment } from 'semantic-ui-react';
 import { Redirect } from 'react-router-dom';
 import { ClubhouseLocation, useAuthContext } from '../context/AuthProvider';
 import styled from 'styled-components';
-import { useFormik } from 'formik';
+import { FormikErrors, useFormik } from 'formik';
 import FormikSelectField from '../ui/FormikSelectField';
 
 interface FormValues {
@@ -45,7 +45,7 @@ const locationDropdownOptions = [
 
 // No validations needed for now
 const validate = ({ username, password, location }: FormValues) => {
-    const errors: Partial<Record<keyof FormValues, string>> = {};
+    const errors: FormikErrors<FormValues> = {};
 
     if (!username) {
         errors.username = 'Required';

--- a/frontend/src/ManageInventory/ManageInventoryListItem.tsx
+++ b/frontend/src/ManageInventory/ManageInventoryListItem.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useContext, useState } from 'react';
 import { Segment, Input, Button, Form, Select, Item } from 'semantic-ui-react';
 import $ from 'jquery';
-import { Formik, FormikErrors, FormikHelpers } from 'formik';
+import { FormikErrors, FormikHelpers, useFormik } from 'formik';
 import createToast from '../common/createToast';
 import CardImage from '../common/CardImage';
 import { finishes, cardConditions } from '../utils/dropdownOptions';
@@ -23,6 +23,16 @@ interface FormValues {
 
 type Finish = 'FOIL' | 'NONFOIL';
 
+const validate = ({ quantity }: FormValues) => {
+    let errors: FormikErrors<FormValues> = {};
+
+    if (!Number(quantity) || !Number.isInteger(+quantity) || +quantity > 100) {
+        errors.quantity = 'error';
+    }
+
+    return errors;
+};
+
 const ManageInventoryListItem: FC<Props> = ({ card }) => {
     const { foil, nonfoil, name, set_name, set, id, cardImage } = card;
 
@@ -36,19 +46,6 @@ const ManageInventoryListItem: FC<Props> = ({ card }) => {
         selectedFinish: checkCardFinish(nonfoil, foil).selectedFinish,
         selectedCondition: 'NM',
         quantity: '0',
-    };
-
-    const validate = ({ quantity }: FormValues) => {
-        let errors: FormikErrors<FormValues> = {};
-
-        if (
-            !Number(quantity) ||
-            !Number.isInteger(+quantity) ||
-            +quantity > 100
-        )
-            errors.quantity = 'error';
-
-        return errors;
     };
 
     const onSubmit = async (
@@ -82,6 +79,18 @@ const ManageInventoryListItem: FC<Props> = ({ card }) => {
         }
     };
 
+    const {
+        values,
+        handleSubmit,
+        setFieldValue,
+        isSubmitting,
+        isValid,
+    } = useFormik({
+        initialValues: initialFormValues,
+        validate,
+        onSubmit,
+    });
+
     return (
         <Segment>
             <Item.Group divided>
@@ -96,99 +105,70 @@ const ManageInventoryListItem: FC<Props> = ({ card }) => {
                             round
                         />
                         <Item.Description>
-                            <Formik
-                                initialValues={initialFormValues}
-                                validate={validate}
-                                onSubmit={onSubmit}
-                                initialErrors={{ quantity: 'error' }}
-                            >
-                                {({
-                                    values,
-                                    handleSubmit,
-                                    setFieldValue,
-                                    isSubmitting,
-                                    isValid,
-                                }) => (
-                                    <Form>
-                                        <Form.Group>
-                                            <Form.Field
-                                                control={Input}
-                                                type="number"
-                                                label="Quantity"
-                                                value={values.quantity}
-                                                onChange={(
-                                                    _: any,
-                                                    { value }: { value: number }
-                                                ) =>
-                                                    setFieldValue(
-                                                        'quantity',
-                                                        value
-                                                    )
-                                                }
-                                                onFocus={() => {
-                                                    if (
-                                                        +values.quantity === 0
-                                                    ) {
-                                                        setFieldValue(
-                                                            'quantity',
-                                                            ''
-                                                        );
-                                                    }
-                                                }}
-                                            />
-                                            <Form.Field
-                                                label="Finish"
-                                                control={Select}
-                                                value={values.selectedFinish}
-                                                options={finishes}
-                                                disabled={
-                                                    checkCardFinish(
-                                                        nonfoil,
-                                                        foil
-                                                    ).finishDisabled
-                                                }
-                                                onChange={(
-                                                    _: any,
-                                                    { value }: { value: Finish }
-                                                ) => {
-                                                    setSelectedFinish(value);
-                                                    setFieldValue(
-                                                        'selectedFinish',
-                                                        value
-                                                    );
-                                                }}
-                                            />
-                                            <Form.Field
-                                                label="Condition"
-                                                control={Select}
-                                                value={values.selectedCondition}
-                                                options={cardConditions}
-                                                onChange={(
-                                                    _: any,
-                                                    { value }: { value: string }
-                                                ) =>
-                                                    setFieldValue(
-                                                        'selectedCondition',
-                                                        value
-                                                    )
-                                                }
-                                            />
-                                            <Form.Button
-                                                label="Add to Inventory?"
-                                                control={Button}
-                                                primary
-                                                disabled={
-                                                    !isValid || isSubmitting
-                                                }
-                                                onClick={() => handleSubmit()}
-                                                loading={isSubmitting}
-                                            >
-                                                Submit
-                                            </Form.Button>
-                                        </Form.Group>
-                                    </Form>
-                                )}
-                            </Formik>
+                            <Form>
+                                <Form.Group>
+                                    <Form.Field
+                                        control={Input}
+                                        type="number"
+                                        label="Quantity"
+                                        value={values.quantity}
+                                        onChange={(
+                                            _: any,
+                                            { value }: { value: number }
+                                        ) => setFieldValue('quantity', value)}
+                                        onFocus={() => {
+                                            if (+values.quantity === 0) {
+                                                setFieldValue('quantity', '');
+                                            }
+                                        }}
+                                    />
+                                    <Form.Field
+                                        label="Finish"
+                                        control={Select}
+                                        value={values.selectedFinish}
+                                        options={finishes}
+                                        disabled={
+                                            checkCardFinish(nonfoil, foil)
+                                                .finishDisabled
+                                        }
+                                        onChange={(
+                                            _: any,
+                                            { value }: { value: Finish }
+                                        ) => {
+                                            setSelectedFinish(value);
+                                            setFieldValue(
+                                                'selectedFinish',
+                                                value
+                                            );
+                                        }}
+                                    />
+                                    <Form.Field
+                                        label="Condition"
+                                        control={Select}
+                                        value={values.selectedCondition}
+                                        options={cardConditions}
+                                        onChange={(
+                                            _: any,
+                                            { value }: { value: string }
+                                        ) =>
+                                            setFieldValue(
+                                                'selectedCondition',
+                                                value
+                                            )
+                                        }
+                                    />
+                                    <Form.Button
+                                        label="Add to Inventory?"
+                                        control={Button}
+                                        primary
+                                        disabled={!isValid || isSubmitting}
+                                        onClick={() => handleSubmit()}
+                                        loading={isSubmitting}
+                                    >
+                                        Submit
+                                    </Form.Button>
+                                </Form.Group>
+                            </Form>
                         </Item.Description>
                     </Item.Content>
                 </Item>

--- a/frontend/src/NewSale/BrowseCardItem.tsx
+++ b/frontend/src/NewSale/BrowseCardItem.tsx
@@ -62,8 +62,6 @@ const BrowseCardItem: FC<Props> = ({ card }) => {
     }: FormValues) => {
         addToSaleList(card, selectedFinishCondition, quantityToSell, price);
 
-        // TODO: Clear whole sale context state when a sate completes
-
         // Highlight the input after successful card add
         $('#searchBar').focus().select();
     };
@@ -129,7 +127,6 @@ const BrowseCardItem: FC<Props> = ({ card }) => {
                             round
                         />
                         <Item.Description>
-                            <pre>{JSON.stringify({ values }, null, 2)}</pre>
                             <Form>
                                 <Form.Group>
                                     <FormikSelectField

--- a/frontend/src/NewSale/BrowseCardItem.tsx
+++ b/frontend/src/NewSale/BrowseCardItem.tsx
@@ -195,6 +195,7 @@ const BrowseCardItem: FC<Props> = ({ card }) => {
                                         step={0.5}
                                     />
                                     <Form.Button
+                                        type="submit"
                                         label="Add to sale?"
                                         control={Button}
                                         primary

--- a/frontend/src/NewSale/BrowseCardItem.tsx
+++ b/frontend/src/NewSale/BrowseCardItem.tsx
@@ -1,28 +1,17 @@
-import React, {
-    useState,
-    useContext,
-    FC,
-    SyntheticEvent,
-    ChangeEvent,
-} from 'react';
-import {
-    Segment,
-    Form,
-    Input,
-    Dropdown,
-    Button,
-    Item,
-} from 'semantic-ui-react';
+import React, { useContext, FC, ChangeEvent } from 'react';
+import { Segment, Form, Input, Button, Item } from 'semantic-ui-react';
 import $ from 'jquery';
 import _ from 'lodash';
 import CardImage from '../common/CardImage';
 import { SaleContext } from '../context/SaleContext';
 import { ScryfallCard, QOH } from '../utils/ScryfallCard';
 import CardHeader from '../ui/CardHeader';
+import { FormikErrors, useFormik } from 'formik';
+import FormikSelectField from '../ui/FormikSelectField';
 
 interface ConditionOptions {
     text: string;
-    value: string;
+    value: keyof QOH;
     key: string;
 }
 
@@ -43,7 +32,7 @@ function createConditionOptions(
 
         return {
             text: `${conditionFinish.split('_').join(' | ')} | Qty: ${qty}`,
-            value: conditionFinish,
+            value: conditionFinish as keyof QOH,
             key: `${id}${conditionFinish}`,
         };
     });
@@ -51,19 +40,10 @@ function createConditionOptions(
 
 type Finish = 'FOIL' | 'NONFOIL';
 
-/**
- * Creates initial selectedFinish value, used for the MarketPrice component
- * Returns FOIL or NONFOIL depending on what's in current inventory (qoh)
- * @param {Object} qoh
- */
-function createInitialSelectedFinish(qoh: Partial<QOH>): Finish {
-    const removeZeroedQuantites = _.pickBy(qoh, (p) => p && p > 0);
-    // Isolate only the FOIL or NONFOIL values with mapping
-    const keysMapped = _.keys(removeZeroedQuantites).map(
-        (k) => k.split('_')[0]
-    );
-    const uniqueValues = _.uniq(keysMapped);
-    return uniqueValues.indexOf('NONFOIL') > -1 ? 'NONFOIL' : 'FOIL';
+interface FormValues {
+    quantityToSell: number;
+    price: number;
+    selectedFinishCondition: keyof QOH;
 }
 
 interface Props {
@@ -71,92 +51,64 @@ interface Props {
 }
 
 const BrowseCardItem: FC<Props> = ({ card }) => {
-    const [selectedFinishCondition, setSelectedFinishCondition] = useState<
-        string
-    >('');
-    const [
-        selectedFinishConditionQty,
-        setSelectedFinishConditionQty,
-    ] = useState<number>(0);
-    const [quantityToSell, setQuantityToSell] = useState<number | null>(0);
-    const [price, setPrice] = useState<number | null>(0);
-    const [selectedFinish, setSelectedFinish] = useState<Finish>(
-        createInitialSelectedFinish(card.qoh)
-    );
-    const [conditionOptions, setConditionOptions] = useState<
-        ConditionOptions[]
-    >(createConditionOptions(card.qoh, card.id));
     const { addToSaleList } = useContext(SaleContext);
 
-    const handleQuantityChange = (
-        e: SyntheticEvent,
-        { value }: { value: string }
-    ) => {
-        if (value === '') {
-            setQuantityToSell(null);
-            return;
-        }
+    const conditionSelectOptions = createConditionOptions(card.qoh, card.id);
 
-        let numVal = parseInt(value);
+    const handleAddToSale = ({
+        selectedFinishCondition,
+        quantityToSell,
+        price,
+    }: FormValues) => {
+        addToSaleList(card, selectedFinishCondition, quantityToSell, price);
 
-        if (numVal > selectedFinishConditionQty)
-            numVal = selectedFinishConditionQty;
-
-        if (isNaN(numVal) || numVal < 0) numVal = 0;
-
-        setQuantityToSell(numVal);
-    };
-
-    const handleSelectedFinishCondition = (
-        e: SyntheticEvent,
-        { value }: { value: keyof QOH }
-    ) => {
-        // TODO: we need to not coerce here
-        setSelectedFinish(value.split('_')[0] as Finish);
-        setSelectedFinishCondition(value);
-        setSelectedFinishConditionQty(card.qoh[value] || 0);
-        setQuantityToSell(0);
-    };
-
-    const handlePriceChange = (
-        e: SyntheticEvent,
-        { value }: { value: string }
-    ) => {
-        if (value === '') {
-            setPrice(null);
-            return;
-        }
-
-        let numVal = Number(value);
-
-        if (isNaN(numVal) || numVal < 0) {
-            numVal = 0;
-        }
-
-        setPrice(numVal);
-    };
-
-    const handleAddToSale = () => {
-        const { id } = card;
-
-        addToSaleList(
-            card,
-            selectedFinishCondition,
-            quantityToSell || 0,
-            price || 0
-        );
-
-        // Reset state
-        setSelectedFinishCondition('');
-        setSelectedFinishConditionQty(0);
-        setQuantityToSell(0);
-        setPrice(0);
-        setConditionOptions(createConditionOptions(card.qoh, id));
-        setSelectedFinish(createInitialSelectedFinish(card.qoh));
+        // TODO: Clear whole sale context state when a sate completes
 
         // Highlight the input after successful card add
         $('#searchBar').focus().select();
     };
+
+    const initialFormValues = {
+        selectedFinishCondition: conditionSelectOptions[0].value,
+        price: 0,
+        quantityToSell: 0,
+    };
+
+    const validate = ({
+        quantityToSell,
+        price,
+        selectedFinishCondition: selectedFinish,
+    }: FormValues) => {
+        const errors: FormikErrors<FormValues> = {};
+
+        if (!quantityToSell) errors.quantityToSell = 'error';
+        if (!price) errors.price = 'error';
+
+        if (!selectedFinish) {
+            errors.selectedFinishCondition = 'error';
+        }
+
+        if (quantityToSell > card.qoh[selectedFinish]!) {
+            errors.quantityToSell = 'error';
+        }
+
+        if (price < 0) {
+            errors.price = 'error';
+        }
+
+        if (quantityToSell < 1) {
+            errors.quantityToSell = 'error';
+        }
+
+        return errors;
+    };
+
+    const { handleSubmit, setFieldValue, values, isValid } = useFormik({
+        initialValues: initialFormValues,
+        validate,
+        onSubmit: handleAddToSale,
+        validateOnMount: true,
+    });
 
     return (
         <Segment>
@@ -168,58 +120,86 @@ const BrowseCardItem: FC<Props> = ({ card }) => {
                     <Item.Content>
                         <CardHeader
                             card={card}
-                            selectedFinish={selectedFinish}
+                            selectedFinish={
+                                values.selectedFinishCondition.split(
+                                    '_'
+                                )[0] as Finish
+                            }
                             showMid
                             round
                         />
                         <Item.Description>
+                            <pre>{JSON.stringify({ values }, null, 2)}</pre>
                             <Form>
                                 <Form.Group>
-                                    <Form.Field
-                                        className="finish-condition"
-                                        control={Dropdown}
-                                        selection
-                                        placeholder="Select inventory"
-                                        options={conditionOptions}
-                                        value={selectedFinishCondition}
+                                    <FormikSelectField
                                         label="Select finish/condition"
-                                        onChange={handleSelectedFinishCondition}
+                                        name="selectedFinishCondition"
+                                        options={conditionSelectOptions}
+                                        defaultValue={
+                                            initialFormValues.selectedFinishCondition
+                                        }
+                                        onChange={(v) => {
+                                            setFieldValue(
+                                                'selectedFinishCondition',
+                                                v
+                                            );
+                                            setFieldValue('quantityToSell', 0);
+                                        }}
                                     />
                                     <Form.Field
-                                        className="sale-qty"
                                         control={Input}
                                         type="number"
                                         label="Quantity to sell"
-                                        value={quantityToSell}
-                                        onChange={handleQuantityChange}
-                                        disabled={!selectedFinishConditionQty}
+                                        value={values.quantityToSell}
+                                        onChange={(
+                                            _: any,
+                                            { value }: { value: string }
+                                        ) => {
+                                            const castVal = parseInt(value, 10);
+
+                                            if (
+                                                castVal >
+                                                card.qoh[
+                                                    values
+                                                        .selectedFinishCondition
+                                                ]!
+                                            ) {
+                                                return;
+                                            }
+
+                                            setFieldValue(
+                                                'quantityToSell',
+                                                castVal
+                                            );
+                                        }}
                                         onFocus={(
                                             e: ChangeEvent<HTMLInputElement>
                                         ) => e.target.select()}
                                     />
                                     <Form.Field
-                                        className="sale-price"
                                         control={Input}
                                         type="number"
                                         label="Price"
-                                        value={price}
-                                        onChange={handlePriceChange}
-                                        disabled={!selectedFinishConditionQty}
+                                        value={values.price}
+                                        onChange={(
+                                            _: any,
+                                            { value }: { value: string }
+                                        ) => {
+                                            const castVal = parseFloat(value);
+                                            setFieldValue('price', castVal);
+                                        }}
                                         onFocus={(
                                             e: ChangeEvent<HTMLInputElement>
                                         ) => e.target.select()}
                                         step={0.5}
                                     />
                                     <Form.Button
-                                        className="add-to-sale"
                                         label="Add to sale?"
                                         control={Button}
                                         primary
-                                        onClick={handleAddToSale}
-                                        disabled={
-                                            !quantityToSell ||
-                                            quantityToSell <= 0
-                                        }
+                                        onClick={() => handleSubmit()}
+                                        disabled={!isValid}
                                     >
                                         Sell
                                     </Form.Button>

--- a/frontend/src/NewSale/Sale.tsx
+++ b/frontend/src/NewSale/Sale.tsx
@@ -1,18 +1,15 @@
-import React, { useState, useContext, FC } from 'react';
-import $ from 'jquery';
+import React, { useContext, FC } from 'react';
 import { Grid, Header, Divider } from 'semantic-ui-react';
 import SearchBar from '../common/SearchBar';
 import BrowseCardList from './BrowseCardList';
 import CustomerSaleList from './CustomerSaleList';
 import PrintList from './PrintList';
 import SuspendSales from './SuspendedSale';
-import { ScryfallCard } from '../utils/ScryfallCard';
 import { SaleContext } from '../context/SaleContext';
 import TotalCardsLabel from '../common/TotalCardsLabel';
 import AllLocationInventory from '../ManageInventory/AllLocationInventory';
 import styled from 'styled-components';
 import sum from '../utils/sum';
-import cardSearchQuery from '../context/cardSearchQuery';
 
 interface Props {}
 
@@ -31,28 +28,14 @@ const ButtonContainer = styled('div')({
 const Sale: FC<Props> = () => {
     const {
         saleListCards,
+        searchTerm,
+        searchResults,
+        handleResultSelect,
         suspendedSale,
         restoreSale,
         deleteSuspendedSale,
         suspendSale,
     } = useContext(SaleContext);
-
-    const [searchResults, setSearchResults] = useState<ScryfallCard[]>([]);
-    const [searchTerm, setSearchTerm] = useState<string>('');
-
-    const handleResultSelect = async (term: string) => {
-        const cards = await cardSearchQuery({
-            cardName: term,
-            inStockOnly: true,
-        });
-
-        setSearchResults(cards);
-        setSearchTerm(term);
-
-        if (cards.length === 0) {
-            $('#searchBar').focus().select();
-        }
-    };
 
     return (
         <>

--- a/frontend/src/PublicInventory/PublicInventory.tsx
+++ b/frontend/src/PublicInventory/PublicInventory.tsx
@@ -2,7 +2,7 @@ import React, { FC, SyntheticEvent, useState } from 'react';
 import { Grid, Segment, Header, Icon, Form, Select } from 'semantic-ui-react';
 import SearchBar from '../common/SearchBar';
 import { ScryfallCard } from '../utils/ScryfallCard';
-import { Formik } from 'formik';
+import { FormikErrors, useFormik } from 'formik';
 import { ClubhouseLocation } from '../context/AuthProvider';
 import styled from 'styled-components';
 import PublicCardItem from './PublicCardItem';
@@ -46,6 +46,16 @@ const locationOptions = [
     { key: 'hillsboro', text: 'CH Hillsboro', value: 'ch2' },
 ];
 
+const validate = ({ searchTerm }: FormValues) => {
+    let errors: FormikErrors<FormValues> = {};
+
+    if (!searchTerm) {
+        errors.searchTerm = 'error';
+    }
+
+    return errors;
+};
+
 const PublicInventory: FC = () => {
     const [state, setState] = useState<State>(initialState);
     const [formSubmitted, setFormSubmitted] = useState<boolean>(false);
@@ -73,56 +83,54 @@ const PublicInventory: FC = () => {
         }
     };
 
+    const onSubmit = async ({ searchTerm, selectedLocation }: FormValues) => {
+        await fetchCards({
+            title: searchTerm,
+            location: selectedLocation,
+        });
+
+        setFormSubmitted(true);
+    };
+
+    const { values, handleSubmit, setFieldValue, isSubmitting } = useFormik({
+        initialValues: initialFormState,
+        validate,
+        onSubmit,
+    });
+
     return (
         <>
-            <Formik
-                onSubmit={async ({
-                    searchTerm,
-                    selectedLocation,
-                }: FormValues) => {
-                    await fetchCards({
-                        title: searchTerm,
-                        location: selectedLocation,
-                    });
-
-                    setFormSubmitted(true);
-                }}
-                initialValues={initialFormState}
-            >
-                {({ values, handleSubmit, setFieldValue, isSubmitting }) => (
-                    <Form>
-                        <StyledFormGroup widths="5">
-                            <Form.Field>
-                                <label>Card search</label>
-                                <SearchBar
-                                    handleSearchSelect={(value) =>
-                                        setFieldValue('searchTerm', value)
-                                    }
-                                />
-                            </Form.Field>
-                            <Form.Field
-                                label="Store location"
-                                control={Select}
-                                value={values.selectedLocation}
-                                options={locationOptions}
-                                onChange={(
-                                    _: SyntheticEvent,
-                                    { value }: { value: ClubhouseLocation }
-                                ) => setFieldValue('selectedLocation', value)}
-                            />
-                            <Form.Button
-                                type="submit"
-                                primary
-                                disabled={!values.searchTerm}
-                                loading={isSubmitting}
-                                onClick={() => handleSubmit()}
-                            >
-                                Search
-                            </Form.Button>
-                        </StyledFormGroup>
-                    </Form>
-                )}
-            </Formik>
+            <Form>
+                <StyledFormGroup widths="5">
+                    <Form.Field>
+                        <label>Card search</label>
+                        <SearchBar
+                            handleSearchSelect={(value) =>
+                                setFieldValue('searchTerm', value)
+                            }
+                        />
+                    </Form.Field>
+                    <Form.Field
+                        label="Store location"
+                        control={Select}
+                        value={values.selectedLocation}
+                        options={locationOptions}
+                        onChange={(
+                            _: SyntheticEvent,
+                            { value }: { value: ClubhouseLocation }
+                        ) => setFieldValue('selectedLocation', value)}
+                    />
+                    <Form.Button
+                        type="submit"
+                        primary
+                        disabled={!values.searchTerm}
+                        loading={isSubmitting}
+                        onClick={() => handleSubmit()}
+                    >
+                        Search
+                    </Form.Button>
+                </StyledFormGroup>
+            </Form>
             <br />
             <Grid stackable={true}>
                 <Grid.Column>

--- a/frontend/src/Receiving/ReceivingListModal.tsx
+++ b/frontend/src/Receiving/ReceivingListModal.tsx
@@ -2,7 +2,7 @@ import React, { useState, useContext, FC } from 'react';
 import { Modal, Button, Form, List, Header } from 'semantic-ui-react';
 import { ReceivingContext, Trade } from '../context/ReceivingContext';
 import Price from '../common/Price';
-import { useFormik } from 'formik';
+import { FormikErrors, useFormik } from 'formik';
 import sum from '../utils/sum';
 
 interface Props {}
@@ -19,7 +19,7 @@ const initialFormValues: FormValues = {
 
 // TODO: Extract and generalize this
 const validate = ({ customerName, customerContact }: FormValues) => {
-    const errors: Partial<Record<keyof FormValues, string>> = {};
+    const errors: FormikErrors<FormValues> = {};
 
     if (!customerName) {
         errors.customerName = 'Required';

--- a/frontend/src/Receiving/ReceivingSearchItem.tsx
+++ b/frontend/src/Receiving/ReceivingSearchItem.tsx
@@ -95,8 +95,6 @@ const ReceivingSearchItem: FC<Props> = ({ card }) => {
             duration: 2000,
         });
 
-        // TODO: reset the form imperatively
-
         // Highlight the input after successful card add
         $('#searchBar').focus().select();
     };
@@ -110,7 +108,10 @@ const ReceivingSearchItem: FC<Props> = ({ card }) => {
     } = useFormik({
         initialValues,
         validate,
-        onSubmit: handleInventoryAdd,
+        onSubmit: (v, { resetForm }) => {
+            handleInventoryAdd(v);
+            resetForm();
+        },
         validateOnMount: true,
     });
 

--- a/frontend/src/Receiving/ReceivingSearchItem.tsx
+++ b/frontend/src/Receiving/ReceivingSearchItem.tsx
@@ -1,6 +1,6 @@
-import React, { useState, useContext, FC, ChangeEvent } from 'react';
+import React, { useContext, FC, ChangeEvent } from 'react';
 import $ from 'jquery';
-import { Segment, Input, Button, Form, Select, Item } from 'semantic-ui-react';
+import { Segment, Input, Button, Form, Item } from 'semantic-ui-react';
 import CardImage from '../common/CardImage';
 import createToast from '../common/createToast';
 import { ReceivingContext } from '../context/ReceivingContext';
@@ -8,20 +8,61 @@ import { finishes, cardConditions } from '../utils/dropdownOptions';
 import checkCardFinish, { Finish } from '../utils/checkCardFinish';
 import { ScryfallCard } from '../utils/ScryfallCard';
 import CardHeader from '../ui/CardHeader';
+import { FormikErrors, useFormik } from 'formik';
+import FormikSelectField from '../ui/FormikSelectField';
 
 interface Props {
     card: ScryfallCard;
 }
 
+type Condition = 'NM' | 'LP' | 'MP' | 'HP';
+
+interface FormValues {
+    quantity: number;
+    cashPrice: number;
+    creditPrice: number;
+    marketPrice: number;
+    selectedCondition: Condition;
+    selectedFinish: Finish;
+}
+
+const validate = ({
+    quantity,
+    cashPrice,
+    creditPrice,
+    marketPrice,
+    selectedFinish,
+    selectedCondition,
+}: FormValues) => {
+    const errors: FormikErrors<FormValues> = {};
+
+    if (!quantity) errors.quantity = 'error';
+
+    if (!cashPrice && !creditPrice) {
+        errors.cashPrice = 'error';
+        errors.creditPrice = 'error';
+    }
+
+    if (cashPrice) {
+        // Cards with cash prices must have market prices specified
+        if (!marketPrice) errors.marketPrice = 'error';
+    }
+
+    if (!selectedFinish) errors.selectedFinish = 'error';
+    if (!selectedCondition) errors.selectedCondition = 'error';
+
+    return errors;
+};
+
 const ReceivingSearchItem: FC<Props> = ({ card }) => {
-    const [quantity, setQuantity] = useState<number | null>(1);
-    const [cashPrice, setCashPrice] = useState<number | null>(0);
-    const [creditPrice, setCreditPrice] = useState<number | null>(0);
-    const [selectedCondition, setSelectedCondition] = useState<string>('NM');
-    const [marketPrice, setMarketPrice] = useState<number | null>(0);
-    const [selectedFinish, setSelectedFinish] = useState<Finish>(
-        checkCardFinish(card.nonfoil, card.foil).selectedFinish // seed state from props
-    );
+    const initialValues: FormValues = {
+        quantity: 1,
+        cashPrice: 0,
+        creditPrice: 0,
+        marketPrice: 0,
+        selectedCondition: 'NM',
+        selectedFinish: checkCardFinish(card.nonfoil, card.foil).selectedFinish,
+    };
 
     // Determines whether the select finish dropdown is permanently disabled, seeded from props
     const finishDisabled = checkCardFinish(card.nonfoil, card.foil)
@@ -29,95 +70,49 @@ const ReceivingSearchItem: FC<Props> = ({ card }) => {
 
     const { addToList } = useContext(ReceivingContext);
 
-    const handleFinishChange = (
-        e: ChangeEvent<HTMLInputElement>,
-        { value }: { value: Finish }
-    ) => setSelectedFinish(value);
-
-    const handleConditionChange = (
-        e: ChangeEvent<HTMLInputElement>,
-        { value }: { value: string }
-    ) => setSelectedCondition(value);
-
-    // Validates/sanitizes user inputs by tracking the `name` attribute of the input element
-    const handlePriceChange = (
-        e: ChangeEvent<HTMLInputElement>,
-        { value }: { value: string }
-    ) => {
-        let val: number | null = Number(value) || 0;
-        if (val < 0) val = 0;
-        if (value === '') val = null;
-
-        switch (e.target.name) {
-            case 'cashInput':
-                setCashPrice(val);
-                break;
-            case 'marketPriceInput':
-                setMarketPrice(val);
-                break;
-            case 'creditInput':
-                setCreditPrice(val);
-                break;
-            default:
-                break;
-        }
-    };
-
-    const handleQuantityChange = (
-        e: ChangeEvent<HTMLInputElement>,
-        { value }: { value: string }
-    ) => {
-        let val = parseInt(value, 10) || 0;
-        if (val < 0) val = 0; // cannot receive less than 0
-        if (val > 50) val = 50; // set max to 50 cards per single transaction
-        setQuantity(val);
-    };
-
     const handleFocus = (e: ChangeEvent<HTMLInputElement>) => e.target.select();
 
-    const handleInventoryAdd = () => {
-        if (quantity) {
-            addToList(quantity, card, {
-                cashPrice,
-                marketPrice,
-                creditPrice,
-                finishCondition: `${selectedFinish}_${selectedCondition}`, // ex. NONFOIL_NM
-            });
+    const handleInventoryAdd = ({
+        quantity,
+        cashPrice,
+        creditPrice,
+        marketPrice,
+        selectedFinish,
+        selectedCondition,
+    }: FormValues) => {
+        if (!quantity) throw new Error('Quantity is missing');
 
-            setQuantity(1);
-            setCashPrice(0);
-            setMarketPrice(0);
-            setCreditPrice(0);
-            setSelectedCondition('NM');
-            setSelectedFinish(
-                checkCardFinish(card.nonfoil, card.foil).selectedFinish
-            );
+        addToList(quantity, card, {
+            cashPrice: cashPrice || 0,
+            marketPrice: marketPrice || 0,
+            creditPrice: creditPrice || 0,
+            finishCondition: `${selectedFinish}_${selectedCondition}`, // ex. NONFOIL_NM
+        });
 
-            createToast({
-                color: 'green',
-                header: `${quantity}x ${card.name} added to buylist!`,
-                duration: 2000,
-            });
-        }
+        createToast({
+            color: 'green',
+            header: `${quantity}x ${card.name} added to buylist!`,
+            duration: 2000,
+        });
+
+        // TODO: reset the form imperatively
 
         // Highlight the input after successful card add
         $('#searchBar').focus().select();
     };
 
-    /**
-     * Determines whether the `Add` button should be disabled
-     */
-    const submitDisabled = () => {
-        const validateQty = !quantity;
-        const validateTradeTypes = !(cashPrice || creditPrice);
-        const validateMarketPrice = !marketPrice;
-
-        if (!!cashPrice) {
-            return validateQty || validateTradeTypes || validateMarketPrice;
-        }
-
-        return validateQty || validateTradeTypes;
-    };
+    const {
+        handleSubmit,
+        setFieldValue,
+        values,
+        isValid,
+        handleChange,
+    } = useFormik({
+        initialValues,
+        validate,
+        onSubmit: handleInventoryAdd,
+        validateOnMount: true,
+    });
 
     const { cardImage } = card;
 
@@ -131,7 +126,7 @@ const ReceivingSearchItem: FC<Props> = ({ card }) => {
                     <Item.Content>
                         <CardHeader
                             card={card}
-                            selectedFinish={selectedFinish}
+                            selectedFinish={values.selectedFinish}
                             showMid
                         />
                         <Item.Description>
@@ -142,75 +137,93 @@ const ReceivingSearchItem: FC<Props> = ({ card }) => {
                                         control={Input}
                                         type="number"
                                         label="Quantity"
-                                        value={quantity}
-                                        onChange={handleQuantityChange}
+                                        value={values.quantity}
+                                        onChange={(
+                                            _: any,
+                                            { value }: { value: string }
+                                        ) => {
+                                            const castVal = parseInt(value);
+                                            setFieldValue(
+                                                'quantity',
+                                                Math.min(
+                                                    castVal < 0 ? 0 : castVal,
+                                                    50
+                                                )
+                                            );
+                                        }}
                                         onFocus={(
                                             e: ChangeEvent<HTMLInputElement>
                                         ) => e.target.select()}
-                                        className="receiving-quantity"
                                     />
                                     <Form.Field
                                         fluid
                                         label="Credit Price"
-                                        name="creditInput"
+                                        name="creditPrice"
                                         control={Input}
                                         type="number"
-                                        value={creditPrice}
-                                        onChange={handlePriceChange}
+                                        value={values.creditPrice}
+                                        onChange={handleChange}
                                         onFocus={handleFocus}
                                         step="0.25"
-                                        className="receiving-credit"
                                     />
                                     <Form.Field
                                         fluid
                                         label="Cash Price"
-                                        name="cashInput"
+                                        name="cashPrice"
                                         control={Input}
                                         type="number"
-                                        value={cashPrice}
-                                        onChange={handlePriceChange}
+                                        value={values.cashPrice}
+                                        onChange={handleChange}
                                         onFocus={handleFocus}
                                         step="0.25"
-                                        className="receiving-cash"
                                     />
                                     <Form.Field
                                         fluid
                                         label="Market Price"
-                                        name="marketPriceInput"
+                                        name="marketPrice"
                                         control={Input}
                                         type="number"
-                                        value={marketPrice}
-                                        onChange={handlePriceChange}
+                                        value={values.marketPrice}
+                                        onChange={handleChange}
                                         onFocus={handleFocus}
                                         step="0.25"
-                                        disabled={cashPrice === 0}
-                                        className="receiving-market"
+                                        disabled={!values.cashPrice}
                                     />
                                 </Form.Group>
                                 <Form.Group widths="equal">
-                                    <Form.Field
-                                        fluid
+                                    <FormikSelectField
                                         label="Finish"
-                                        control={Select}
-                                        value={selectedFinish}
+                                        name="selectedFinish"
                                         options={finishes}
+                                        defaultValue={
+                                            initialValues.selectedFinish
+                                        }
+                                        onChange={(v) => {
+                                            setFieldValue('selectedFinish', v);
+                                        }}
                                         disabled={finishDisabled}
-                                        onChange={handleFinishChange}
                                     />
-                                    <Form.Field
-                                        fluid
+                                    <FormikSelectField
                                         label="Condition"
-                                        control={Select}
-                                        value={selectedCondition}
+                                        name="selectedCondition"
                                         options={cardConditions}
-                                        onChange={handleConditionChange}
+                                        defaultValue={
+                                            initialValues.selectedCondition
+                                        }
+                                        onChange={(v) => {
+                                            setFieldValue(
+                                                'selectedCondition',
+                                                v
+                                            );
+                                        }}
                                     />
                                     <Form.Button
+                                        type="submit"
                                         label="Add to List?"
                                         control={Button}
                                         primary
-                                        disabled={submitDisabled()}
-                                        onClick={handleInventoryAdd}
+                                        disabled={!isValid}
+                                        onClick={() => handleSubmit()}
                                     >
                                         Add
                                     </Form.Button>

--- a/frontend/src/ui/FormikDropdown.tsx
+++ b/frontend/src/ui/FormikDropdown.tsx
@@ -1,33 +1,25 @@
-import { FormFieldProps, Dropdown } from 'semantic-ui-react';
-import { FieldConfig, FormikProps } from 'formik';
+import { FormFieldProps, Dropdown, DropdownProps } from 'semantic-ui-react';
 import { SyntheticEvent } from 'react';
 
-type FormikFieldProps<T, O> = {
-    field: FieldConfig;
-    form: FormikProps<T>;
-    label: string;
-    options: O[];
-} & Omit<FormFieldProps, 'label' | 'name' | 'options'>;
+type FormikDropdownFieldProps<T> = {
+    name: string;
+    onChange: (value: DropdownProps['value']) => void;
+    options: T[];
+} & Omit<FormFieldProps, 'name' | 'options' | 'onChange'>;
 
-/**
- * This is meant to be wrapped by a <Field /> component.
- *
- * The generics are inferred by passed prop values.
- */
-function FormikDropdown<T, O>({
+function FormikDropdown<T>({
+    label,
+    name,
+    onChange,
     options,
-    /** Injected by <Field /> */
-    field,
-    /** Injected by <Field /> */
-    form,
     ...props
-}: FormikFieldProps<T, O>) {
+}: FormikDropdownFieldProps<T>) {
     return (
         <Dropdown
             options={options}
-            name={field.name}
-            onChange={(_: SyntheticEvent, data) => {
-                form.setFieldValue(field.name, data.value);
+            name={name}
+            onChange={(_: SyntheticEvent, data: DropdownProps) => {
+                onChange(data.value);
             }}
             {...props}
         />

--- a/frontend/src/ui/FormikNativeDatePicker.tsx
+++ b/frontend/src/ui/FormikNativeDatePicker.tsx
@@ -1,5 +1,6 @@
 import { Form, FormFieldProps, Input } from 'semantic-ui-react';
-import { FieldConfig, FormikProps } from 'formik';
+import { FieldConfig, FormikBag, FormikProps } from 'formik';
+import { ChangeEvent, FC } from 'react';
 
 type FormikFieldProps<T> = {
     field: FieldConfig;
@@ -40,5 +41,38 @@ function FormikNativeDatePicker<T>({
         </Form.Field>
     );
 }
+
+interface FormNativeDatePickerProps {
+    label: string;
+    name: string;
+    defaultValue: string;
+    handleChange: (e: ChangeEvent) => void;
+    min?: string;
+    max?: string;
+}
+
+export const FormNativeDatePicker: FC<FormNativeDatePickerProps> = ({
+    label,
+    name,
+    defaultValue,
+    handleChange,
+    min,
+    max,
+}) => {
+    return (
+        <Form.Field>
+            <label>{label}</label>
+            <Input
+                id={name}
+                name={name}
+                type="date"
+                onChange={handleChange}
+                defaultValue={defaultValue}
+                min={min}
+                max={max}
+            />
+        </Form.Field>
+    );
+};
 
 export default FormikNativeDatePicker;

--- a/frontend/src/ui/FormikNativeDatePicker.tsx
+++ b/frontend/src/ui/FormikNativeDatePicker.tsx
@@ -1,48 +1,7 @@
-import { Form, FormFieldProps, Input } from 'semantic-ui-react';
-import { FieldConfig, FormikBag, FormikProps } from 'formik';
+import { Form, Input } from 'semantic-ui-react';
 import { ChangeEvent, FC } from 'react';
 
-type FormikFieldProps<T> = {
-    field: FieldConfig;
-    form: FormikProps<T>;
-    label: string;
-    defaultValue?: string;
-    min?: string;
-    max?: string;
-} & Omit<FormFieldProps, 'label' | 'name'>;
-
-/**
- * This is meant to be wrapped by a <Field /> component.
- *
- * The generics are inferred by passed prop values.
- */
-function FormikNativeDatePicker<T>({
-    label,
-    /** Injected by <Field /> */
-    field,
-    /** Injected by <Field /> */
-    form,
-    defaultValue,
-    min,
-    max,
-}: FormikFieldProps<T>) {
-    return (
-        <Form.Field>
-            <label>{label}</label>
-            <Input
-                id={field.name}
-                name={field.name}
-                type="date"
-                onChange={form.handleChange}
-                defaultValue={defaultValue}
-                min={min}
-                max={max}
-            />
-        </Form.Field>
-    );
-}
-
-interface FormNativeDatePickerProps {
+interface FormikNativeDatePickerProps {
     label: string;
     name: string;
     defaultValue: string;
@@ -51,7 +10,7 @@ interface FormNativeDatePickerProps {
     max?: string;
 }
 
-export const FormNativeDatePicker: FC<FormNativeDatePickerProps> = ({
+export const FormikNativeDatePicker: FC<FormikNativeDatePickerProps> = ({
     label,
     name,
     defaultValue,

--- a/frontend/src/ui/FormikSearchBar.tsx
+++ b/frontend/src/ui/FormikSearchBar.tsx
@@ -1,49 +1,16 @@
-import { Form, FormFieldProps } from 'semantic-ui-react';
-import { FieldConfig, FormikProps } from 'formik';
+import { Form } from 'semantic-ui-react';
 import SearchBar from '../common/SearchBar';
 import { FC, SyntheticEvent } from 'react';
 
-type FormikFieldProps<T> = {
-    field: FieldConfig;
-    form: FormikProps<T>;
-    label: string;
-} & Omit<FormFieldProps, 'label' | 'name'>;
-
-/**
- * This is meant to be wrapped by a <Field /> component.
- *
- * The generics are inferred by passed prop values.
- */
-function FormikSearchBar<T>({
-    label,
-    /** Injected by <Field /> */
-    field,
-    /** Injected by <Field /> */
-    form,
-}: FormikFieldProps<T>) {
-    return (
-        <Form.Field>
-            <label>{label}</label>
-            <SearchBar
-                handleSearchSelect={(value) => {
-                    form.setFieldValue(field.name, value);
-                }}
-                // Reset form state after user blurs cardName
-                onBlur={(event: SyntheticEvent<Element, Event>) => {
-                    const element = event.target as HTMLInputElement;
-                    form.setFieldValue(field.name, element.value);
-                }}
-            />
-        </Form.Field>
-    );
-}
-
-interface FormSearchBarProps {
+interface FormikSearchBarProps {
     label: string;
     onChange: (value: string) => void;
 }
 
-export const FormSearchBar: FC<FormSearchBarProps> = ({ label, onChange }) => {
+export const FormikSearchBar: FC<FormikSearchBarProps> = ({
+    label,
+    onChange,
+}) => {
     return (
         <Form.Field>
             <label>{label}</label>

--- a/frontend/src/ui/FormikSearchBar.tsx
+++ b/frontend/src/ui/FormikSearchBar.tsx
@@ -1,7 +1,7 @@
 import { Form, FormFieldProps } from 'semantic-ui-react';
 import { FieldConfig, FormikProps } from 'formik';
 import SearchBar from '../common/SearchBar';
-import { SyntheticEvent } from 'react';
+import { FC, SyntheticEvent } from 'react';
 
 type FormikFieldProps<T> = {
     field: FieldConfig;
@@ -37,5 +37,30 @@ function FormikSearchBar<T>({
         </Form.Field>
     );
 }
+
+interface FormSearchBarProps {
+    label: string;
+    onChange: (value: string) => void;
+}
+
+export const FormSearchBar: FC<FormSearchBarProps> = ({ label, onChange }) => {
+    return (
+        <Form.Field>
+            <label>{label}</label>
+            <SearchBar
+                handleSearchSelect={(value) => {
+                    onChange(value);
+                    // setFieldValue('cardName', value);
+                }}
+                // Reset form state after user blurs cardName
+                onBlur={(event: SyntheticEvent<Element, Event>) => {
+                    const element = event.target as HTMLInputElement;
+                    onChange(element.value);
+                    // setFieldValue('cardName', element.value);
+                }}
+            />
+        </Form.Field>
+    );
+};
 
 export default FormikSearchBar;

--- a/frontend/src/ui/FormikSearchBar.tsx
+++ b/frontend/src/ui/FormikSearchBar.tsx
@@ -17,13 +17,11 @@ export const FormikSearchBar: FC<FormikSearchBarProps> = ({
             <SearchBar
                 handleSearchSelect={(value) => {
                     onChange(value);
-                    // setFieldValue('cardName', value);
                 }}
                 // Reset form state after user blurs cardName
                 onBlur={(event: SyntheticEvent<Element, Event>) => {
                     const element = event.target as HTMLInputElement;
                     onChange(element.value);
-                    // setFieldValue('cardName', element.value);
                 }}
             />
         </Form.Field>

--- a/frontend/src/ui/FormikSelectField.tsx
+++ b/frontend/src/ui/FormikSelectField.tsx
@@ -5,6 +5,7 @@ type FormSelectFieldProps<T> = {
     name: string;
     onChange: (value: string) => void;
     options: T[];
+    error?: string;
 } & Omit<FormFieldProps, 'label' | 'name' | 'options' | 'onChange'>;
 
 function FormikSelectField<T>({
@@ -12,10 +13,12 @@ function FormikSelectField<T>({
     name,
     options,
     onChange,
+    error,
     ...props
 }: FormSelectFieldProps<T>) {
     return (
         <Form.Field
+            error={error}
             control={Select}
             label={label}
             placeholder={label}

--- a/frontend/src/ui/FormikSelectField.tsx
+++ b/frontend/src/ui/FormikSelectField.tsx
@@ -1,36 +1,28 @@
 import { Form, Select, FormFieldProps } from 'semantic-ui-react';
-import { FieldConfig, FormikProps } from 'formik';
 
-type FormikFieldProps<T, O> = {
-    field: FieldConfig;
-    form: FormikProps<T>;
+type FormSelectFieldProps<T> = {
     label: string;
-    options: O[];
-} & Omit<FormFieldProps, 'label' | 'name' | 'options'>;
+    name: string;
+    onChange: (value: string) => void;
+    options: T[];
+} & Omit<FormFieldProps, 'label' | 'name' | 'options' | 'onChange'>;
 
-/**
- * This is meant to be wrapped by a <Field /> component.
- *
- * The generics are inferred by passed prop values.
- */
-function FormikSelectField<T, O>({
+function FormikSelectField<T>({
     label,
+    name,
     options,
-    /** Injected by <Field /> */
-    field,
-    /** Injected by <Field /> */
-    form,
+    onChange,
     ...props
-}: FormikFieldProps<T, O>) {
+}: FormSelectFieldProps<T>) {
     return (
         <Form.Field
             control={Select}
             label={label}
             placeholder={label}
             options={options}
-            name={field.name}
+            name={name}
             onChange={(_: any, { value }: { value: string }) => {
-                form.setFieldValue(field.name, value);
+                onChange(value);
             }}
             {...props}
         />


### PR DESCRIPTION
## Summary
This PR rounds out two remaining problems with our application forms:
1. We were using Formik only intermittently. Sale and Receiving forms were still vanilla JS, and needed to be brought up to speed.
2. We desired to use the `useFormik` hook pattern for form state management to decouple the view/templating from necessary Formik utilities via render props.

We've also began extracting relevant Formik wrappers for controlled components like Selects and Dropdowns as well. This will make future form iteration much easier.

Also, `722 additions and 743 deletions`! Basically a 1:1 strict upgrade 😆 