### PR TITLE
Interrupt tab close

### DIFF
--- a/frontend/src/Receiving/Receiving.tsx
+++ b/frontend/src/Receiving/Receiving.tsx
@@ -15,7 +15,7 @@ import useInterruptExit from '../utils/useInterruptExit';
 interface Props {}
 
 const Receiving: FC<Props> = () => {
-    const [showPrompt, setShowPrompt] = useInterruptExit(false);
+    const { setShowPrompt } = useInterruptExit(false);
     const [term, setTerm] = useState<string>('');
     const [loading, setLoading] = useState<boolean>(false);
     const {

--- a/frontend/src/Receiving/Receiving.tsx
+++ b/frontend/src/Receiving/Receiving.tsx
@@ -9,10 +9,13 @@ import { Grid } from '@material-ui/core';
 import { HeaderText } from '../ui/Typography';
 import ControlledSearchBar from '../ui/ControlledSearchBar';
 import Loading from '../ui/Loading';
+import { Prompt } from 'react-router';
+import useInterruptExit from '../utils/useInterruptExit';
 
 interface Props {}
 
 const Receiving: FC<Props> = () => {
+    const [showPrompt, setShowPrompt] = useInterruptExit(false);
     const [term, setTerm] = useState<string>('');
     const [loading, setLoading] = useState<boolean>(false);
     const {
@@ -22,10 +25,23 @@ const Receiving: FC<Props> = () => {
         resetSearchResults,
     } = useContext(ReceivingContext);
 
-    // Reset the search results on componentDidUnmount to clear store
+    /**
+     * Reset the search results on unmount to clear store
+     */
     useEffect(() => {
         return () => resetSearchResults();
     }, []);
+
+    /**
+     * Maintains whether or not we show the exit prompt on tab close or refresh
+     */
+    useEffect(() => {
+        if (receivingList.length > 0) {
+            setShowPrompt(true);
+        } else {
+            setShowPrompt(false);
+        }
+    }, [receivingList]);
 
     useEffect(() => {
         if (term) {
@@ -39,6 +55,10 @@ const Receiving: FC<Props> = () => {
 
     return (
         <>
+            <Prompt
+                message="You have items in your list. Are you sure you wish to leave?"
+                when={receivingList.length > 0}
+            />
             <ControlledSearchBar value={term} onChange={(v) => setTerm(v)} />
             <br />
             <Grid container spacing={2}>

--- a/frontend/src/Sale/Sale.tsx
+++ b/frontend/src/Sale/Sale.tsx
@@ -11,10 +11,13 @@ import sum from '../utils/sum';
 import { Box, Grid } from '@material-ui/core';
 import { HeaderText } from '../ui/Typography';
 import ControlledSearchBar from '../ui/ControlledSearchBar';
+import useInterruptExit from '../utils/useInterruptExit';
+import { Prompt } from 'react-router';
 
 interface Props {}
 
 const Sale: FC<Props> = () => {
+    const { setShowPrompt } = useInterruptExit(false);
     const [term, setTerm] = useState<string>('');
     const [loading, setLoading] = useState<boolean>(false);
     const {
@@ -28,6 +31,17 @@ const Sale: FC<Props> = () => {
         suspendSale,
     } = useContext(SaleContext);
 
+    /**
+     * Maintains whether or not we show the exit prompt on tab close or refresh
+     */
+    useEffect(() => {
+        if (saleListCards.length > 0) {
+            setShowPrompt(true);
+        } else {
+            setShowPrompt(false);
+        }
+    }, [saleListCards]);
+
     useEffect(() => {
         if (term) {
             (async () => {
@@ -40,6 +54,10 @@ const Sale: FC<Props> = () => {
 
     return (
         <>
+            <Prompt
+                message="You have items in your list. Are you sure you wish to leave?"
+                when={saleListCards.length > 0}
+            />
             <ControlledSearchBar value={term} onChange={(v) => setTerm(v)} />
             <br />
             <Grid container spacing={2}>

--- a/frontend/src/utils/useInterruptExit.ts
+++ b/frontend/src/utils/useInterruptExit.ts
@@ -1,0 +1,41 @@
+import { useState, useEffect } from 'react';
+
+/**
+ * The browser emits a "beforeunload" event right before the user closes a tab or refreshes
+ * to indicate freeing resources. We interrupt this process and render a confirmation dialog.
+ */
+const onInterrupt = (e: BeforeUnloadEvent) => {
+    e.preventDefault();
+    e.returnValue = '';
+};
+
+const initBeforeUnload = (showPrompt: boolean) => {
+    if (showPrompt) {
+        window.addEventListener('beforeunload', onInterrupt);
+    } else {
+        window.removeEventListener('beforeunload', onInterrupt);
+    }
+};
+
+/**
+ * Custom hook that tracks whether or not we add the listener event,
+ * based on an initial value.
+ */
+const useInterruptExit = (initial: boolean) => {
+    const [showPrompt, setShowPrompt] = useState<boolean>(initial);
+
+    initBeforeUnload(showPrompt);
+
+    useEffect(() => {
+        initBeforeUnload(showPrompt);
+
+        // Remember to remove the listener on unmount!
+        return () => {
+            window.removeEventListener('beforeunload', onInterrupt);
+        };
+    }, [showPrompt]);
+
+    return [showPrompt, setShowPrompt] as const;
+};
+
+export default useInterruptExit;

--- a/frontend/src/utils/useInterruptExit.ts
+++ b/frontend/src/utils/useInterruptExit.ts
@@ -35,7 +35,7 @@ const useInterruptExit = (initial: boolean) => {
         };
     }, [showPrompt]);
 
-    return [showPrompt, setShowPrompt] as const;
+    return { showPrompt, setShowPrompt };
 };
 
 export default useInterruptExit;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/15024562/125974094-d600656d-6cd6-4efb-bf4f-71ee7f6652c8.png)
![image](https://user-images.githubusercontent.com/15024562/125974450-ad54c6ae-fddc-4b4a-a700-3fb74fd4c7fc.png)

## Summary
Users have still reported losing critical in-progress lists through accidental refreshes or tab closures. To that end, I've issued confirmation dialogs via:
1. Subscribing to the `beforeunload` event right before the browser releases resources on refresh or tab close, by interrupting it, and
2. Issued a `<Prompt />` component to interrupt history changes.

Each of these dialogs will trigger if a user has a list in progress. I'm confident that these measures will cover 99.9% of our bases here, short of actively saving lists to the server or localstorage to rehydrate state after an accidental closure.