### PR TITLE
Browse receiving dialog

### DIFF
--- a/frontend/src/BrowseReceiving/BrowseReceiving.tsx
+++ b/frontend/src/BrowseReceiving/BrowseReceiving.tsx
@@ -8,6 +8,7 @@ import { HeaderText, SectionText } from '../ui/Typography';
 import BrowseReceivingFilterDialog, {
     FormValues,
 } from './BrowseReceivingFilterDialog';
+import Placeholder from '../ui/Placeholder';
 
 interface Filters {
     cardName: string;
@@ -95,6 +96,10 @@ const BrowseReceiving: FC = () => {
                 </Grid>
                 {loading ? (
                     <Loading />
+                ) : receivedList.length === 0 ? (
+                    <Grid item xs={12}>
+                        <Placeholder>No results</Placeholder>
+                    </Grid>
                 ) : (
                     receivedList.map((rl) => (
                         <Grid item xs={12} key={rl._id}>

--- a/frontend/src/BrowseReceiving/BrowseReceiving.tsx
+++ b/frontend/src/BrowseReceiving/BrowseReceiving.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useEffect, useState } from 'react';
 import browseReceivingQuery, { Received } from './browseReceivingQuery';
-import { Grid, Box, Typography } from '@material-ui/core';
+import { Grid, Box, Typography, Button } from '@material-ui/core';
 import BrowseReceivingItem from './BrowseReceivingItem';
 import moment from 'moment';
 import Loading from '../ui/Loading';
@@ -21,6 +21,10 @@ const initialFilters: Filters = {
     endDate: moment().format('YYYY-MM-DD'),
 };
 
+function shallowCompare(obj1: Filters, obj2: Filters) {
+    return JSON.stringify(obj1) === JSON.stringify(obj2);
+}
+
 const BrowseReceiving: FC = () => {
     const [filters, setFilters] = useState<Filters>(initialFilters);
     const [loading, setLoading] = useState<boolean>(false);
@@ -28,11 +32,13 @@ const BrowseReceiving: FC = () => {
 
     const onSubmit = async (formValues: FormValues) => {
         /**
-         * If the types of the `filters` change, we can convert them here
-         * from the form values before setting the filter state
+         * If the types of `Filters` changes, we can convert them here
+         * from the submitted form values.
          */
-        setFilters(formValues);
+        setFilters({ ...filters, ...formValues }); // preserves order when using JSON.stringify to diff
     };
+
+    const onClearFilters = () => setFilters(initialFilters);
 
     useEffect(() => {
         (async () => {
@@ -54,47 +60,49 @@ const BrowseReceiving: FC = () => {
             <Box pb={2}>
                 <HeaderText>Browse Receiving</HeaderText>
             </Box>
-            {loading ? (
-                <Loading />
-            ) : (
-                <Grid
-                    container
-                    justify="space-between"
-                    md={12}
-                    lg={6}
-                    spacing={2}
-                >
-                    <Grid item alignItems="center" xs={12}>
-                        <Box
-                            display="flex"
-                            justifyContent="space-between"
-                            alignItems="center"
-                        >
-                            <div>
-                                <SectionText>Results</SectionText>
-                                <Typography color="textSecondary">
-                                    {`Searching ${
-                                        filters.cardName || 'all cards'
-                                    } from ${filters.startDate} to ${
-                                        filters.endDate
-                                    }`}
-                                </Typography>
-                            </div>
-                            <div>
-                                <BrowseReceivingFilterDialog
-                                    filters={filters}
-                                    onSubmit={onSubmit}
-                                />
-                            </div>
-                        </Box>
-                    </Grid>
-                    {receivedList.map((rl) => (
+            <Grid container justify="space-between" md={12} lg={6} spacing={2}>
+                <Grid item alignItems="center" xs={12}>
+                    <Box
+                        display="flex"
+                        justifyContent="space-between"
+                        alignItems="center"
+                    >
+                        <div>
+                            <SectionText>Results</SectionText>
+                            <Typography color="textSecondary">
+                                {`Searching ${
+                                    filters.cardName || 'all cards'
+                                } from ${filters.startDate} to ${
+                                    filters.endDate
+                                }`}
+                            </Typography>
+                        </div>
+                        <div>
+                            {!shallowCompare(initialFilters, filters) && (
+                                <Button
+                                    color="primary"
+                                    onClick={onClearFilters}
+                                >
+                                    Clear filters
+                                </Button>
+                            )}
+                            <BrowseReceivingFilterDialog
+                                filters={filters}
+                                onSubmit={onSubmit}
+                            />
+                        </div>
+                    </Box>
+                </Grid>
+                {loading ? (
+                    <Loading />
+                ) : (
+                    receivedList.map((rl) => (
                         <Grid item xs={12} key={rl._id}>
                             <BrowseReceivingItem received={rl} />
                         </Grid>
-                    ))}
-                </Grid>
-            )}
+                    ))
+                )}
+            </Grid>
         </div>
     );
 };

--- a/frontend/src/BrowseReceiving/BrowseReceiving.tsx
+++ b/frontend/src/BrowseReceiving/BrowseReceiving.tsx
@@ -1,110 +1,99 @@
 import React, { FC, useEffect, useState } from 'react';
 import browseReceivingQuery, { Received } from './browseReceivingQuery';
-import { Grid, Box } from '@material-ui/core';
+import { Grid, Box, Typography } from '@material-ui/core';
 import BrowseReceivingItem from './BrowseReceivingItem';
 import moment from 'moment';
-import { useFormik } from 'formik';
-import { Form } from 'semantic-ui-react';
 import Loading from '../ui/Loading';
-import FormikControlledSearchBar from '../ui/FormikControlledSearchBar';
-import { FormikNativeDatePicker } from '../ui/FormikNativeDatePicker';
 import { HeaderText, SectionText } from '../ui/Typography';
+import BrowseReceivingFilterDialog, {
+    FormValues,
+} from './BrowseReceivingFilterDialog';
 
-interface FormValues {
+interface Filters {
     cardName: string;
     startDate: string;
     endDate: string;
 }
 
-const initialFormValues: FormValues = {
+const initialFilters: Filters = {
     cardName: '',
     startDate: moment().subtract(30, 'days').format('YYYY-MM-DD'),
     endDate: moment().format('YYYY-MM-DD'),
 };
 
-// No validations needed for now
-const validate = () => {
-    return {};
-};
-
 const BrowseReceiving: FC = () => {
-    const [receivedList, setReceivedList] = useState<Received[]>([]);
+    const [filters, setFilters] = useState<Filters>(initialFilters);
     const [loading, setLoading] = useState<boolean>(false);
+    const [receivedList, setReceivedList] = useState<Received[]>([]);
 
-    const onSubmit = async ({ cardName, startDate, endDate }: FormValues) => {
-        setLoading(true);
-        const received = await browseReceivingQuery({
-            cardName: cardName ? cardName : null,
-            startDate,
-            endDate,
-        });
-        setLoading(false);
-        setReceivedList(received);
+    const onSubmit = async (formValues: FormValues) => {
+        /**
+         * If the types of the `filters` change, we can convert them here
+         * from the form values before setting the filter state
+         */
+        setFilters(formValues);
     };
-
-    const { handleChange, values, setFieldValue, handleSubmit } = useFormik({
-        initialValues: initialFormValues,
-        validate,
-        onSubmit,
-    });
 
     useEffect(() => {
         (async () => {
-            await onSubmit(initialFormValues);
+            const { cardName, startDate, endDate } = filters;
+
+            setLoading(true);
+            const received = await browseReceivingQuery({
+                cardName: cardName ? cardName : null,
+                startDate,
+                endDate,
+            });
+            setLoading(false);
+            setReceivedList(received);
         })();
-    }, []);
+    }, [filters]);
 
     return (
         <div>
             <Box pb={2}>
                 <HeaderText>Browse Receiving</HeaderText>
             </Box>
-            <SectionText>Filters</SectionText>
-            <Box pb={2}>
-                <Form>
-                    <Form.Group widths="6">
-                        <FormikControlledSearchBar
-                            label="Card name"
-                            value={values.cardName}
-                            onChange={(v) => setFieldValue('cardName', v)}
-                        />
-                        <FormikNativeDatePicker
-                            label="Start date"
-                            name="startDate"
-                            defaultValue={initialFormValues.startDate}
-                            handleChange={handleChange}
-                            max={values.endDate}
-                        />
-                        <FormikNativeDatePicker
-                            label="End date"
-                            name="endDate"
-                            defaultValue={initialFormValues.endDate}
-                            handleChange={handleChange}
-                            max={initialFormValues.endDate}
-                        />
-                    </Form.Group>
-                    <Form.Button
-                        type="submit"
-                        onClick={() => handleSubmit()}
-                        primary
-                    >
-                        Search
-                    </Form.Button>
-                </Form>
-            </Box>
             {loading ? (
                 <Loading />
             ) : (
-                <>
-                    <SectionText>Results</SectionText>
-                    <Grid container direction="column" spacing={2}>
-                        {receivedList.map((rl) => (
-                            <Grid item xs={12} md={6} key={rl._id}>
-                                <BrowseReceivingItem received={rl} />
-                            </Grid>
-                        ))}
+                <Grid
+                    container
+                    justify="space-between"
+                    md={12}
+                    lg={6}
+                    spacing={2}
+                >
+                    <Grid item alignItems="center" xs={12}>
+                        <Box
+                            display="flex"
+                            justifyContent="space-between"
+                            alignItems="center"
+                        >
+                            <div>
+                                <SectionText>Results</SectionText>
+                                <Typography color="textSecondary">
+                                    {`Searching ${
+                                        filters.cardName || 'all cards'
+                                    } from ${filters.startDate} to ${
+                                        filters.endDate
+                                    }`}
+                                </Typography>
+                            </div>
+                            <div>
+                                <BrowseReceivingFilterDialog
+                                    filters={filters}
+                                    onSubmit={onSubmit}
+                                />
+                            </div>
+                        </Box>
                     </Grid>
-                </>
+                    {receivedList.map((rl) => (
+                        <Grid item xs={12} key={rl._id}>
+                            <BrowseReceivingItem received={rl} />
+                        </Grid>
+                    ))}
+                </Grid>
             )}
         </div>
     );

--- a/frontend/src/BrowseReceiving/BrowseReceivingFilterDialog.tsx
+++ b/frontend/src/BrowseReceiving/BrowseReceivingFilterDialog.tsx
@@ -29,13 +29,22 @@ const validate = () => {
 
 const BrowseReceivingFilterDialog: FC<Props> = ({ onSubmit, filters }) => {
     const [dialogOpen, setDialogOpen] = useState<boolean>(false);
+
+    const onDialogOpen = () => setDialogOpen(true);
+    const onDialogClose = () => setDialogOpen(false);
+
     const { handleChange, values, setFieldValue, handleSubmit } = useFormik({
         initialValues: filters,
         validate,
         onSubmit: async (v: FormValues) => {
             await onSubmit(v);
-            setDialogOpen(false);
+            onDialogClose();
         },
+        /**
+         * Formik will not update `initialValues` from externally-controlled sources (ie. props) if changed,
+         * even if the component is unmounted. We have to flip this switch to initialize with updated prop values
+         */
+        enableReinitialize: true,
     });
 
     return (
@@ -44,17 +53,12 @@ const BrowseReceivingFilterDialog: FC<Props> = ({ onSubmit, filters }) => {
                 disableElevation
                 variant="contained"
                 color="primary"
-                onClick={() => setDialogOpen(true)}
+                onClick={onDialogOpen}
             >
                 Filter
             </Button>
             {dialogOpen && (
-                <Dialog
-                    open
-                    onClose={() => setDialogOpen(false)}
-                    maxWidth="sm"
-                    fullWidth
-                >
+                <Dialog open onClose={onDialogClose} maxWidth="sm" fullWidth>
                     <DialogTitle>Receiving search</DialogTitle>
                     <DialogContent>
                         <Form>
@@ -80,10 +84,7 @@ const BrowseReceivingFilterDialog: FC<Props> = ({ onSubmit, filters }) => {
                         </Form>
                     </DialogContent>
                     <DialogActions>
-                        <Button
-                            variant="outlined"
-                            onClick={() => setDialogOpen(false)}
-                        >
+                        <Button variant="outlined" onClick={onDialogClose}>
                             Cancel
                         </Button>
                         <Button

--- a/frontend/src/BrowseReceiving/BrowseReceivingFilterDialog.tsx
+++ b/frontend/src/BrowseReceiving/BrowseReceivingFilterDialog.tsx
@@ -1,0 +1,104 @@
+import React, { FC, useState } from 'react';
+import {
+    Button,
+    Dialog,
+    DialogActions,
+    DialogContent,
+    DialogTitle,
+} from '@material-ui/core';
+import { useFormik } from 'formik';
+import { Form } from 'semantic-ui-react';
+import FormikControlledSearchBar from '../ui/FormikControlledSearchBar';
+import FormikNativeDatePicker from '../ui/FormikNativeDatePicker';
+
+export interface FormValues {
+    cardName: string;
+    startDate: string;
+    endDate: string;
+}
+
+interface Props {
+    onSubmit: (v: FormValues) => void;
+    filters: FormValues;
+}
+
+// No validations needed for now
+const validate = () => {
+    return {};
+};
+
+const BrowseReceivingFilterDialog: FC<Props> = ({ onSubmit, filters }) => {
+    const [dialogOpen, setDialogOpen] = useState<boolean>(false);
+    const { handleChange, values, setFieldValue, handleSubmit } = useFormik({
+        initialValues: filters,
+        validate,
+        onSubmit: async (v: FormValues) => {
+            await onSubmit(v);
+            setDialogOpen(false);
+        },
+    });
+
+    return (
+        <>
+            <Button
+                disableElevation
+                variant="contained"
+                color="primary"
+                onClick={() => setDialogOpen(true)}
+            >
+                Filter
+            </Button>
+            {dialogOpen && (
+                <Dialog
+                    open
+                    onClose={() => setDialogOpen(false)}
+                    maxWidth="sm"
+                    fullWidth
+                >
+                    <DialogTitle>Receiving search</DialogTitle>
+                    <DialogContent>
+                        <Form>
+                            <FormikControlledSearchBar
+                                label="Card name"
+                                value={values.cardName}
+                                onChange={(v) => setFieldValue('cardName', v)}
+                            />
+                            <FormikNativeDatePicker
+                                label="Start date"
+                                name="startDate"
+                                defaultValue={filters.startDate}
+                                handleChange={handleChange}
+                                max={values.endDate}
+                            />
+                            <FormikNativeDatePicker
+                                label="End date"
+                                name="endDate"
+                                defaultValue={filters.endDate}
+                                handleChange={handleChange}
+                                max={filters.endDate}
+                            />
+                        </Form>
+                    </DialogContent>
+                    <DialogActions>
+                        <Button
+                            variant="outlined"
+                            onClick={() => setDialogOpen(false)}
+                        >
+                            Cancel
+                        </Button>
+                        <Button
+                            disableElevation
+                            variant="contained"
+                            color="primary"
+                            onClick={() => handleSubmit()}
+                        >
+                            Search
+                        </Button>
+                    </DialogActions>
+                </Dialog>
+            )}
+        </>
+    );
+};
+
+export default BrowseReceivingFilterDialog;

--- a/frontend/src/ui/Placeholder.tsx
+++ b/frontend/src/ui/Placeholder.tsx
@@ -1,0 +1,36 @@
+import React, { FC } from 'react';
+import { Box, makeStyles, Paper, Typography } from '@material-ui/core';
+
+const useStyles = makeStyles(({ typography, spacing }) => ({
+    font: {
+        fontWeight: typography.fontWeightBold,
+    },
+    container: {
+        boxShadow: '0 2px 25px 0 rgb(34 36 38 / 5%) inset',
+        backgroundColor: 'transparent',
+    },
+    flexContainer: {
+        minHeight: spacing(20),
+    },
+}));
+
+const Placeholder: FC = ({ children }) => {
+    const { font, container, flexContainer } = useStyles();
+
+    return (
+        <Paper variant="outlined" className={container}>
+            <Box
+                display="flex"
+                justifyContent="center"
+                alignItems="center"
+                className={flexContainer}
+            >
+                <Typography variant="h6" className={font}>
+                    {children}
+                </Typography>
+            </Box>
+        </Paper>
+    );
+};
+
+export default Placeholder;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/15024562/125859797-8f096cdd-24ff-40d1-93ce-81741e290683.png)

## Summary
This PR extracts the browse receiving filters into a dialog. I was unsatisfied with the current UI - the feature was pushed live to satisfy a critical business need at the time, and required further polish.

Filter metadata was extracted into the results list header, and we've also implemented a "clear filters" button as well. This also implements a "no results found" placeholder, which was missing entirely.

Interestingly, I learned that Formik forms do not reinitialize with new values when props change (I suspect they are being cached in some external context?), and even when unmounted and remounted. Because the filter form dialog state is seeded from the parent's filters as a prop, we have to enable the aptly-named `enableReinitialize` config option for this functionality.