### PR TITLE
Continue removing Semantic UI React - Layouts

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.10.7",
             "dependencies": {
                 "@fontsource/roboto": "^4.5.0",
-                "@material-ui/core": "^4.11.4",
+                "@material-ui/core": "^4.12.1",
                 "@material-ui/icons": "^4.11.2",
                 "@material-ui/lab": "^4.0.0-alpha.60",
                 "@types/jest": "^26.0.20",
@@ -3622,13 +3622,13 @@
             }
         },
         "node_modules/@material-ui/core": {
-            "version": "4.11.4",
-            "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.11.4.tgz",
-            "integrity": "sha512-oqb+lJ2Dl9HXI9orc6/aN8ZIAMkeThufA5iZELf2LQeBn2NtjVilF5D2w7e9RpntAzDb4jK5DsVhkfOvFY/8fg==",
+            "version": "4.12.3",
+            "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.12.3.tgz",
+            "integrity": "sha512-sdpgI/PL56QVsEJldwEe4FFaFTLUqN+rd7sSZiRCdx2E/C7z5yK0y/khAWVBH24tXwto7I1hCzNWfJGZIYJKnw==",
             "dependencies": {
                 "@babel/runtime": "^7.4.4",
                 "@material-ui/styles": "^4.11.4",
-                "@material-ui/system": "^4.11.3",
+                "@material-ui/system": "^4.12.1",
                 "@material-ui/types": "5.1.0",
                 "@material-ui/utils": "^4.11.2",
                 "@types/react-transition-group": "^4.2.0",
@@ -3751,9 +3751,9 @@
             "integrity": "sha512-u1wmTI1jJGzCJzWndZo8mk4wnPTZd1eOIYTYvuEyOQGfmDl3TrabCCfKnOC86FZwW/9djqTl933UF/cS425i9A=="
         },
         "node_modules/@material-ui/system": {
-            "version": "4.11.3",
-            "resolved": "https://registry.npmjs.org/@material-ui/system/-/system-4.11.3.tgz",
-            "integrity": "sha512-SY7otguNGol41Mu2Sg6KbBP1ZRFIbFLHGK81y4KYbsV2yIcaEPOmsCK6zwWlp+2yTV3J/VwT6oSBARtGIVdXPw==",
+            "version": "4.12.1",
+            "resolved": "https://registry.npmjs.org/@material-ui/system/-/system-4.12.1.tgz",
+            "integrity": "sha512-lUdzs4q9kEXZGhbN7BptyiS1rLNHe6kG9o8Y307HCvF4sQxbCgpL2qi+gUk+yI8a2DNk48gISEQxoxpgph0xIw==",
             "dependencies": {
                 "@babel/runtime": "^7.4.4",
                 "@material-ui/utils": "^4.11.2",
@@ -26690,13 +26690,13 @@
             }
         },
         "@material-ui/core": {
-            "version": "4.11.4",
-            "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.11.4.tgz",
-            "integrity": "sha512-oqb+lJ2Dl9HXI9orc6/aN8ZIAMkeThufA5iZELf2LQeBn2NtjVilF5D2w7e9RpntAzDb4jK5DsVhkfOvFY/8fg==",
+            "version": "4.12.3",
+            "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.12.3.tgz",
+            "integrity": "sha512-sdpgI/PL56QVsEJldwEe4FFaFTLUqN+rd7sSZiRCdx2E/C7z5yK0y/khAWVBH24tXwto7I1hCzNWfJGZIYJKnw==",
             "requires": {
                 "@babel/runtime": "^7.4.4",
                 "@material-ui/styles": "^4.11.4",
-                "@material-ui/system": "^4.11.3",
+                "@material-ui/system": "^4.12.1",
                 "@material-ui/types": "5.1.0",
                 "@material-ui/utils": "^4.11.2",
                 "@types/react-transition-group": "^4.2.0",
@@ -26759,9 +26759,9 @@
             }
         },
         "@material-ui/system": {
-            "version": "4.11.3",
-            "resolved": "https://registry.npmjs.org/@material-ui/system/-/system-4.11.3.tgz",
-            "integrity": "sha512-SY7otguNGol41Mu2Sg6KbBP1ZRFIbFLHGK81y4KYbsV2yIcaEPOmsCK6zwWlp+2yTV3J/VwT6oSBARtGIVdXPw==",
+            "version": "4.12.1",
+            "resolved": "https://registry.npmjs.org/@material-ui/system/-/system-4.12.1.tgz",
+            "integrity": "sha512-lUdzs4q9kEXZGhbN7BptyiS1rLNHe6kG9o8Y307HCvF4sQxbCgpL2qi+gUk+yI8a2DNk48gISEQxoxpgph0xIw==",
             "requires": {
                 "@babel/runtime": "^7.4.4",
                 "@material-ui/utils": "^4.11.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
     "homepage": "http://www.chcollector.com/",
     "dependencies": {
         "@fontsource/roboto": "^4.5.0",
-        "@material-ui/core": "^4.11.4",
+        "@material-ui/core": "^4.12.1",
         "@material-ui/icons": "^4.11.2",
         "@material-ui/lab": "^4.0.0-alpha.60",
         "@types/jest": "^26.0.20",

--- a/frontend/src/BrowseInventory/BrowseInventory.tsx
+++ b/frontend/src/BrowseInventory/BrowseInventory.tsx
@@ -2,7 +2,6 @@ import React, { FC, useState } from 'react';
 import BrowseInventoryForm, { initialFilters } from './BrowseInventoryForm';
 import BrowseInventoryRow from './BrowseInventoryRow';
 import {
-    Table,
     Menu,
     Icon,
     Dimmer,
@@ -17,6 +16,16 @@ import filteredCardsQuery, {
 } from './filteredCardsQuery';
 import Placeholder from '../ui/Placeholder';
 import SearchIcon from '@material-ui/icons/Search';
+import {
+    Paper,
+    Table,
+    TableBody,
+    TableCell,
+    TableContainer,
+    TableFooter,
+    TableHead,
+    TableRow,
+} from '@material-ui/core';
 
 const LIMIT = 100; // Matching the backend for now
 
@@ -110,147 +119,158 @@ const BrowseInventory: FC = () => {
             </Segment>
             <BrowseInventoryForm doSubmit={fetchData} />
             {!!cards.length && (
-                <Table celled striped compact>
-                    <Table.Header>
-                        <Table.Row>
-                            <Table.HeaderCell colSpan="5">
-                                <Menu floated>
-                                    <Menu.Item>
-                                        Viewing page {currentPage} of {numPages}
-                                    </Menu.Item>
-                                </Menu>
-                                <Menu floated="right">
-                                    {showLeftPageButtons && (
-                                        <Menu.Item
-                                            as="a"
-                                            icon
-                                            onClick={() =>
-                                                fetchData(
-                                                    cachedFilters,
-                                                    currentPage - 1
-                                                )
-                                            }
-                                        >
-                                            <Icon name="chevron left" />
+                <TableContainer component={Paper} variant="outlined">
+                    <Table size="small">
+                        <TableHead>
+                            <TableRow>
+                                <TableHead>
+                                    <Menu floated>
+                                        <Menu.Item>
+                                            Viewing page {currentPage} of{' '}
+                                            {numPages}
                                         </Menu.Item>
-                                    )}
-                                    <React.Fragment>
-                                        {showPages.map((p) => {
-                                            return (
-                                                <Menu.Item
-                                                    key={`page-${p}`}
-                                                    onClick={() =>
-                                                        fetchData(
-                                                            cachedFilters,
-                                                            p
-                                                        )
-                                                    }
-                                                    active={currentPage === p}
-                                                    disabled={currentPage === p}
-                                                    as="a"
-                                                >
-                                                    {p}
-                                                </Menu.Item>
-                                            );
-                                        })}
-                                    </React.Fragment>
-                                    {showRightPageButtons && (
-                                        <Menu.Item
-                                            as="a"
-                                            icon
-                                            onClick={() =>
-                                                fetchData(
-                                                    cachedFilters,
-                                                    currentPage + 1
-                                                )
-                                            }
-                                        >
-                                            <Icon name="chevron right" />
+                                    </Menu>
+                                    <Menu floated="right">
+                                        {showLeftPageButtons && (
+                                            <Menu.Item
+                                                as="a"
+                                                icon
+                                                onClick={() =>
+                                                    fetchData(
+                                                        cachedFilters,
+                                                        currentPage - 1
+                                                    )
+                                                }
+                                            >
+                                                <Icon name="chevron left" />
+                                            </Menu.Item>
+                                        )}
+                                        <React.Fragment>
+                                            {showPages.map((p) => {
+                                                return (
+                                                    <Menu.Item
+                                                        key={`page-${p}`}
+                                                        onClick={() =>
+                                                            fetchData(
+                                                                cachedFilters,
+                                                                p
+                                                            )
+                                                        }
+                                                        active={
+                                                            currentPage === p
+                                                        }
+                                                        disabled={
+                                                            currentPage === p
+                                                        }
+                                                        as="a"
+                                                    >
+                                                        {p}
+                                                    </Menu.Item>
+                                                );
+                                            })}
+                                        </React.Fragment>
+                                        {showRightPageButtons && (
+                                            <Menu.Item
+                                                as="a"
+                                                icon
+                                                onClick={() =>
+                                                    fetchData(
+                                                        cachedFilters,
+                                                        currentPage + 1
+                                                    )
+                                                }
+                                            >
+                                                <Icon name="chevron right" />
+                                            </Menu.Item>
+                                        )}
+                                    </Menu>
+                                </TableHead>
+                            </TableRow>
+                        </TableHead>
+                        <TableHead>
+                            <TableRow>
+                                <TableCell>Name</TableCell>
+                                <TableCell>Edition</TableCell>
+                                <TableCell>Condition</TableCell>
+                                <TableCell>Qty</TableCell>
+                                <TableCell>Price</TableCell>
+                            </TableRow>
+                        </TableHead>
+                        <TableBody>
+                            {cards.map((card) => (
+                                <BrowseInventoryRow
+                                    key={`${card._id}-${card.finishCondition}`}
+                                    card={card}
+                                />
+                            ))}
+                        </TableBody>
+                        <TableFooter>
+                            <TableRow>
+                                <TableCell>
+                                    <Menu floated>
+                                        <Menu.Item>
+                                            Total results: {count}
                                         </Menu.Item>
-                                    )}
-                                </Menu>
-                            </Table.HeaderCell>
-                        </Table.Row>
-                    </Table.Header>
-                    <Table.Header>
-                        <Table.Row>
-                            <Table.HeaderCell>Name</Table.HeaderCell>
-                            <Table.HeaderCell>Edition</Table.HeaderCell>
-                            <Table.HeaderCell>Condition</Table.HeaderCell>
-                            <Table.HeaderCell>Qty</Table.HeaderCell>
-                            <Table.HeaderCell>Price</Table.HeaderCell>
-                        </Table.Row>
-                    </Table.Header>
-                    <Table.Body>
-                        {cards.map((card) => (
-                            <BrowseInventoryRow
-                                key={`${card._id}-${card.finishCondition}`}
-                                card={card}
-                            />
-                        ))}
-                    </Table.Body>
-                    <Table.Footer>
-                        <Table.Row>
-                            <Table.HeaderCell colSpan="5">
-                                <Menu floated>
-                                    <Menu.Item>
-                                        Total results: {count}
-                                    </Menu.Item>
-                                </Menu>
-                                <Menu floated="right">
-                                    {showLeftPageButtons && (
-                                        <Menu.Item
-                                            as="a"
-                                            icon
-                                            onClick={() =>
-                                                fetchData(
-                                                    cachedFilters,
-                                                    currentPage - 1
-                                                )
-                                            }
-                                        >
-                                            <Icon name="chevron left" />
-                                        </Menu.Item>
-                                    )}
-                                    <React.Fragment>
-                                        {showPages.map((p) => {
-                                            return (
-                                                <Menu.Item
-                                                    key={`page-${p}`}
-                                                    onClick={() =>
-                                                        fetchData(
-                                                            cachedFilters,
-                                                            p
-                                                        )
-                                                    }
-                                                    active={currentPage === p}
-                                                    disabled={currentPage === p}
-                                                    as="a"
-                                                >
-                                                    {p}
-                                                </Menu.Item>
-                                            );
-                                        })}
-                                    </React.Fragment>
-                                    {showRightPageButtons && (
-                                        <Menu.Item
-                                            as="a"
-                                            icon
-                                            onClick={() =>
-                                                fetchData(
-                                                    cachedFilters,
-                                                    currentPage + 1
-                                                )
-                                            }
-                                        >
-                                            <Icon name="chevron right" />
-                                        </Menu.Item>
-                                    )}
-                                </Menu>
-                            </Table.HeaderCell>
-                        </Table.Row>
-                    </Table.Footer>
-                </Table>
+                                    </Menu>
+                                    <Menu floated="right">
+                                        {showLeftPageButtons && (
+                                            <Menu.Item
+                                                as="a"
+                                                icon
+                                                onClick={() =>
+                                                    fetchData(
+                                                        cachedFilters,
+                                                        currentPage - 1
+                                                    )
+                                                }
+                                            >
+                                                <Icon name="chevron left" />
+                                            </Menu.Item>
+                                        )}
+                                        <React.Fragment>
+                                            {showPages.map((p) => {
+                                                return (
+                                                    <Menu.Item
+                                                        key={`page-${p}`}
+                                                        onClick={() =>
+                                                            fetchData(
+                                                                cachedFilters,
+                                                                p
+                                                            )
+                                                        }
+                                                        active={
+                                                            currentPage === p
+                                                        }
+                                                        disabled={
+                                                            currentPage === p
+                                                        }
+                                                        as="a"
+                                                    >
+                                                        {p}
+                                                    </Menu.Item>
+                                                );
+                                            })}
+                                        </React.Fragment>
+                                        {showRightPageButtons && (
+                                            <Menu.Item
+                                                as="a"
+                                                icon
+                                                onClick={() =>
+                                                    fetchData(
+                                                        cachedFilters,
+                                                        currentPage + 1
+                                                    )
+                                                }
+                                            >
+                                                <Icon name="chevron right" />
+                                            </Menu.Item>
+                                        )}
+                                    </Menu>
+                                </TableCell>
+                            </TableRow>
+                        </TableFooter>
+                    </Table>
+                </TableContainer>
             )}
             <br />
             {!cards.length && (

--- a/frontend/src/BrowseInventory/BrowseInventory.tsx
+++ b/frontend/src/BrowseInventory/BrowseInventory.tsx
@@ -8,7 +8,6 @@ import {
     Dimmer,
     Loader,
     Segment,
-    Header,
     Container,
 } from 'semantic-ui-react';
 import _ from 'lodash';
@@ -16,6 +15,9 @@ import filteredCardsQuery, {
     Filters,
     ResponseCard,
 } from './filteredCardsQuery';
+import Placeholder from '../ui/Placeholder';
+import SearchIcon from '@material-ui/icons/Search';
+
 const LIMIT = 100; // Matching the backend for now
 
 interface State {
@@ -250,15 +252,13 @@ const BrowseInventory: FC = () => {
                     </Table.Footer>
                 </Table>
             )}
+            <br />
             {!cards.length && (
-                <Segment placeholder>
-                    <Header icon>
-                        <Icon name="search" />
-                        {state.searchTouched
-                            ? 'No results found'
-                            : 'Use the filters to browse inventory'}
-                    </Header>
-                </Segment>
+                <Placeholder icon={<SearchIcon style={{ fontSize: 80 }} />}>
+                    {state.searchTouched
+                        ? 'No results found'
+                        : 'Use the filters to browse inventory'}
+                </Placeholder>
             )}
         </Container>
     );

--- a/frontend/src/BrowseInventory/BrowseInventoryRow.tsx
+++ b/frontend/src/BrowseInventory/BrowseInventoryRow.tsx
@@ -41,6 +41,7 @@ const BrowseInventoryRow: FC<Props> = ({
                     <span style={{ cursor: 'help' }}>{name} </span>
                 </CardImageTooltip>
                 {finish === 'FOIL' && (
+                    // TODO: Pull out this inline styling into a custom component
                     <StarIcon
                         fontSize="small"
                         color="primary"

--- a/frontend/src/BrowseInventory/BrowseInventoryRow.tsx
+++ b/frontend/src/BrowseInventory/BrowseInventoryRow.tsx
@@ -1,9 +1,10 @@
+import { TableCell, TableRow } from '@material-ui/core';
 import React, { FC } from 'react';
-import { Table, Icon } from 'semantic-ui-react';
 import Price from '../common/Price';
 import CardImageTooltip from '../ui/CardImageTooltip';
 import SetIcon from '../ui/SetIcon';
 import { ResponseCard } from './filteredCardsQuery';
+import StarIcon from '@material-ui/icons/Star';
 
 const conditionMap = {
     NM: 'Near Mint',
@@ -34,23 +35,29 @@ const BrowseInventoryRow: FC<Props> = ({
     const condition = finishCondition.split('_')[1] as Condition;
 
     return (
-        <Table.Row>
-            <Table.Cell>
+        <TableRow>
+            <TableCell>
                 <CardImageTooltip cardImage={image_uri}>
                     <span style={{ cursor: 'help' }}>{name} </span>
                 </CardImageTooltip>
-                {finish === 'FOIL' && <Icon name="star" color="blue" />}
-            </Table.Cell>
-            <Table.Cell>
+                {finish === 'FOIL' && (
+                    <StarIcon
+                        fontSize="small"
+                        color="primary"
+                        style={{ verticalAlign: 'middle' }}
+                    />
+                )}
+            </TableCell>
+            <TableCell>
                 <SetIcon set={set} rarity={rarity} />
                 {set_name}
-            </Table.Cell>
-            <Table.Cell>{conditionMap[condition]}</Table.Cell>
-            <Table.Cell>{quantityInStock}</Table.Cell>
-            <Table.Cell>
+            </TableCell>
+            <TableCell>{conditionMap[condition]}</TableCell>
+            <TableCell>{quantityInStock}</TableCell>
+            <TableCell>
                 <Price num={price} />
-            </Table.Cell>
-        </Table.Row>
+            </TableCell>
+        </TableRow>
     );
 };
 

--- a/frontend/src/BrowseReceiving/BrowseReceivingItem.tsx
+++ b/frontend/src/BrowseReceiving/BrowseReceivingItem.tsx
@@ -1,5 +1,4 @@
 import React, { FC, useState } from 'react';
-import { Label } from 'semantic-ui-react';
 import { Received } from './browseReceivingQuery';
 import pluralize from '../utils/pluralize';
 import formatDate from '../utils/formatDate';
@@ -16,6 +15,7 @@ import { getPrice } from '../common/Price';
 import MetaData from '../ui/MetaData';
 import { Trade } from '../context/ReceivingContext';
 import displayEmpty from '../utils/displayEmpty';
+import Chip from '../common/Chip';
 
 interface Props {
     received: Received;
@@ -83,24 +83,20 @@ const BrowseReceivingItem: FC<Props> = ({ received }) => {
                                 </Typography>
                             </Grid>
                             <Grid item>
-                                <Label
-                                    color={cashPrice > 0 ? 'blue' : undefined}
-                                    image
-                                >
-                                    Cash:
-                                    <Label.Detail>
-                                        {getPrice(cashPrice)}
-                                    </Label.Detail>
-                                </Label>
-                                <Label
-                                    color={creditPrice > 0 ? 'blue' : undefined}
-                                    image
-                                >
-                                    Credit:
-                                    <Label.Detail>
-                                        {getPrice(creditPrice)}
-                                    </Label.Detail>
-                                </Label>
+                                <Chip
+                                    size="small"
+                                    label={`Cash: ${getPrice(cashPrice)}`}
+                                    color={
+                                        cashPrice > 0 ? 'primary' : undefined
+                                    }
+                                />
+                                <Chip
+                                    size="small"
+                                    label={`Cash: ${getPrice(creditPrice)}`}
+                                    color={
+                                        creditPrice > 0 ? 'primary' : undefined
+                                    }
+                                />
                             </Grid>
                         </Grid>
                     </CardContent>

--- a/frontend/src/BrowseSales/BrowseSales.tsx
+++ b/frontend/src/BrowseSales/BrowseSales.tsx
@@ -1,10 +1,9 @@
 import React, { FC, useEffect, useState } from 'react';
 import BrowseSalesList from './BrowseSalesList';
-import { Divider } from 'semantic-ui-react';
 import browseSalesQuery, { Sale } from './browseSalesQuery';
 import { HeaderText } from '../ui/Typography';
 import Loading from '../ui/Loading';
-import { Grid, Typography } from '@material-ui/core';
+import { Grid, Typography, Divider } from '@material-ui/core';
 import ControlledSearchBar from '../ui/ControlledSearchBar';
 
 const BrowseSales: FC = () => {

--- a/frontend/src/BrowseSales/BrowseSales.tsx
+++ b/frontend/src/BrowseSales/BrowseSales.tsx
@@ -3,7 +3,7 @@ import BrowseSalesList from './BrowseSalesList';
 import browseSalesQuery, { Sale } from './browseSalesQuery';
 import { HeaderText } from '../ui/Typography';
 import Loading from '../ui/Loading';
-import { Grid, Typography, Divider } from '@material-ui/core';
+import { Grid, Typography, Divider, Box } from '@material-ui/core';
 import ControlledSearchBar from '../ui/ControlledSearchBar';
 
 const BrowseSales: FC = () => {
@@ -44,12 +44,13 @@ const BrowseSales: FC = () => {
                 <Loading />
             ) : (
                 <>
-                    {term !== '' && (
-                        <Typography>
-                            {salesList.length} results for <em>{term}</em>
-                        </Typography>
-                    )}
-
+                    <Box py={2}>
+                        {term !== '' && (
+                            <Typography>
+                                {salesList.length} results for <em>{term}</em>
+                            </Typography>
+                        )}
+                    </Box>
                     <BrowseSalesList list={salesList} />
                 </>
             )}

--- a/frontend/src/BrowseSales/BrowseSalesItem.tsx
+++ b/frontend/src/BrowseSales/BrowseSalesItem.tsx
@@ -1,8 +1,8 @@
 import React, { FC } from 'react';
-import { Table } from 'semantic-ui-react';
 import sum from '../utils/sum';
 import { Sale } from './browseSalesQuery';
 import formatDate from '../utils/formatDate';
+import { TableCell, TableRow } from '@material-ui/core';
 
 interface Props {
     sale: Sale;
@@ -14,11 +14,11 @@ const BrowseSalesItem: FC<Props> = ({ sale }) => {
     const quantitySold = sum(card_list.map((c) => Number(c.qtyToSell)));
 
     return (
-        <Table.Row>
-            <Table.Cell>{sale_data.saleID}</Table.Cell>
-            <Table.Cell>{formatDate(sale_data.createTime)}</Table.Cell>
-            <Table.Cell>{quantitySold}</Table.Cell>
-        </Table.Row>
+        <TableRow>
+            <TableCell>{sale_data.saleID}</TableCell>
+            <TableCell>{formatDate(sale_data.createTime)}</TableCell>
+            <TableCell>{quantitySold}</TableCell>
+        </TableRow>
     );
 };
 

--- a/frontend/src/BrowseSales/BrowseSalesList.tsx
+++ b/frontend/src/BrowseSales/BrowseSalesList.tsx
@@ -1,6 +1,14 @@
+import {
+    Table,
+    TableCell,
+    TableHead,
+    TableBody,
+    TableRow,
+    Paper,
+    TableContainer,
+} from '@material-ui/core';
 import React, { FC } from 'react';
 import BrowseSalesItem from './BrowseSalesItem';
-import { Table } from 'semantic-ui-react';
 import { Sale } from './browseSalesQuery';
 
 interface Props {
@@ -9,21 +17,22 @@ interface Props {
 
 const BrowseSalesList: FC<Props> = ({ list }) => {
     return (
-        <Table celled unstackable compact>
-            <Table.Header>
-                <Table.Row>
-                    <Table.HeaderCell>Sale ID</Table.HeaderCell>
-                    <Table.HeaderCell>Date of Sale</Table.HeaderCell>
-                    <Table.HeaderCell>Quantity Sold</Table.HeaderCell>
-                </Table.Row>
-            </Table.Header>
-
-            <Table.Body>
-                {list.map((sale) => (
-                    <BrowseSalesItem sale={sale} />
-                ))}
-            </Table.Body>
-        </Table>
+        <TableContainer component={Paper} variant="outlined">
+            <Table size="small">
+                <TableHead>
+                    <TableRow>
+                        <TableCell>Sale ID</TableCell>
+                        <TableCell>Date of Sale</TableCell>
+                        <TableCell>Quantity Sold</TableCell>
+                    </TableRow>
+                </TableHead>
+                <TableBody>
+                    {list.map((sale) => (
+                        <BrowseSalesItem sale={sale} />
+                    ))}
+                </TableBody>
+            </Table>
+        </TableContainer>
     );
 };
 

--- a/frontend/src/ManageInventory/ManageInventory.tsx
+++ b/frontend/src/ManageInventory/ManageInventory.tsx
@@ -1,5 +1,4 @@
 import React, { useContext, useEffect, useState } from 'react';
-import { Segment, Header, Icon, Divider } from 'semantic-ui-react';
 import TotalStoreInventory from './TotalStoreInventory';
 import { InventoryContext } from '../context/InventoryContext';
 import ManageInventoryListItem from './ManageInventoryListItem';
@@ -7,6 +6,8 @@ import { Grid } from '@material-ui/core';
 import { HeaderText } from '../ui/Typography';
 import Loading from '../ui/Loading';
 import ControlledSearchBar from '../ui/ControlledSearchBar';
+import Placeholder from '../ui/Placeholder';
+import SearchIcon from '@material-ui/icons/Search';
 
 export default function ManageInventory() {
     const [term, setTerm] = useState<string>('');
@@ -43,21 +44,20 @@ export default function ManageInventory() {
                     />
                 )}
             </Grid>
-            <Divider />
+            <br />
             {loading ? (
                 <Loading />
             ) : (
                 <>
                     {!searchResults.length && (
-                        <Segment placeholder>
-                            <Header icon>
-                                <Icon name="search" />
-                                <em>
-                                    "For the first time in his life, Grakk felt
-                                    a little warm and fuzzy inside."
-                                </em>
-                            </Header>
-                        </Segment>
+                        <Placeholder
+                            icon={<SearchIcon style={{ fontSize: 80 }} />}
+                        >
+                            <em>
+                                "For the first time in his life, Grakk felt a
+                                little warm and fuzzy inside."
+                            </em>
+                        </Placeholder>
                     )}
                     <Grid container spacing={2}>
                         {searchResults.map((card) => (

--- a/frontend/src/PublicInventory/PublicInventory.tsx
+++ b/frontend/src/PublicInventory/PublicInventory.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useState } from 'react';
-import { Grid, Segment, Header, Icon } from 'semantic-ui-react';
+import { Grid, Header } from 'semantic-ui-react';
 import { ScryfallCard } from '../utils/ScryfallCard';
 import { FormikErrors, useFormik } from 'formik';
 import { ClubhouseLocation } from '../context/AuthProvider';
@@ -10,6 +10,8 @@ import ControlledSearchBar from '../ui/ControlledSearchBar';
 import ControlledDropdown from '../ui/ControlledDropdown';
 import Button from '../ui/Button';
 import { Grid as MUIGrid } from '@material-ui/core';
+import Placeholder from '../ui/Placeholder';
+import SearchIcon from '@material-ui/icons/Search';
 
 interface State {
     searchResults: ScryfallCard[];
@@ -145,16 +147,15 @@ const PublicInventory: FC = () => {
                             ))}
                         </GridContainer>
                     ) : (
-                        <Segment placeholder>
-                            <Header icon>
-                                <Icon name="search" />
-                                {formSubmitted ? (
-                                    <span>No cards found in stock</span>
-                                ) : (
-                                    <span>Search for a card</span>
-                                )}
-                            </Header>
-                        </Segment>
+                        <Placeholder
+                            icon={<SearchIcon style={{ fontSize: 80 }} />}
+                        >
+                            {formSubmitted ? (
+                                <span>No cards found in stock</span>
+                            ) : (
+                                <span>Search for a card</span>
+                            )}
+                        </Placeholder>
                     )}
                 </Grid.Column>
             </Grid>

--- a/frontend/src/Receiving/CashReport.tsx
+++ b/frontend/src/Receiving/CashReport.tsx
@@ -1,8 +1,15 @@
 import React, { FC } from 'react';
 import _ from 'lodash';
 import Price from '../common/Price';
-import { Table } from 'semantic-ui-react';
 import { ReceivingCard } from '../context/ReceivingContext';
+import {
+    Table,
+    TableHead,
+    TableRow,
+    TableCell,
+    TableBody,
+    TableFooter,
+} from '@material-ui/core';
 
 interface Props {
     receivingList: ReceivingCard[];
@@ -49,51 +56,49 @@ const CashReport: FC<Props> = ({ receivingList }) => {
     return (
         <React.Fragment>
             <div id="cash-report">
-                <Table celled>
-                    <Table.Header>
-                        <Table.Row>
-                            <Table.HeaderCell colSpan={6}>
-                                Employee Name:
-                            </Table.HeaderCell>
-                        </Table.Row>
-                        <Table.Row>
-                            <Table.HeaderCell>Card Name</Table.HeaderCell>
-                            <Table.HeaderCell>Market Value</Table.HeaderCell>
-                            <Table.HeaderCell>Condition</Table.HeaderCell>
-                            <Table.HeaderCell>Quantity</Table.HeaderCell>
-                            <Table.HeaderCell>Cash Offer</Table.HeaderCell>
-                            <Table.HeaderCell>Cash Out</Table.HeaderCell>
-                        </Table.Row>
-                    </Table.Header>
-                    <Table.Body>
+                <Table>
+                    <TableHead>
+                        <TableRow>
+                            <TableCell colSpan={6}>Employee Name:</TableCell>
+                        </TableRow>
+                        <TableRow>
+                            <TableCell>Card Name</TableCell>
+                            <TableCell>Market Value</TableCell>
+                            <TableCell>Condition</TableCell>
+                            <TableCell>Quantity</TableCell>
+                            <TableCell>Cash Offer</TableCell>
+                            <TableCell>Cash Out</TableCell>
+                        </TableRow>
+                    </TableHead>
+                    <TableBody>
                         {mergedWithQty.map((c) => {
                             return (
-                                <Table.Row key={c.temp_uuid}>
-                                    <Table.Cell>{c.name}</Table.Cell>
-                                    <Table.Cell>
+                                <TableRow key={c.temp_uuid}>
+                                    <TableCell>{c.name}</TableCell>
+                                    <TableCell>
                                         <Price num={c.marketPrice} />
-                                    </Table.Cell>
-                                    <Table.Cell>{c.finishCondition}</Table.Cell>
-                                    <Table.Cell>{c.tradeQty}</Table.Cell>
-                                    <Table.Cell>
+                                    </TableCell>
+                                    <TableCell>{c.finishCondition}</TableCell>
+                                    <TableCell>{c.tradeQty}</TableCell>
+                                    <TableCell>
                                         <Price num={c.cashPrice} />
-                                    </Table.Cell>
-                                    <Table.Cell>
+                                    </TableCell>
+                                    <TableCell>
                                         <Price
                                             num={
                                                 c.tradeQty * (c.cashPrice || 0)
                                             }
                                         />
-                                    </Table.Cell>
-                                </Table.Row>
+                                    </TableCell>
+                                </TableRow>
                             );
                         })}
-                    </Table.Body>
-                    <Table.Footer>
-                        <Table.HeaderCell colSpan={6}>
+                    </TableBody>
+                    <TableFooter>
+                        <TableCell colSpan={6}>
                             Total: <Price num={totalCashOut} />
-                        </Table.HeaderCell>
-                    </Table.Footer>
+                        </TableCell>
+                    </TableFooter>
                 </Table>
             </div>
         </React.Fragment>

--- a/frontend/src/Receiving/Receiving.tsx
+++ b/frontend/src/Receiving/Receiving.tsx
@@ -1,16 +1,17 @@
 import React, { FC, useContext, useEffect, useState } from 'react';
 import ReceivingSearchItem from './ReceivingSearchItem';
-import { Divider, Header, Icon, Segment } from 'semantic-ui-react';
 import { ReceivingContext } from '../context/ReceivingContext';
 import ReceivingCart from './ReceivingCart';
 import TotalCardsLabel from '../common/TotalCardsLabel';
 import TotalStoreInventory from '../ManageInventory/TotalStoreInventory';
-import { Grid } from '@material-ui/core';
+import { Grid, Divider } from '@material-ui/core';
 import { HeaderText } from '../ui/Typography';
 import Loading from '../ui/Loading';
 import { Prompt } from 'react-router';
 import useInterruptExit from '../utils/useInterruptExit';
 import ControlledSearchBar from '../ui/ControlledSearchBar';
+import Placeholder from '../ui/Placeholder';
+import SearchIcon from '@material-ui/icons/Search';
 
 interface Props {}
 
@@ -79,14 +80,13 @@ const Receiving: FC<Props> = () => {
                             />
                         )}
                     </Grid>
-                    <Divider />
+                    <br />
                     {!loading && !searchResults.length && (
-                        <Segment placeholder>
-                            <Header icon>
-                                <Icon name="search" />
-                                <em>"So many cards, so little time."</em>
-                            </Header>
-                        </Segment>
+                        <Placeholder
+                            icon={<SearchIcon style={{ fontSize: 80 }} />}
+                        >
+                            <em>"So many cards, so little time."</em>
+                        </Placeholder>
                     )}
                     {loading ? (
                         <Loading />
@@ -105,14 +105,13 @@ const Receiving: FC<Props> = () => {
                         <HeaderText>Buylist</HeaderText>
                         <TotalCardsLabel listLength={receivingList.length} />
                     </Grid>
-                    <Divider />
+                    <br />
                     {!receivingList.length && (
-                        <Segment placeholder>
-                            <Header icon>
-                                <Icon name="search" />
-                                <em>"If you receive it, they will come."</em>
-                            </Header>
-                        </Segment>
+                        <Placeholder
+                            icon={<SearchIcon style={{ fontSize: 80 }} />}
+                        >
+                            <em>"If you receive it, they will come."</em>
+                        </Placeholder>
                     )}
                     <ReceivingCart cards={receivingList} />
                 </Grid>

--- a/frontend/src/Receiving/Receiving.tsx
+++ b/frontend/src/Receiving/Receiving.tsx
@@ -12,6 +12,7 @@ import useInterruptExit from '../utils/useInterruptExit';
 import ControlledSearchBar from '../ui/ControlledSearchBar';
 import Placeholder from '../ui/Placeholder';
 import SearchIcon from '@material-ui/icons/Search';
+import ReceivingListTotals from './ReceivingListTotals';
 
 interface Props {}
 
@@ -114,6 +115,7 @@ const Receiving: FC<Props> = () => {
                         </Placeholder>
                     )}
                     <ReceivingCart cards={receivingList} />
+                    {receivingList.length > 0 && <ReceivingListTotals />}
                 </Grid>
             </Grid>
         </>

--- a/frontend/src/Receiving/Receiving.tsx
+++ b/frontend/src/Receiving/Receiving.tsx
@@ -4,7 +4,7 @@ import { ReceivingContext } from '../context/ReceivingContext';
 import ReceivingCart from './ReceivingCart';
 import TotalCardsLabel from '../common/TotalCardsLabel';
 import TotalStoreInventory from '../ManageInventory/TotalStoreInventory';
-import { Grid, Divider } from '@material-ui/core';
+import { Grid } from '@material-ui/core';
 import { HeaderText } from '../ui/Typography';
 import Loading from '../ui/Loading';
 import { Prompt } from 'react-router';

--- a/frontend/src/Receiving/Receiving.tsx
+++ b/frontend/src/Receiving/Receiving.tsx
@@ -115,6 +115,7 @@ const Receiving: FC<Props> = () => {
                         </Placeholder>
                     )}
                     <ReceivingCart cards={receivingList} />
+                    <br />
                     {receivingList.length > 0 && <ReceivingListTotals />}
                 </Grid>
             </Grid>

--- a/frontend/src/Receiving/ReceivingCart.tsx
+++ b/frontend/src/Receiving/ReceivingCart.tsx
@@ -1,5 +1,5 @@
 import { Divider, List, Paper } from '@material-ui/core';
-import React, { FC } from 'react';
+import React, { FC, Fragment } from 'react';
 import { ReceivingCard } from '../context/ReceivingContext';
 import ReceivingCartItem from './ReceivingCartItem';
 import ReceivingListTotals from './ReceivingListTotals';
@@ -14,10 +14,10 @@ const ReceivingCart: FC<Props> = ({ cards }) => {
             {cards.length > 0 && (
                 <List component={Paper} variant="outlined">
                     {cards.map((card, idx, arr) => (
-                        <>
+                        <Fragment>
                             <ReceivingCartItem card={card} />
                             {idx !== arr.length - 1 && <Divider />}
-                        </>
+                        </Fragment>
                     ))}
                 </List>
             )}

--- a/frontend/src/Receiving/ReceivingCart.tsx
+++ b/frontend/src/Receiving/ReceivingCart.tsx
@@ -1,4 +1,4 @@
-import { List, Paper } from '@material-ui/core';
+import { Divider, List, Paper } from '@material-ui/core';
 import React, { FC } from 'react';
 import { ReceivingCard } from '../context/ReceivingContext';
 import ReceivingCartItem from './ReceivingCartItem';
@@ -13,8 +13,11 @@ const ReceivingCart: FC<Props> = ({ cards }) => {
         <>
             {cards.length > 0 && (
                 <List component={Paper} variant="outlined">
-                    {cards.map((card) => (
-                        <ReceivingCartItem card={card} />
+                    {cards.map((card, idx, arr) => (
+                        <>
+                            <ReceivingCartItem card={card} />
+                            {idx !== arr.length - 1 && <Divider />}
+                        </>
                     ))}
                 </List>
             )}

--- a/frontend/src/Receiving/ReceivingCart.tsx
+++ b/frontend/src/Receiving/ReceivingCart.tsx
@@ -2,7 +2,6 @@ import { Divider, List, Paper } from '@material-ui/core';
 import React, { FC, Fragment } from 'react';
 import { ReceivingCard } from '../context/ReceivingContext';
 import ReceivingCartItem from './ReceivingCartItem';
-import ReceivingListTotals from './ReceivingListTotals';
 
 interface Props {
     cards: ReceivingCard[];
@@ -21,7 +20,6 @@ const ReceivingCart: FC<Props> = ({ cards }) => {
                     ))}
                 </List>
             )}
-            {cards.length > 0 && <ReceivingListTotals />}
         </>
     );
 };

--- a/frontend/src/Receiving/ReceivingCart.tsx
+++ b/frontend/src/Receiving/ReceivingCart.tsx
@@ -1,5 +1,5 @@
+import { List, Paper } from '@material-ui/core';
 import React, { FC } from 'react';
-import { Segment } from 'semantic-ui-react';
 import { ReceivingCard } from '../context/ReceivingContext';
 import ReceivingCartItem from './ReceivingCartItem';
 import ReceivingListTotals from './ReceivingListTotals';
@@ -12,11 +12,11 @@ const ReceivingCart: FC<Props> = ({ cards }) => {
     return (
         <>
             {cards.length > 0 && (
-                <Segment.Group>
+                <List component={Paper} variant="outlined">
                     {cards.map((card) => (
                         <ReceivingCartItem card={card} />
                     ))}
-                </Segment.Group>
+                </List>
             )}
             {cards.length > 0 && <ReceivingListTotals />}
         </>

--- a/frontend/src/Receiving/ReceivingCartItem.tsx
+++ b/frontend/src/Receiving/ReceivingCartItem.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useContext, FC } from 'react';
-import { Button, Label, Icon, Grid, Segment, Header } from 'semantic-ui-react';
+import { Button, Label, Icon, Header } from 'semantic-ui-react';
 import Price from '../common/Price';
 import {
     ReceivingCard,
@@ -8,6 +8,7 @@ import {
 } from '../context/ReceivingContext';
 import SetIcon from '../ui/SetIcon';
 import CardImageTooltip from '../ui/CardImageTooltip';
+import { ListItem, Grid } from '@material-ui/core';
 
 interface Props {
     card: ReceivingCard;
@@ -34,9 +35,9 @@ const ReceivingCartItem: FC<Props> = ({
     const { removeFromList, activeTradeType } = useContext(ReceivingContext);
 
     return (
-        <Segment>
-            <Grid verticalAlign="middle">
-                <Grid.Column tablet={16} computer={11}>
+        <ListItem>
+            <Grid container alignItems="center" justify="space-between">
+                <Grid item>
                     <div>
                         <CardImageTooltip cardImage={cardImage}>
                             <Header as="h4" style={{ cursor: 'help' }}>
@@ -67,8 +68,8 @@ const ReceivingCartItem: FC<Props> = ({
                             </b>
                         </span>
                     </div>
-                </Grid.Column>
-                <Grid.Column tablet={16} computer={5} textAlign="right">
+                </Grid>
+                <Grid item>
                     <Button
                         compact
                         active={tradeType === CASH}
@@ -98,9 +99,9 @@ const ReceivingCartItem: FC<Props> = ({
                         onMouseOut={() => setHovered(false)}
                         color={hovered ? 'red' : undefined}
                     />
-                </Grid.Column>
+                </Grid>
             </Grid>
-        </Segment>
+        </ListItem>
     );
 };
 

--- a/frontend/src/Receiving/ReceivingCartItem.tsx
+++ b/frontend/src/Receiving/ReceivingCartItem.tsx
@@ -1,5 +1,4 @@
-import React, { useState, useContext, FC } from 'react';
-import { Button, Icon } from 'semantic-ui-react';
+import React, { useContext, FC } from 'react';
 import Price from '../common/Price';
 import {
     ReceivingCard,
@@ -8,8 +7,11 @@ import {
 } from '../context/ReceivingContext';
 import SetIcon from '../ui/SetIcon';
 import CardImageTooltip from '../ui/CardImageTooltip';
-import { ListItem, Grid, Typography, Box } from '@material-ui/core';
+import { ListItem, Grid, Typography, Box, IconButton } from '@material-ui/core';
 import Chip from '../common/Chip';
+import AttachMoneyIcon from '@material-ui/icons/AttachMoney';
+import CreditCardIcon from '@material-ui/icons/CreditCard';
+import CloseIcon from '@material-ui/icons/Close';
 
 interface Props {
     card: ReceivingCard;
@@ -32,7 +34,6 @@ const ReceivingCartItem: FC<Props> = ({
     },
 }) => {
     const { CASH, CREDIT } = TRADE_TYPE;
-    const [hovered, setHovered] = useState(false);
     const { removeFromList, activeTradeType } = useContext(ReceivingContext);
 
     return (
@@ -71,35 +72,26 @@ const ReceivingCartItem: FC<Props> = ({
                     </div>
                 </Grid>
                 <Grid item>
-                    <Button
-                        compact
-                        active={tradeType === CASH}
-                        color={tradeType === CASH ? 'blue' : undefined}
+                    <IconButton
+                        color={tradeType === CASH ? 'primary' : undefined}
                         onClick={() => activeTradeType(uuid_key, Trade.Cash)}
                         disabled={cashPrice === 0}
-                        icon
                     >
-                        <Icon name="dollar sign"></Icon>
-                    </Button>
-                    <Button
-                        compact
-                        active={tradeType === CREDIT}
-                        color={tradeType === CREDIT ? 'blue' : undefined}
+                        <AttachMoneyIcon />
+                    </IconButton>
+                    <IconButton
+                        color={tradeType === CREDIT ? 'primary' : undefined}
                         onClick={() => activeTradeType(uuid_key, Trade.Credit)}
                         disabled={creditPrice === 0}
-                        icon
                     >
-                        <Icon name="credit card outline"></Icon>
-                    </Button>
-                    <Button
-                        compact
-                        icon="cancel"
-                        circular
+                        <CreditCardIcon />
+                    </IconButton>
+                    <IconButton
                         onClick={() => removeFromList(uuid_key)}
-                        onMouseOver={() => setHovered(true)}
-                        onMouseOut={() => setHovered(false)}
-                        color={hovered ? 'red' : undefined}
-                    />
+                        color="secondary"
+                    >
+                        <CloseIcon />
+                    </IconButton>
                 </Grid>
             </Grid>
         </ListItem>

--- a/frontend/src/Receiving/ReceivingCartItem.tsx
+++ b/frontend/src/Receiving/ReceivingCartItem.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useContext, FC } from 'react';
-import { Button, Label, Icon, Header } from 'semantic-ui-react';
+import { Button, Icon } from 'semantic-ui-react';
 import Price from '../common/Price';
 import {
     ReceivingCard,
@@ -8,7 +8,8 @@ import {
 } from '../context/ReceivingContext';
 import SetIcon from '../ui/SetIcon';
 import CardImageTooltip from '../ui/CardImageTooltip';
-import { ListItem, Grid } from '@material-ui/core';
+import { ListItem, Grid, Typography, Box } from '@material-ui/core';
+import Chip from '../common/Chip';
 
 interface Props {
     card: ReceivingCard;
@@ -38,15 +39,15 @@ const ReceivingCartItem: FC<Props> = ({
         <ListItem>
             <Grid container alignItems="center" justify="space-between">
                 <Grid item>
-                    <div>
-                        <CardImageTooltip cardImage={cardImage}>
-                            <Header as="h4" style={{ cursor: 'help' }}>
+                    <CardImageTooltip cardImage={cardImage}>
+                        <Box display="flex" alignItems="center">
+                            <Typography variant="h6" style={{ cursor: 'help' }}>
                                 {display_name}
-                            </Header>
-                        </CardImageTooltip>
-                    </div>
-                    <SetIcon set={set} rarity={rarity} />
-                    <Label color="grey">{set.toUpperCase()}</Label>
+                            </Typography>
+                            <SetIcon set={set} rarity={rarity} />
+                            <Chip size="small" label={set.toUpperCase()} />
+                        </Box>
+                    </CardImageTooltip>
                     {finishCondition && (
                         <span>
                             {finishCondition.split('_')[1]} {' | '}

--- a/frontend/src/Receiving/ReceivingListModal.tsx
+++ b/frontend/src/Receiving/ReceivingListModal.tsx
@@ -76,6 +76,7 @@ const ReceivingListModal: FC<Props> = () => {
     return (
         <>
             <Button
+                fluid
                 color="blue"
                 disabled={receivingList.length === 0}
                 onClick={() => setShowModal(true)}

--- a/frontend/src/Receiving/ReceivingListTotals.tsx
+++ b/frontend/src/Receiving/ReceivingListTotals.tsx
@@ -1,33 +1,14 @@
 import React, { useState, useContext, FC } from 'react';
-import { Segment, Statistic, Button, Modal } from 'semantic-ui-react';
-import styled from 'styled-components';
+import { Button, Modal } from 'semantic-ui-react';
 import Price from '../common/Price';
 import CashReport from './CashReport';
 import printCashReport from './printCashReport';
 import ReceivingListModal from './ReceivingListModal';
 import { ReceivingContext, Trade } from '../context/ReceivingContext';
 import sum from '../utils/sum';
+import { Box, Grid, Paper, Typography } from '@material-ui/core';
 
 interface Props {}
-
-const FlexRow = styled.div`
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-    align-items: center;
-`;
-
-const FlexCol = styled.div`
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
-    align-items: center;
-    min-height: 100px;
-`;
-
-const StatisticColor = styled(Statistic.Label)`
-    color: gray !important;
-`;
 
 const ReceivingListTotals: FC<Props> = () => {
     const { Cash, Credit } = Trade;
@@ -55,71 +36,90 @@ const ReceivingListTotals: FC<Props> = () => {
     );
 
     return (
-        <Segment>
-            <FlexRow>
-                <FlexCol>
-                    <Button.Group>
-                        <Button
-                            id="select-all-cash"
-                            onClick={() => selectAll(Trade.Cash)}
-                        >
-                            Select all cash
-                        </Button>
-                        <Button.Or />
-                        <Button
-                            id="select-all-credit"
-                            onClick={() => selectAll(Trade.Credit)}
-                        >
-                            Select all credit
-                        </Button>
-                    </Button.Group>
-                    <Modal
-                        open={showCashModal}
-                        trigger={
+        <Paper variant="outlined">
+            <Box p={2}>
+                <Grid container spacing={2}>
+                    <Grid item xs={12} justify="space-between">
+                        <Button.Group fluid>
                             <Button
-                                color={cashTotal > 0 ? 'green' : undefined}
-                                disabled={cashTotal === 0}
-                                onClick={openCashModal}
+                                id="select-all-cash"
+                                onClick={() => selectAll(Trade.Cash)}
                             >
-                                Generate cash report
+                                Select all cash
                             </Button>
-                        }
-                    >
-                        <Modal.Content>
-                            <CashReport receivingList={receivingList} />
-                        </Modal.Content>
-                        <Modal.Actions>
+                            <Button.Or />
                             <Button
-                                onClick={handlePrintCashReport}
-                                color="blue"
+                                id="select-all-credit"
+                                onClick={() => selectAll(Trade.Credit)}
                             >
-                                Print Report
+                                Select all credit
                             </Button>
-                            <Button onClick={closeCashModal}>Cancel</Button>
-                        </Modal.Actions>
-                    </Modal>
-                </FlexCol>
-                <FlexCol>
-                    <Segment>
-                        <div>
-                            <Statistic size="mini">
-                                <StatisticColor>Cash Due</StatisticColor>
-                                <Statistic.Value id="cash-total">
+                        </Button.Group>
+                    </Grid>
+                    <Grid item xs={12}>
+                        <Modal
+                            open={showCashModal}
+                            trigger={
+                                <Button
+                                    floated="right"
+                                    color={cashTotal > 0 ? 'green' : undefined}
+                                    disabled={cashTotal === 0}
+                                    onClick={openCashModal}
+                                >
+                                    Generate cash report
+                                </Button>
+                            }
+                        >
+                            <Modal.Content>
+                                <CashReport receivingList={receivingList} />
+                            </Modal.Content>
+                            <Modal.Actions>
+                                <Button
+                                    onClick={handlePrintCashReport}
+                                    color="blue"
+                                >
+                                    Print Report
+                                </Button>
+                                <Button onClick={closeCashModal}>Cancel</Button>
+                            </Modal.Actions>
+                        </Modal>
+                    </Grid>
+                    <Grid item xs={12}>
+                        <Box
+                            display="flex"
+                            justifyContent="space-between"
+                            alignItems="center"
+                        >
+                            <Typography>CASH DUE</Typography>
+
+                            <Typography variant="h6">
+                                <b>
                                     <Price num={cashTotal} />
-                                </Statistic.Value>
-                            </Statistic>
-                            <Statistic size="mini">
-                                <StatisticColor>Credit Due</StatisticColor>
-                                <Statistic.Value id="credit-total">
+                                </b>
+                            </Typography>
+                        </Box>
+                    </Grid>
+                    <Grid item xs={12}>
+                        <Box
+                            display="flex"
+                            justifyContent="space-between"
+                            alignItems="center"
+                        >
+                            <Typography>CREDIT DUE</Typography>
+
+                            <Typography variant="h6">
+                                <b>
                                     <Price num={creditTotal} />
-                                </Statistic.Value>
-                            </Statistic>
-                        </div>
+                                </b>
+                            </Typography>
+                        </Box>
+                    </Grid>
+                    <Grid item xs={12}>
                         <ReceivingListModal />
-                    </Segment>
-                </FlexCol>
-            </FlexRow>
-        </Segment>
+                    </Grid>
+                </Grid>
+            </Box>
+        </Paper>
     );
 };
 

--- a/frontend/src/Sale/FinishSale.tsx
+++ b/frontend/src/Sale/FinishSale.tsx
@@ -15,7 +15,7 @@ const FinishSale: FC<Props> = () => {
     };
 
     const modalTrigger = (
-        <Button floated="right" primary onClick={() => setShowModal(true)}>
+        <Button fluid primary onClick={() => setShowModal(true)}>
             Finalize sale
         </Button>
     );

--- a/frontend/src/Sale/Sale.tsx
+++ b/frontend/src/Sale/Sale.tsx
@@ -1,5 +1,4 @@
 import React, { useContext, FC, useState, useEffect } from 'react';
-import { Divider } from 'semantic-ui-react';
 import BrowseCardList from './SaleSearchCardList';
 import SaleCartList from './SaleCartList';
 import PrintList from './PrintList';
@@ -78,7 +77,7 @@ const Sale: FC<Props> = () => {
                             />
                         )}
                     </Grid>
-                    <Divider />
+                    <br />
                     <BrowseCardList
                         loading={loading}
                         term={searchTerm}
@@ -112,7 +111,7 @@ const Sale: FC<Props> = () => {
                             )}
                         </Box>
                     </Grid>
-                    <Divider />
+                    <br />
                     <SaleCartList saleList={saleListCards} />
                 </Grid>
             </Grid>

--- a/frontend/src/Sale/SaleCartItem.tsx
+++ b/frontend/src/Sale/SaleCartItem.tsx
@@ -1,9 +1,11 @@
-import React, { useState, useContext, FC } from 'react';
-import { Button, Grid, Header, Label, Segment } from 'semantic-ui-react';
+import React, { useContext, FC } from 'react';
 import { SaleContext, SaleListCard } from '../context/SaleContext';
 import Price from '../common/Price';
 import SetIcon from '../ui/SetIcon';
 import CardImageTooltip from '../ui/CardImageTooltip';
+import { ListItem, Grid, Box, Typography, IconButton } from '@material-ui/core';
+import Chip from '../common/Chip';
+import CloseIcon from '@material-ui/icons/Close';
 
 interface Props {
     card: SaleListCard;
@@ -21,22 +23,21 @@ const SaleCartItem: FC<Props> = ({
         cardImage,
     },
 }) => {
-    const [hovered, setHovered] = useState(false);
     const { removeFromSaleList } = useContext(SaleContext);
 
     return (
-        <Segment>
-            <Grid verticalAlign="middle">
-                <Grid.Column tablet={16} computer={11}>
-                    <div>
-                        <CardImageTooltip cardImage={cardImage}>
-                            <Header as="h4" style={{ cursor: 'help' }}>
+        <ListItem>
+            <Grid container alignItems="center" justify="space-between">
+                <Grid item>
+                    <CardImageTooltip cardImage={cardImage}>
+                        <Box display="flex" alignItems="center">
+                            <Typography variant="h6" style={{ cursor: 'help' }}>
                                 {display_name}
-                            </Header>
-                        </CardImageTooltip>
-                    </div>
-                    <SetIcon set={set} rarity={rarity} />
-                    <Label color="grey">{set.toUpperCase()}</Label>
+                            </Typography>
+                            <SetIcon set={set} rarity={rarity} />
+                            <Chip size="small" label={set.toUpperCase()} />
+                        </Box>
+                    </CardImageTooltip>
                     <div className="line-item-price">
                         {qtyToSell}x @ <Price num={price} />
                         {' • '}
@@ -47,20 +48,17 @@ const SaleCartItem: FC<Props> = ({
                             </span>
                         )}
                     </div>
-                </Grid.Column>
-                <Grid.Column tablet={16} computer={5} textAlign="right">
-                    <Button
-                        compact
-                        icon="cancel"
-                        circular
+                </Grid>
+                <Grid item>
+                    <IconButton
                         onClick={() => removeFromSaleList(id, finishCondition)}
-                        onMouseOver={() => setHovered(true)}
-                        onMouseOut={() => setHovered(false)}
-                        color={hovered ? 'red' : undefined}
-                    />
-                </Grid.Column>
+                        color="secondary"
+                    >
+                        <CloseIcon />
+                    </IconButton>
+                </Grid>
             </Grid>
-        </Segment>
+        </ListItem>
     );
 };
 

--- a/frontend/src/Sale/SaleCartList.tsx
+++ b/frontend/src/Sale/SaleCartList.tsx
@@ -5,7 +5,7 @@ import FinishSale from './FinishSale';
 import { SaleListCard } from '../context/SaleContext';
 import AddIcon from '@material-ui/icons/Add';
 import Placeholder from '../ui/Placeholder';
-import { List, Paper, Divider, Box, Typography } from '@material-ui/core';
+import { List, Paper, Divider, Box, Grid, Typography } from '@material-ui/core';
 
 interface Props {
     saleList: SaleListCard[];
@@ -34,21 +34,28 @@ const SaleCartList: FC<Props> = ({ saleList }) => {
             </List>
             <br />
             <Paper variant="outlined">
-                <Box
-                    display="flex"
-                    justifyContent="space-between"
-                    alignItems="center"
-                    p={2}
-                >
-                    <div>
-                        <Typography variant="body2">SUBTOTAL</Typography>
-                        <Typography variant="h6">
-                            <b>
-                                <SaleCartPriceTotal saleList={saleList} />
-                            </b>
-                        </Typography>
-                    </div>
-                    <FinishSale />
+                <Box p={2}>
+                    <Grid container spacing={2}>
+                        <Grid item xs={12}>
+                            <Box
+                                display="flex"
+                                justifyContent="space-between"
+                                alignItems="center"
+                            >
+                                <Typography>SUBTOTAL</Typography>
+                                <Typography variant="h6">
+                                    <b>
+                                        <SaleCartPriceTotal
+                                            saleList={saleList}
+                                        />
+                                    </b>
+                                </Typography>
+                            </Box>
+                        </Grid>
+                        <Grid item xs={12}>
+                            <FinishSale />
+                        </Grid>
+                    </Grid>
                 </Box>
             </Paper>
         </>

--- a/frontend/src/Sale/SaleCartList.tsx
+++ b/frontend/src/Sale/SaleCartList.tsx
@@ -1,9 +1,11 @@
 import React, { FC } from 'react';
 import SaleCartItem from './SaleCartItem';
-import { Segment, Header, Icon } from 'semantic-ui-react';
+import { Segment, Header } from 'semantic-ui-react';
 import SaleCartPriceTotal from './SaleCartPriceTotal';
 import FinishSale from './FinishSale';
 import { SaleListCard } from '../context/SaleContext';
+import AddIcon from '@material-ui/icons/Add';
+import Placeholder from '../ui/Placeholder';
 
 interface Props {
     saleList: SaleListCard[];
@@ -12,12 +14,9 @@ interface Props {
 const SaleCartList: FC<Props> = ({ saleList }) => {
     if (saleList.length === 0) {
         return (
-            <Segment placeholder>
-                <Header icon>
-                    <Icon name="plus" />
-                    <em>"Give them what they need"</em>
-                </Header>
-            </Segment>
+            <Placeholder icon={<AddIcon style={{ fontSize: 80 }} />}>
+                <em>"Give them what they need"</em>
+            </Placeholder>
         );
     }
 

--- a/frontend/src/Sale/SaleCartList.tsx
+++ b/frontend/src/Sale/SaleCartList.tsx
@@ -1,12 +1,11 @@
 import React, { FC, Fragment } from 'react';
 import SaleCartItem from './SaleCartItem';
-import { Segment, Header } from 'semantic-ui-react';
 import SaleCartPriceTotal from './SaleCartPriceTotal';
 import FinishSale from './FinishSale';
 import { SaleListCard } from '../context/SaleContext';
 import AddIcon from '@material-ui/icons/Add';
 import Placeholder from '../ui/Placeholder';
-import { List, Paper, Divider } from '@material-ui/core';
+import { List, Paper, Divider, Box, Typography } from '@material-ui/core';
 
 interface Props {
     saleList: SaleListCard[];
@@ -33,13 +32,25 @@ const SaleCartList: FC<Props> = ({ saleList }) => {
                     </Fragment>
                 ))}
             </List>
-            <Segment clearing>
-                <Header floated="left">
-                    <Header sub>Subtotal</Header>
-                    <SaleCartPriceTotal saleList={saleList} />
-                </Header>
-                <FinishSale />
-            </Segment>
+            <br />
+            <Paper variant="outlined">
+                <Box
+                    display="flex"
+                    justifyContent="space-between"
+                    alignItems="center"
+                    p={2}
+                >
+                    <div>
+                        <Typography variant="body2">SUBTOTAL</Typography>
+                        <Typography variant="h6">
+                            <b>
+                                <SaleCartPriceTotal saleList={saleList} />
+                            </b>
+                        </Typography>
+                    </div>
+                    <FinishSale />
+                </Box>
+            </Paper>
         </>
     );
 };

--- a/frontend/src/Sale/SaleCartList.tsx
+++ b/frontend/src/Sale/SaleCartList.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, Fragment } from 'react';
 import SaleCartItem from './SaleCartItem';
 import { Segment, Header } from 'semantic-ui-react';
 import SaleCartPriceTotal from './SaleCartPriceTotal';
@@ -6,6 +6,7 @@ import FinishSale from './FinishSale';
 import { SaleListCard } from '../context/SaleContext';
 import AddIcon from '@material-ui/icons/Add';
 import Placeholder from '../ui/Placeholder';
+import { List, Paper, Divider } from '@material-ui/core';
 
 interface Props {
     saleList: SaleListCard[];
@@ -22,14 +23,16 @@ const SaleCartList: FC<Props> = ({ saleList }) => {
 
     return (
         <>
-            <Segment.Group>
-                {saleList.map((card) => (
-                    <SaleCartItem
+            <List component={Paper} variant="outlined">
+                {saleList.map((card, idx, arr) => (
+                    <Fragment
                         key={`${card.id}${card.finishCondition}${card.qtyToSell}`}
-                        card={card}
-                    />
+                    >
+                        <SaleCartItem card={card} />
+                        {idx !== arr.length - 1 && <Divider />}
+                    </Fragment>
                 ))}
-            </Segment.Group>
+            </List>
             <Segment clearing>
                 <Header floated="left">
                     <Header sub>Subtotal</Header>

--- a/frontend/src/Sale/SaleSearchCardList.tsx
+++ b/frontend/src/Sale/SaleSearchCardList.tsx
@@ -1,9 +1,10 @@
 import React, { FC } from 'react';
 import SaleSearchCard from './SaleSearchCard';
-import { Segment, Header, Icon } from 'semantic-ui-react';
 import { ScryfallCard } from '../utils/ScryfallCard';
 import { Grid } from '@material-ui/core';
 import Loading from '../ui/Loading';
+import SearchIcon from '@material-ui/icons/Search';
+import Placeholder from '../ui/Placeholder';
 
 interface Props {
     loading: boolean;
@@ -35,12 +36,9 @@ const BrowseCardList: FC<Props> = ({ loading, term, cards }) => {
 
     if (cards.length === 0) {
         return (
-            <Segment placeholder>
-                <Header icon>
-                    <Icon name="search" />
-                    <span>{searchNotification()}</span>
-                </Header>
-            </Segment>
+            <Placeholder icon={<SearchIcon style={{ fontSize: 80 }} />}>
+                <span>{searchNotification()}</span>
+            </Placeholder>
         );
     }
 

--- a/frontend/src/common/CardImage.tsx
+++ b/frontend/src/common/CardImage.tsx
@@ -1,29 +1,40 @@
+import { makeStyles } from '@material-ui/core';
 import React, { FC, useState } from 'react';
-import { Image } from 'semantic-ui-react';
-import styled from 'styled-components';
+import clsx from 'clsx';
 
 interface Props {
     image: string;
     hover?: boolean;
 }
 
-const StyledImage = styled(Image)({
-    boxShadow: '2px 2px 5px 0 rgba(0,0,0,.25)',
-    zIndex: 10,
-    transition: 'all .2s ease-in-out',
-});
+const useStyles = makeStyles(({ zIndex }) => ({
+    imageStyle: {
+        boxShadow: '2px 2px 5px 0 rgba(0,0,0,.25)',
+        zIndex: zIndex.appBar,
+        transition: 'all .2s ease-in-out',
+    },
+    hoveredStyle: {
+        transform: 'scale(1.75)',
+    },
+}));
 
 const CardImage: FC<Props> = ({ image, hover }) => {
+    const { imageStyle, hoveredStyle } = useStyles();
     const [hovered, setHovered] = useState<boolean>(false);
 
+    const onHover = (val: boolean) => {
+        if (!hover) return;
+        setHovered(val);
+    };
+
     return (
-        <StyledImage
+        <img
             src={image}
-            onMouseOver={() => (hover ? setHovered(true) : null)}
-            onMouseOut={() => (hover ? setHovered(false) : null)}
-            style={{
-                transform: `${hovered ? 'scale(1.75)' : 'scale(1)'}`,
-            }}
+            className={clsx(imageStyle, {
+                [hoveredStyle]: hovered,
+            })}
+            onMouseOver={() => onHover(true)}
+            onMouseOut={() => onHover(false)}
         />
     );
 };

--- a/frontend/src/common/TotalCardsLabel.tsx
+++ b/frontend/src/common/TotalCardsLabel.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react';
-import { Label } from 'semantic-ui-react';
 import pluralize from '../utils/pluralize';
+import Chip from './Chip';
 
 interface Props {
     listLength: number;
@@ -10,11 +10,10 @@ const TotalCardsLabel: FC<Props> = ({ listLength }) => {
     if (listLength === 0) return null;
 
     return (
-        <div>
-            <Label color="grey">
-                {listLength} {pluralize(listLength, 'card')}
-            </Label>
-        </div>
+        <Chip
+            label={`${listLength} ${pluralize(listLength, 'card')}`}
+            size="small"
+        />
     );
 };
 

--- a/frontend/src/ui/CardHeader.tsx
+++ b/frontend/src/ui/CardHeader.tsx
@@ -7,6 +7,7 @@ import SetIcon from './SetIcon';
 import Button from './Button';
 import { Box, Link, Typography, withStyles } from '@material-ui/core';
 import language from '../utils/Language';
+import OpenInNewIcon from '@material-ui/icons/OpenInNew';
 
 interface Props {
     card: ScryfallCard;
@@ -19,10 +20,18 @@ interface Props {
 const TcgPriceButton: FC<{ tcgId: number | null }> = ({ tcgId }) => {
     const tcgUrl = `https://www.tcgplayer.com/product/${tcgId}`;
 
+    if (!tcgId) {
+        return (
+            <Button disabled size="small">
+                TCG Link unavailable
+            </Button>
+        );
+    }
+
     return (
-        <Link href={tcgUrl} target="_blank">
-            <Button primary disabled={!tcgId} size="small">
-                {!tcgId ? 'Link unavailable' : 'View on TCG'}
+        <Link href={tcgUrl} target="_blank" underline="none">
+            <Button size="small">
+                View on TCG <OpenInNewIcon fontSize="small" />
             </Button>
         </Link>
     );

--- a/frontend/src/ui/CardImageTooltip.tsx
+++ b/frontend/src/ui/CardImageTooltip.tsx
@@ -1,6 +1,6 @@
 import { makeStyles, Tooltip } from '@material-ui/core';
 import { FC } from 'react';
-import { Image } from 'semantic-ui-react';
+import clsx from 'clsx';
 
 interface Props {
     cardImage: string;
@@ -13,16 +13,23 @@ const useStyles = makeStyles({
     borderRounded: {
         borderRadius: '7px 7px 7px 7px',
     },
+    imageSize: {
+        width: 155,
+        height: 'auto',
+    },
 });
 
 const CardImageTooltip: FC<Props> = ({ cardImage, children }) => {
-    const { transparentBackground, borderRounded } = useStyles();
+    const { transparentBackground, borderRounded, imageSize } = useStyles();
 
     return (
         <Tooltip
             placement="bottom-start"
             title={
-                <Image className={borderRounded} size="small" src={cardImage} />
+                <img
+                    className={clsx(borderRounded, imageSize)}
+                    src={cardImage}
+                />
             }
             classes={{
                 tooltip: transparentBackground,

--- a/frontend/src/ui/Placeholder.tsx
+++ b/frontend/src/ui/Placeholder.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, ReactNode } from 'react';
 import { Box, makeStyles, Paper, Typography } from '@material-ui/core';
 
 const useStyles = makeStyles(({ typography, spacing }) => ({
@@ -10,21 +10,27 @@ const useStyles = makeStyles(({ typography, spacing }) => ({
         backgroundColor: 'transparent',
     },
     flexContainer: {
-        minHeight: spacing(20),
+        minHeight: spacing(25),
     },
 }));
 
-const Placeholder: FC = ({ children }) => {
+interface Props {
+    icon?: ReactNode;
+}
+
+const Placeholder: FC<Props> = ({ icon, children }) => {
     const { font, container, flexContainer } = useStyles();
 
     return (
         <Paper variant="outlined" className={container}>
             <Box
                 display="flex"
+                flexDirection="column"
                 justifyContent="center"
                 alignItems="center"
                 className={flexContainer}
             >
+                {icon && icon}
                 <Typography variant="h6" className={font}>
                     {children}
                 </Typography>


### PR DESCRIPTION
## Summary
This PR represents a large bulk of work refactoring and pruning stray Semantic UI React imports. Where applicable, I attempted to directly translate what was available to MUI, but in some cases (such as card headers and pagination), more refactors and layout improvements were required.

Users will notice a _far_ more readable layout for most frequently-used features:

Before:
![image](https://user-images.githubusercontent.com/15024562/128402492-b6dd2443-e4df-4109-b895-5881180f813b.png)

After:
![image](https://user-images.githubusercontent.com/15024562/128402579-bae4fa0f-79b0-4e9d-9e64-258309e29679.png)

