### PR TITLE
MUI Header

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,4 @@
-import React, { FC, useState } from 'react';
-import Header from './Header/Header';
+import React, { FC } from 'react';
 import AuthProvider from './context/AuthProvider';
 import { Switch, Route } from 'react-router-dom';
 import ManageInventory from './ManageInventory/ManageInventory';
@@ -10,26 +9,26 @@ import DeckboxClone from './DeckboxClone/DeckboxClone';
 import Login from './Login/Login';
 import Logout from './Logout/Logout';
 import Receiving from './Receiving/Receiving';
-import styled from 'styled-components';
 import { SaleProvider } from './context/SaleContext';
 import ReceivingProvider from './context/ReceivingContext';
 import InventoryProvider from './context/InventoryContext';
 import AdminRoute from './AuthenticatedRoute';
 import Home from './LandingPage/Home';
 import BrowseReceiving from './BrowseReceiving/BrowseReceiving';
-import { Box, createMuiTheme, ThemeProvider } from '@material-ui/core';
+import { createMuiTheme, makeStyles, ThemeProvider } from '@material-ui/core';
 import NavBar from './Header/NavBar';
 
-const ContentContainer = styled.div`
-    padding-top: 75px;
-    margin-left: 20px;
-    margin-right: 20px;
-`;
-
-const BackgroundColor = styled.div`
-    background-color: #f9fafb;
-    min-height: 100vh;
-`;
+const useStyles = makeStyles(({ spacing }) => ({
+    contentContainer: {
+        paddingTop: spacing(10),
+        marginLeft: spacing(3),
+        marginRight: spacing(3),
+    },
+    backgroundColor: {
+        backgroundColor: '#f9fafb',
+        minHeight: '100vh',
+    },
+}));
 
 const theme = createMuiTheme({
     palette: {
@@ -40,20 +39,16 @@ const theme = createMuiTheme({
 });
 
 const App: FC = () => {
-    const [showBar, setShowBar] = useState<boolean>(false);
+    const { backgroundColor, contentContainer } = useStyles();
 
     return (
         <AuthProvider>
             <ThemeProvider theme={theme}>
-                <Header />
-                {showBar && <NavBar />}
-                <Box pt={10}>
-                    <button onClick={() => setShowBar(!showBar)}>Switch</button>
-                </Box>
+                <NavBar />
                 <Switch>
                     <Route exact path="/" component={Home} />
-                    <BackgroundColor>
-                        <ContentContainer id="content-container">
+                    <div className={backgroundColor}>
+                        <div className={contentContainer}>
                             <AdminRoute exact path="/manage-inventory">
                                 <InventoryProvider>
                                     <ManageInventory />
@@ -85,8 +80,8 @@ const App: FC = () => {
                             />
                             <Route exact path="/login" component={Login} />
                             <Route exact path="/logout" component={Logout} />
-                        </ContentContainer>
-                    </BackgroundColor>
+                        </div>
+                    </div>
                 </Switch>
             </ThemeProvider>
         </AuthProvider>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, useState } from 'react';
 import Header from './Header/Header';
 import AuthProvider from './context/AuthProvider';
 import { Switch, Route } from 'react-router-dom';
@@ -17,7 +17,8 @@ import InventoryProvider from './context/InventoryContext';
 import AdminRoute from './AuthenticatedRoute';
 import Home from './LandingPage/Home';
 import BrowseReceiving from './BrowseReceiving/BrowseReceiving';
-import { createMuiTheme, ThemeProvider } from '@material-ui/core';
+import { Box, createMuiTheme, ThemeProvider } from '@material-ui/core';
+import NavBar from './Header/NavBar';
 
 const ContentContainer = styled.div`
     padding-top: 75px;
@@ -39,10 +40,16 @@ const theme = createMuiTheme({
 });
 
 const App: FC = () => {
+    const [showBar, setShowBar] = useState<boolean>(false);
+
     return (
         <AuthProvider>
             <ThemeProvider theme={theme}>
                 <Header />
+                {showBar && <NavBar />}
+                <Box pt={10}>
+                    <button onClick={() => setShowBar(!showBar)}>Switch</button>
+                </Box>
                 <Switch>
                     <Route exact path="/" component={Home} />
                     <BackgroundColor>

--- a/frontend/src/Header/NavBar.tsx
+++ b/frontend/src/Header/NavBar.tsx
@@ -8,23 +8,33 @@ import {
     Typography,
 } from '@material-ui/core';
 import MenuIcon from '@material-ui/icons/Menu';
-import { useAuthContext } from '../context/AuthProvider';
+import { ClubhouseLocation, useAuthContext } from '../context/AuthProvider';
 import NavLinks from './NavLinks';
+import { Link as RouterLink } from 'react-router-dom';
 
-const useStyles = makeStyles({
+const useStyles = makeStyles(({ spacing }) => ({
     title: {
         flexGrow: 1,
     },
     list: {
         width: 250,
     },
-});
+    menuButton: {
+        marginRight: spacing(2),
+    },
+}));
+
+const getClubhouseLocationName = (location: ClubhouseLocation | null) => {
+    if (location === 'ch1') return 'Beaverton';
+    if (location === 'ch2') return 'Hillsboro';
+    return '';
+};
 
 const NavBar: FC<{}> = () => {
     const { loggedIn, currentLocation, currentUser } = useAuthContext();
     const [drawerOpen, setDrawerOpen] = useState<boolean>(false);
 
-    const { title, list } = useStyles();
+    const { title, list, menuButton } = useStyles();
 
     return (
         <AppBar>
@@ -32,12 +42,28 @@ const NavBar: FC<{}> = () => {
                 <IconButton
                     edge="start"
                     color="inherit"
+                    className={menuButton}
                     onClick={() => setDrawerOpen(true)}
                 >
                     <MenuIcon />
                 </IconButton>
-                <Typography variant="h6" className={title}>
-                    Clubhouse Collection StoreName
+                <Typography
+                    color="inherit"
+                    component={RouterLink}
+                    variant="h6"
+                    className={title}
+                    to="/"
+                >
+                    Clubhouse Collection{' '}
+                    {getClubhouseLocationName(currentLocation)}
+                </Typography>
+                <Typography
+                    color="inherit"
+                    component={RouterLink}
+                    variant="button"
+                    to="/public-inventory"
+                >
+                    Search cards
                 </Typography>
                 <Drawer
                     anchor="left"

--- a/frontend/src/Header/NavBar.tsx
+++ b/frontend/src/Header/NavBar.tsx
@@ -16,10 +16,15 @@ import { Link as RouterLink } from 'react-router-dom';
 import LocationOnIcon from '@material-ui/icons/LocationOn';
 import { version } from '../../package.json';
 
-const useStyles = makeStyles(({ spacing, typography }) => ({
+const useStyles = makeStyles(({ spacing, typography, palette }) => ({
     title: {
         flexGrow: 1,
+    },
+    menuLinkText: {
         fontWeight: typography.fontWeightBold,
+        '&:hover': {
+            color: palette.common.white,
+        },
     },
     list: {
         width: 250,
@@ -38,8 +43,7 @@ const getClubhouseLocationName = (location: ClubhouseLocation | null) => {
 const NavBar: FC<{}> = () => {
     const { loggedIn, currentLocation, currentUser } = useAuthContext();
     const [drawerOpen, setDrawerOpen] = useState<boolean>(false);
-
-    const { title, list, menuButton } = useStyles();
+    const { title, list, menuButton, menuLinkText } = useStyles();
 
     return (
         <AppBar>
@@ -54,17 +58,20 @@ const NavBar: FC<{}> = () => {
                         <MenuIcon />
                     </IconButton>
                 )}
+                <div className={title}>
+                    <Typography
+                        color="inherit"
+                        className={menuLinkText}
+                        component={RouterLink}
+                        variant="h6"
+                        to="/"
+                    >
+                        Clubhouse Collection
+                    </Typography>
+                </div>
                 <Typography
                     color="inherit"
-                    component={RouterLink}
-                    variant="h6"
-                    className={title}
-                    to="/"
-                >
-                    Clubhouse Collection
-                </Typography>
-                <Typography
-                    color="inherit"
+                    className={menuLinkText}
                     component={RouterLink}
                     variant="button"
                     to="/public-inventory"

--- a/frontend/src/Header/NavBar.tsx
+++ b/frontend/src/Header/NavBar.tsx
@@ -1,0 +1,56 @@
+import React, { FC, useState } from 'react';
+import {
+    AppBar,
+    Drawer,
+    IconButton,
+    makeStyles,
+    Toolbar,
+    Typography,
+} from '@material-ui/core';
+import MenuIcon from '@material-ui/icons/Menu';
+import { useAuthContext } from '../context/AuthProvider';
+import NavLinks from './NavLinks';
+
+const useStyles = makeStyles({
+    title: {
+        flexGrow: 1,
+    },
+    list: {
+        width: 250,
+    },
+});
+
+const NavBar: FC<{}> = () => {
+    const { loggedIn, currentLocation, currentUser } = useAuthContext();
+    const [drawerOpen, setDrawerOpen] = useState<boolean>(false);
+
+    const { title, list } = useStyles();
+
+    return (
+        <AppBar>
+            <Toolbar>
+                <IconButton
+                    edge="start"
+                    color="inherit"
+                    onClick={() => setDrawerOpen(true)}
+                >
+                    <MenuIcon />
+                </IconButton>
+                <Typography variant="h6" className={title}>
+                    Clubhouse Collection StoreName
+                </Typography>
+                <Drawer
+                    anchor="left"
+                    open={drawerOpen}
+                    onClose={() => setDrawerOpen(false)}
+                >
+                    <div className={list} onClick={() => setDrawerOpen(false)}>
+                        <NavLinks />
+                    </div>
+                </Drawer>
+            </Toolbar>
+        </AppBar>
+    );
+};
+
+export default NavBar;

--- a/frontend/src/Header/NavBar.tsx
+++ b/frontend/src/Header/NavBar.tsx
@@ -1,7 +1,9 @@
 import React, { FC, useState } from 'react';
 import {
     AppBar,
+    Box,
     Drawer,
+    Grid,
     IconButton,
     makeStyles,
     Toolbar,
@@ -11,10 +13,13 @@ import MenuIcon from '@material-ui/icons/Menu';
 import { ClubhouseLocation, useAuthContext } from '../context/AuthProvider';
 import NavLinks from './NavLinks';
 import { Link as RouterLink } from 'react-router-dom';
+import LocationOnIcon from '@material-ui/icons/LocationOn';
+import { version } from '../../package.json';
 
-const useStyles = makeStyles(({ spacing }) => ({
+const useStyles = makeStyles(({ spacing, typography }) => ({
     title: {
         flexGrow: 1,
+        fontWeight: typography.fontWeightBold,
     },
     list: {
         width: 250,
@@ -39,14 +44,16 @@ const NavBar: FC<{}> = () => {
     return (
         <AppBar>
             <Toolbar>
-                <IconButton
-                    edge="start"
-                    color="inherit"
-                    className={menuButton}
-                    onClick={() => setDrawerOpen(true)}
-                >
-                    <MenuIcon />
-                </IconButton>
+                {loggedIn && (
+                    <IconButton
+                        edge="start"
+                        color="inherit"
+                        className={menuButton}
+                        onClick={() => setDrawerOpen(true)}
+                    >
+                        <MenuIcon />
+                    </IconButton>
+                )}
                 <Typography
                     color="inherit"
                     component={RouterLink}
@@ -54,8 +61,7 @@ const NavBar: FC<{}> = () => {
                     className={title}
                     to="/"
                 >
-                    Clubhouse Collection{' '}
-                    {getClubhouseLocationName(currentLocation)}
+                    Clubhouse Collection
                 </Typography>
                 <Typography
                     color="inherit"
@@ -70,9 +76,39 @@ const NavBar: FC<{}> = () => {
                     open={drawerOpen}
                     onClose={() => setDrawerOpen(false)}
                 >
-                    <div className={list} onClick={() => setDrawerOpen(false)}>
-                        <NavLinks />
-                    </div>
+                    <Box
+                        py={2}
+                        display="flex"
+                        flexDirection="column"
+                        justifyContent="space-between"
+                        height={1}
+                    >
+                        <div>
+                            <Grid
+                                container
+                                direction="row"
+                                alignItems="center"
+                                justify="center"
+                            >
+                                <LocationOnIcon color="primary" />
+                                <Typography color="primary" variant="h6">
+                                    {getClubhouseLocationName(currentLocation)}
+                                </Typography>
+                            </Grid>
+                            <Typography color="textSecondary" align="center">
+                                Logged in as {currentUser}
+                            </Typography>
+                            <div
+                                className={list}
+                                onClick={() => setDrawerOpen(false)}
+                            >
+                                <NavLinks />
+                            </div>
+                        </div>
+                        <Typography color="textSecondary" align="center">
+                            Version {version}
+                        </Typography>
+                    </Box>
                 </Drawer>
             </Toolbar>
         </AppBar>

--- a/frontend/src/Header/NavLinks.test.tsx
+++ b/frontend/src/Header/NavLinks.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter, Route } from 'react-router-dom';
+import NavLinks from './NavLinks';
+
+test('Correct link navigation', async () => {
+    const pathHistory: string[] = [];
+
+    render(
+        <MemoryRouter initialEntries={['/']}>
+            <Route
+                render={({ location }) => {
+                    pathHistory.push(location.pathname);
+                    return '';
+                }}
+            />
+            <NavLinks />
+        </MemoryRouter>
+    );
+
+    await screen.findByText('Manage Inventory');
+    await screen.findByText('New Sale');
+    await screen.findByText('Receiving');
+    await screen.findByText('Browse Inventory');
+    await screen.findByText('Browse Sales');
+    await screen.findByText('Browse Receiving');
+    await screen.findByText('Log Out');
+
+    await fireEvent.click(await screen.findByText('Manage Inventory'));
+    await fireEvent.click(await screen.findByText('New Sale'));
+    await fireEvent.click(await screen.findByText('Receiving'));
+    await fireEvent.click(await screen.findByText('Browse Inventory'));
+    await fireEvent.click(await screen.findByText('Browse Sales'));
+    await fireEvent.click(await screen.findByText('Browse Receiving'));
+    await fireEvent.click(await screen.findByText('Log Out'));
+
+    expect(pathHistory).toMatchInlineSnapshot(`
+        Array [
+          "/",
+          "/manage-inventory",
+          "/new-sale",
+          "/receiving",
+          "/browse-inventory",
+          "/browse-sales",
+          "/browse-receiving",
+          "/logout",
+        ]
+    `);
+});

--- a/frontend/src/Header/NavLinks.tsx
+++ b/frontend/src/Header/NavLinks.tsx
@@ -1,0 +1,107 @@
+import React, { FC } from 'react';
+import { Divider, List, ListItem, ListItemIcon } from '@material-ui/core';
+import { useLocation, Link as RouterLink } from 'react-router-dom';
+import AddIcon from '@material-ui/icons/Add';
+import AttachMoneyIcon from '@material-ui/icons/AttachMoney';
+import ListAltIcon from '@material-ui/icons/ListAlt';
+import BusinessCenterIcon from '@material-ui/icons/BusinessCenter';
+import VisibilityIcon from '@material-ui/icons/Visibility';
+import ViewListIcon from '@material-ui/icons/ViewList';
+import ExitToAppIcon from '@material-ui/icons/ExitToApp';
+
+const NavLinks: FC<{}> = () => {
+    const { pathname } = useLocation();
+
+    return (
+        <List>
+            <ListItem
+                button
+                component={RouterLink}
+                to="/manage-inventory"
+                selected={pathname === '/manage-inventory'}
+                replace
+            >
+                <ListItemIcon>
+                    <AddIcon color="primary" />
+                </ListItemIcon>
+                Manage Inventory
+            </ListItem>
+            <ListItem
+                button
+                component={RouterLink}
+                to="/new-sale"
+                selected={pathname === '/new-sale'}
+                replace
+            >
+                <ListItemIcon>
+                    <AttachMoneyIcon color="primary" />
+                </ListItemIcon>
+                New Sale
+            </ListItem>
+            <ListItem
+                button
+                component={RouterLink}
+                to="/receiving"
+                selected={pathname === '/receiving'}
+                replace
+            >
+                <ListItemIcon>
+                    <ListAltIcon color="primary" />
+                </ListItemIcon>
+                Receiving
+            </ListItem>
+            <Divider />
+            <ListItem
+                button
+                component={RouterLink}
+                to="/browse-inventory"
+                selected={pathname === '/browse-inventory'}
+                replace
+            >
+                <ListItemIcon>
+                    <BusinessCenterIcon color="primary" />
+                </ListItemIcon>
+                Browse Inventory
+            </ListItem>
+            <ListItem
+                button
+                component={RouterLink}
+                to="/browse-sales"
+                selected={pathname === '/browse-sales'}
+                replace
+            >
+                <ListItemIcon>
+                    <VisibilityIcon color="primary" />
+                </ListItemIcon>
+                Browse Sales
+            </ListItem>
+            <ListItem
+                button
+                component={RouterLink}
+                to="/browse-receiving"
+                selected={pathname === '/browse-receiving'}
+                replace
+            >
+                <ListItemIcon>
+                    <ViewListIcon color="primary" />
+                </ListItemIcon>
+                Browse Receiving
+            </ListItem>
+            <Divider />
+            <ListItem
+                button
+                component={RouterLink}
+                to="/logout"
+                selected={pathname === '/logout'}
+                replace
+            >
+                <ListItemIcon>
+                    <ExitToAppIcon color="primary" />
+                </ListItemIcon>
+                Log out
+            </ListItem>
+        </List>
+    );
+};
+
+export default NavLinks;

--- a/frontend/src/Header/NavLinks.tsx
+++ b/frontend/src/Header/NavLinks.tsx
@@ -98,7 +98,7 @@ const NavLinks: FC<{}> = () => {
                 <ListItemIcon>
                     <ExitToAppIcon color="primary" />
                 </ListItemIcon>
-                Log out
+                Log Out
             </ListItem>
         </List>
     );


### PR DESCRIPTION
![002](https://user-images.githubusercontent.com/15024562/125710583-0e360648-da1b-4051-8d4e-8d936d8b36e8.gif)

## Summary
We'll likely be branding the application for at least two stores going forward. This PR addresses the following considerations:
1. Stores with long names or locations could wrap on mobile layouts
2. The navbar was not responsive enough on mobile for logged-in users
3. New features may require top-level space, and we needed to reclaim it

Ultimately, we may decide to permanently dock the sidebar for large screens, but that's not a priority. Biggest shift here that users will see is a moving of the navigation from the right to the left.

Store location, username, and app version number were scoped to the drawer so the header could remain free and clean!