### PR TITLE
Card header MUI refactors and layout improvements

### DIFF
--- a/frontend/src/common/Chip.tsx
+++ b/frontend/src/common/Chip.tsx
@@ -1,0 +1,28 @@
+import React, { FC } from 'react';
+import { Chip as MUIChip, makeStyles, ChipProps } from '@material-ui/core';
+import clsx from 'clsx';
+
+type Props = ChipProps & { foil?: boolean };
+
+const useStyles = makeStyles({
+    foilContainer: {
+        backgroundColor: '#ffcfdf !important',
+        backgroundImage:
+            'linear-gradient(90deg, #ffcfdf 0%, #b0f3f1 74%) !important',
+    },
+    border: {
+        borderRadius: 5,
+    },
+});
+
+const Chip: FC<Props> = (props) => {
+    const { foilContainer, border } = useStyles();
+
+    if (props.foil) {
+        return <MUIChip {...props} className={clsx(foilContainer, border)} />;
+    }
+
+    return <MUIChip {...props} className={border} />;
+};
+
+export default Chip;

--- a/frontend/src/common/MarketPrice.tsx
+++ b/frontend/src/common/MarketPrice.tsx
@@ -1,16 +1,6 @@
 import React, { useState, useEffect, FC } from 'react';
-import { Label, Icon } from 'semantic-ui-react';
-import styled from 'styled-components';
+import Chip from './Chip';
 import marketPriceQuery from './marketPriceQuery';
-
-const LabelStyle = styled(Label)`
-    background-color: ${(props) =>
-        !!props.foil ? '#ffcfdf' : null} !important;
-    background-image: ${(props) =>
-        !!props.foil
-            ? 'linear-gradient(90deg, #ffcfdf 0%, #b0f3f1 74%)'
-            : null} !important;
-`;
 
 type Finish = 'FOIL' | 'NONFOIL';
 
@@ -58,36 +48,40 @@ const MarketPrice: FC<Props> = ({ id, finish, round, showMid = true }) => {
         })();
     }, [id, finish]);
 
-    const loader = (
-        <span>
-            Loading <Icon loading name="spinner" />
-        </span>
-    );
+    const loader = <span>Loading...</span>;
 
     return (
         <>
-            <LabelStyle foil={isFoil}>
-                {loading ? (
-                    loader
-                ) : (
-                    <span>
-                        Mkt.{' '}
-                        {round
-                            ? displayPrice(
-                                  market ? roundNearestStep(market) : null
-                              )
-                            : displayPrice(market)}
-                    </span>
-                )}
-            </LabelStyle>
-            {showMid && (
-                <LabelStyle foil={isFoil}>
-                    {loading ? (
+            <Chip
+                size="small"
+                foil={isFoil}
+                label={
+                    loading ? (
                         loader
                     ) : (
-                        <span>Mid. {displayPrice(median)}</span>
-                    )}
-                </LabelStyle>
+                        <span>
+                            Mkt.{' '}
+                            {round
+                                ? displayPrice(
+                                      market ? roundNearestStep(market) : null
+                                  )
+                                : displayPrice(market)}
+                        </span>
+                    )
+                }
+            />
+            {showMid && (
+                <Chip
+                    size="small"
+                    foil={isFoil}
+                    label={
+                        loading ? (
+                            loader
+                        ) : (
+                            <span>Mid. {displayPrice(median)}</span>
+                        )
+                    }
+                />
             )}
         </>
     );

--- a/frontend/src/common/QohLabels.tsx
+++ b/frontend/src/common/QohLabels.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react';
-import { Popup } from 'semantic-ui-react';
+import { Tooltip, Typography } from '@material-ui/core';
 import InventoryChip from '../ui/InventoryChip';
 import displayFinishCondition from '../utils/finishCondition';
 import parseQoh from '../utils/parseQoh';
@@ -38,12 +38,17 @@ const LabelWithPopup: FC<LabelWithPopupProps> = ({
     label,
     popupLineItems,
 }) => (
-    <Popup
-        content={popupLineItems.map((msg) => (
-            <div>{msg}</div>
+    <Tooltip
+        title={popupLineItems.map((item) => (
+            <Typography key={Math.random()} variant="body2">
+                {item}
+            </Typography>
         ))}
-        trigger={<InventoryChip quantity={quantity} label={label} />}
-    />
+        arrow
+        placement="top"
+    >
+        <InventoryChip quantity={quantity} label={label} />
+    </Tooltip>
 );
 
 // This component parses the `qoh` object from mongo into something more presentable

--- a/frontend/src/common/QohLabels.tsx
+++ b/frontend/src/common/QohLabels.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from 'react';
-import { Label, Popup } from 'semantic-ui-react';
+import { Popup } from 'semantic-ui-react';
+import InventoryChip from '../ui/InventoryChip';
 import displayFinishCondition from '../utils/finishCondition';
 import parseQoh from '../utils/parseQoh';
 import { QOH } from '../utils/ScryfallCard';
@@ -41,12 +42,7 @@ const LabelWithPopup: FC<LabelWithPopupProps> = ({
         content={popupLineItems.map((msg) => (
             <div>{msg}</div>
         ))}
-        trigger={
-            <Label color={quantity > 0 ? 'blue' : undefined} image>
-                {label}
-                <Label.Detail>{quantity}</Label.Detail>
-            </Label>
-        }
+        trigger={<InventoryChip quantity={quantity} label={label} />}
     />
 );
 

--- a/frontend/src/ui/CardHeader.tsx
+++ b/frontend/src/ui/CardHeader.tsx
@@ -1,11 +1,13 @@
 import React, { FC } from 'react';
 import { ScryfallCard } from '../utils/ScryfallCard';
-import { Label, Item, Button, Icon } from 'semantic-ui-react';
+import { Label, Item } from 'semantic-ui-react';
 import QohLabels from '../common/QohLabels';
 import Language from '../common/Language';
 import MarketPrice from '../common/MarketPrice';
 import { Finish } from '../utils/checkCardFinish';
 import SetIcon from './SetIcon';
+import Button from './Button';
+import { Link } from '@material-ui/core';
 
 interface Props {
     card: ScryfallCard;
@@ -19,19 +21,11 @@ const TcgPriceButton: FC<{ tcgId: number | null }> = ({ tcgId }) => {
     const tcgUrl = `https://www.tcgplayer.com/product/${tcgId}`;
 
     return (
-        <Button
-            icon
-            disabled={!tcgId}
-            color="twitter"
-            labelPosition="right"
-            size="mini"
-            as="a"
-            href={tcgUrl}
-            target="_blank"
-        >
-            {!tcgId ? 'Link unavailable' : 'View on TCG'}
-            <Icon name="external share" />
-        </Button>
+        <Link href={tcgUrl} target="_blank">
+            <Button primary disabled={!tcgId} size="small">
+                {!tcgId ? 'Link unavailable' : 'View on TCG'}
+            </Button>
+        </Link>
     );
 };
 

--- a/frontend/src/ui/CardHeader.tsx
+++ b/frontend/src/ui/CardHeader.tsx
@@ -1,13 +1,13 @@
 import React, { FC } from 'react';
 import { ScryfallCard } from '../utils/ScryfallCard';
-import { Label, Item } from 'semantic-ui-react';
 import QohLabels from '../common/QohLabels';
-import Language from '../common/Language';
 import MarketPrice from '../common/MarketPrice';
 import { Finish } from '../utils/checkCardFinish';
 import SetIcon from './SetIcon';
 import Button from './Button';
-import { Link } from '@material-ui/core';
+import { Box, Link, Typography, withStyles } from '@material-ui/core';
+import Chip from '../common/Chip';
+import language from '../utils/Language';
 
 interface Props {
     card: ScryfallCard;
@@ -29,6 +29,12 @@ const TcgPriceButton: FC<{ tcgId: number | null }> = ({ tcgId }) => {
     );
 };
 
+const SubheaderContainer = withStyles({
+    '& div': {
+        marginRight: 5,
+    },
+})(Box);
+
 const CardHeader: FC<Props> = ({
     card,
     selectedFinish,
@@ -47,22 +53,29 @@ const CardHeader: FC<Props> = ({
     } = card;
 
     return (
-        <Item.Header as="h3">
-            {display_name}
-            <SetIcon set={set} rarity={rarity} />
-            <Label color="grey">
-                {set_name} ({set.toUpperCase()})
-            </Label>
-            <QohLabels inventoryQty={qoh} />
-            <MarketPrice
-                id={id}
-                finish={selectedFinish}
-                showMid={showMid}
-                round={round}
-            />
-            <Language languageCode={lang} />
-            <TcgPriceButton tcgId={tcgplayer_id} />
-        </Item.Header>
+        <Box>
+            <Box display="flex" alignItems="center">
+                <Typography variant="h6">
+                    <b>{display_name}</b>
+                </Typography>
+                <SetIcon set={set} rarity={rarity} />
+            </Box>
+            <SubheaderContainer>
+                <Chip
+                    size="small"
+                    label={`${set_name} (${set.toUpperCase()})`}
+                />
+                <QohLabels inventoryQty={qoh} />
+                <MarketPrice
+                    id={id}
+                    finish={selectedFinish}
+                    showMid={showMid}
+                    round={round}
+                />
+                <Chip size="small" label={`${language(lang)}`} />
+                <TcgPriceButton tcgId={tcgplayer_id} />
+            </SubheaderContainer>
+        </Box>
     );
 };
 

--- a/frontend/src/ui/CardHeader.tsx
+++ b/frontend/src/ui/CardHeader.tsx
@@ -6,7 +6,6 @@ import { Finish } from '../utils/checkCardFinish';
 import SetIcon from './SetIcon';
 import Button from './Button';
 import { Box, Link, Typography, withStyles } from '@material-ui/core';
-import Chip from '../common/Chip';
 import language from '../utils/Language';
 
 interface Props {
@@ -29,11 +28,13 @@ const TcgPriceButton: FC<{ tcgId: number | null }> = ({ tcgId }) => {
     );
 };
 
-const SubheaderContainer = withStyles({
-    '& div': {
-        marginRight: 5,
+const SubheaderContainer = withStyles(({ spacing }) => ({
+    root: {
+        '& > div': {
+            marginRight: spacing(1),
+        },
     },
-})(Box);
+}))(Box);
 
 const CardHeader: FC<Props> = ({
     card,
@@ -61,10 +62,9 @@ const CardHeader: FC<Props> = ({
                 <SetIcon set={set} rarity={rarity} />
             </Box>
             <SubheaderContainer>
-                <Chip
-                    size="small"
-                    label={`${set_name} (${set.toUpperCase()})`}
-                />
+                <Typography variant="body2">
+                    {set_name} ({set.toUpperCase()}) - {language(lang)}
+                </Typography>
                 <QohLabels inventoryQty={qoh} />
                 <MarketPrice
                     id={id}
@@ -72,7 +72,6 @@ const CardHeader: FC<Props> = ({
                     showMid={showMid}
                     round={round}
                 />
-                <Chip size="small" label={`${language(lang)}`} />
                 <TcgPriceButton tcgId={tcgplayer_id} />
             </SubheaderContainer>
         </Box>

--- a/frontend/src/ui/InventoryChip.tsx
+++ b/frontend/src/ui/InventoryChip.tsx
@@ -1,0 +1,46 @@
+import React, { FC } from 'react';
+import { Chip, makeStyles } from '@material-ui/core';
+
+const useStyles = makeStyles(({ palette }) => ({
+    container: {
+        backgroundColor: ({ color }: { color?: 'primary' }) => {
+            if (color === 'primary') return palette.primary.main;
+            else return palette.grey[300];
+        },
+        display: 'inline-block',
+        borderRadius: 5,
+    },
+    chip: {
+        borderRadius: 5,
+    },
+}));
+
+const InventoryChip: FC<{
+    label: string;
+    quantity: number;
+}> = ({ label, quantity }) => {
+    const quantityColor = quantity > 0 ? 'primary' : undefined;
+
+    const { container, chip } = useStyles({
+        color: quantityColor,
+    });
+
+    return (
+        <div className={container}>
+            <Chip
+                color={quantityColor}
+                className={chip}
+                size="small"
+                label={label}
+            />
+            <Chip
+                color={quantityColor}
+                className={chip}
+                size="small"
+                label={quantity}
+            />
+        </div>
+    );
+};
+
+export default InventoryChip;

--- a/frontend/src/ui/InventoryChip.tsx
+++ b/frontend/src/ui/InventoryChip.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from 'react';
 import { Chip, makeStyles } from '@material-ui/core';
+import { forwardRef } from 'react';
 
 const useStyles = makeStyles(({ palette }) => ({
     container: {
@@ -15,32 +16,41 @@ const useStyles = makeStyles(({ palette }) => ({
     },
 }));
 
-const InventoryChip: FC<{
+interface Props {
     label: string;
     quantity: number;
-}> = ({ label, quantity }) => {
-    const quantityColor = quantity > 0 ? 'primary' : undefined;
+}
 
-    const { container, chip } = useStyles({
-        color: quantityColor,
-    });
+/**
+ * We need to forward the refs from possible tooltip implementations to this custom
+ * component so `Tooltip` can access and modify the underlying children
+ */
+const InventoryChip: FC<Props> = forwardRef<HTMLDivElement, Props>(
+    (props, ref) => {
+        const { quantity, label } = props;
+        const quantityColor = quantity > 0 ? 'primary' : undefined;
 
-    return (
-        <div className={container}>
-            <Chip
-                color={quantityColor}
-                className={chip}
-                size="small"
-                label={label}
-            />
-            <Chip
-                color={quantityColor}
-                className={chip}
-                size="small"
-                label={quantity}
-            />
-        </div>
-    );
-};
+        const { container, chip } = useStyles({
+            color: quantityColor,
+        });
+
+        return (
+            <div {...props} ref={ref} className={container}>
+                <Chip
+                    color={quantityColor}
+                    className={chip}
+                    size="small"
+                    label={label}
+                />
+                <Chip
+                    color={quantityColor}
+                    className={chip}
+                    size="small"
+                    label={quantity}
+                />
+            </div>
+        );
+    }
+);
 
 export default InventoryChip;

--- a/frontend/src/ui/InventoryChip.tsx
+++ b/frontend/src/ui/InventoryChip.tsx
@@ -2,19 +2,27 @@ import React, { FC } from 'react';
 import { Chip, makeStyles } from '@material-ui/core';
 import { forwardRef } from 'react';
 
-const useStyles = makeStyles(({ palette }) => ({
+const useStyles = makeStyles({
     container: {
-        backgroundColor: ({ color }: { color?: 'primary' }) => {
-            if (color === 'primary') return palette.primary.main;
-            else return palette.grey[300];
-        },
         display: 'inline-block',
         borderRadius: 5,
     },
     chip: {
         borderRadius: 5,
     },
-}));
+    leftChip: {
+        borderTopRightRadius: 0,
+        borderBottomRightRadius: 0,
+        borderTopLeftRadius: 5,
+        borderBottomLeftRadius: 5,
+    },
+    rightChip: {
+        borderTopLeftRadius: 0,
+        borderBottomLeftRadius: 0,
+        borderTopRightRadius: 5,
+        borderBottomRightRadius: 5,
+    },
+});
 
 interface Props {
     label: string;
@@ -28,23 +36,20 @@ interface Props {
 const InventoryChip: FC<Props> = forwardRef<HTMLDivElement, Props>(
     (props, ref) => {
         const { quantity, label } = props;
+        const { container, leftChip, rightChip } = useStyles();
         const quantityColor = quantity > 0 ? 'primary' : undefined;
-
-        const { container, chip } = useStyles({
-            color: quantityColor,
-        });
 
         return (
             <div {...props} ref={ref} className={container}>
                 <Chip
                     color={quantityColor}
-                    className={chip}
+                    className={leftChip}
                     size="small"
                     label={label}
                 />
                 <Chip
                     color={quantityColor}
-                    className={chip}
+                    className={rightChip}
                     size="small"
                     label={quantity}
                 />

--- a/frontend/src/utils/Language.ts
+++ b/frontend/src/utils/Language.ts
@@ -1,6 +1,4 @@
-import React, { FC } from 'react';
-import { Label } from 'semantic-ui-react';
-import { LanguageCode } from '../utils/ScryfallCard';
+import { LanguageCode } from './ScryfallCard';
 
 const LANG_CODES: Record<LanguageCode, string> = {
     en: 'English',
@@ -21,14 +19,9 @@ const LANG_CODES: Record<LanguageCode, string> = {
     sa: 'Sanskrit',
     px: 'Phyrexian',
 };
-interface Props {
-    languageCode: LanguageCode;
+
+function language(languageCode: LanguageCode): string {
+    return LANG_CODES[languageCode];
 }
 
-const Language: FC<Props> = ({ languageCode }) => (
-    <Label image color="grey">
-        {LANG_CODES[languageCode]}
-    </Label>
-);
-
-export default Language;
+export default language;


### PR DESCRIPTION
Before (it's hideous!):
![image](https://user-images.githubusercontent.com/15024562/128257301-d5dc9a2a-e846-4876-90b1-536b1c8b59ba.png)

After (it's organized!):
![image](https://user-images.githubusercontent.com/15024562/128257376-62a443ca-bad8-4655-80f4-de2ac9029947.png)

## Summary
This PR issues some changes to the card header layout, but more importantly, it refactors all of `CardHeader`'s dependencies away from Semantic-ui-react. 