### PR TITLE
Bulk card entry

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -19,6 +19,7 @@ import { createMuiTheme, makeStyles, ThemeProvider } from '@material-ui/core';
 import NavBar from './NavBar/NavBar';
 import Reporting from './Reporting/Reporting';
 import BulkInventory from './BulkInventory/BulkInventory';
+import ToastProvider from './ui/ToastContext';
 
 const useStyles = makeStyles(({ spacing }) => ({
     contentContainer: {
@@ -46,53 +47,59 @@ const App: FC = () => {
     return (
         <AuthProvider>
             <ThemeProvider theme={theme}>
-                <NavBar />
-                <Switch>
-                    <Route exact path="/" component={Home} />
-                    <div className={backgroundColor}>
-                        <div className={contentContainer}>
-                            <AdminRoute exact path="/manage-inventory">
-                                <InventoryProvider>
-                                    <ManageInventory />
-                                </InventoryProvider>
-                            </AdminRoute>
-                            <AdminRoute exact path="/new-sale">
-                                <SaleProvider>
-                                    <Sale />
-                                </SaleProvider>
-                            </AdminRoute>
-                            <AdminRoute exact path="/receiving">
-                                <ReceivingProvider>
-                                    <Receiving />
-                                </ReceivingProvider>
-                            </AdminRoute>
-                            <AdminRoute exact path="/browse-sales">
-                                <BrowseSales />
-                            </AdminRoute>
-                            <AdminRoute exact path="/browse-inventory">
-                                <BrowseInventory />
-                            </AdminRoute>
-                            <AdminRoute exact path="/browse-receiving">
-                                <BrowseReceiving />
-                            </AdminRoute>
-                            <AdminRoute exact path="/bulk-add">
-                                <BulkInventory />
-                            </AdminRoute>
-                            <Route
-                                exact
-                                path="/public-inventory"
-                                component={PublicInventory}
-                            />
-                            <Route
-                                exact
-                                path="/reporting"
-                                component={Reporting}
-                            />
-                            <Route exact path="/login" component={Login} />
-                            <Route exact path="/logout" component={Logout} />
+                <ToastProvider>
+                    <NavBar />
+                    <Switch>
+                        <Route exact path="/" component={Home} />
+                        <div className={backgroundColor}>
+                            <div className={contentContainer}>
+                                <AdminRoute exact path="/manage-inventory">
+                                    <InventoryProvider>
+                                        <ManageInventory />
+                                    </InventoryProvider>
+                                </AdminRoute>
+                                <AdminRoute exact path="/new-sale">
+                                    <SaleProvider>
+                                        <Sale />
+                                    </SaleProvider>
+                                </AdminRoute>
+                                <AdminRoute exact path="/receiving">
+                                    <ReceivingProvider>
+                                        <Receiving />
+                                    </ReceivingProvider>
+                                </AdminRoute>
+                                <AdminRoute exact path="/browse-sales">
+                                    <BrowseSales />
+                                </AdminRoute>
+                                <AdminRoute exact path="/browse-inventory">
+                                    <BrowseInventory />
+                                </AdminRoute>
+                                <AdminRoute exact path="/browse-receiving">
+                                    <BrowseReceiving />
+                                </AdminRoute>
+                                <AdminRoute exact path="/bulk-add">
+                                    <BulkInventory />
+                                </AdminRoute>
+                                <Route
+                                    exact
+                                    path="/public-inventory"
+                                    component={PublicInventory}
+                                />
+                                <Route
+                                    exact
+                                    path="/reporting"
+                                    component={Reporting}
+                                />
+                                <Route exact path="/login" component={Login} />
+                                <Route
+                                    exact
+                                    path="/logout"
+                                    component={Logout}
+                                />
+                            </div>
                         </div>
-                    </div>
-                </Switch>
+                    </Switch>
+                </ToastProvider>
             </ThemeProvider>
         </AuthProvider>
     );

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,6 +18,7 @@ import BrowseReceiving from './BrowseReceiving/BrowseReceiving';
 import { createMuiTheme, makeStyles, ThemeProvider } from '@material-ui/core';
 import NavBar from './NavBar/NavBar';
 import Reporting from './Reporting/Reporting';
+import BulkInventory from './BulkInventory/BulkInventory';
 
 const useStyles = makeStyles(({ spacing }) => ({
     contentContainer: {
@@ -73,6 +74,9 @@ const App: FC = () => {
                             </AdminRoute>
                             <AdminRoute exact path="/browse-receiving">
                                 <BrowseReceiving />
+                            </AdminRoute>
+                            <AdminRoute exact path="/bulk-add">
+                                <BulkInventory />
                             </AdminRoute>
                             <Route
                                 exact

--- a/frontend/src/BulkInventory/BulkInventory.tsx
+++ b/frontend/src/BulkInventory/BulkInventory.tsx
@@ -14,6 +14,7 @@ import IntegerInput from '../ui/IntegerInput';
 import { cardConditions } from '../utils/dropdownOptions';
 import { BulkCard } from './bulkInventoryQuery';
 import BulkSearchBar from './BulkSearchBar';
+import Button from '../ui/Button';
 
 type Finish = 'FOIL' | 'NONFOIL';
 type Condition = 'NM' | 'LP' | 'MP' | 'HP';
@@ -65,73 +66,89 @@ const BulkInventory: FC = () => {
 
     return (
         <Container>
-            <pre>{JSON.stringify({ values }, null, 2)}</pre>
             <form>
                 <Grid container spacing={2}>
-                    <Grid item xs={6}>
-                        <BulkSearchBar
-                            value={values.bulkCard}
-                            onChange={(v) => setFieldValue('bulkCard', v)}
-                            onHighlight={(o) =>
-                                setCurrentCardImage(o?.image || '')
-                            }
-                        />
-                    </Grid>
-                    <Grid item xs={6}>
-                        <FormControl
-                            variant="outlined"
-                            size="small"
-                            fullWidth
-                            disabled={!values.bulkCard}
-                        >
-                            <InputLabel>Finish</InputLabel>
-                            <Select
-                                label="Finish"
-                                value={values.finish}
-                                onChange={(e) =>
-                                    setFieldValue(
-                                        'finish',
-                                        e.target.value as string
-                                    )
+                    <Grid item container spacing={2} xs={8}>
+                        <Grid item xs={12}>
+                            <BulkSearchBar
+                                value={values.bulkCard}
+                                onChange={(v) => setFieldValue('bulkCard', v)}
+                                onHighlight={(o) =>
+                                    setCurrentCardImage(o?.image || '')
                                 }
+                            />
+                        </Grid>
+                        <Grid item xs={4}>
+                            <FormControl
+                                variant="outlined"
+                                size="small"
+                                fullWidth
+                                disabled={!values.bulkCard}
                             >
-                                <MenuItem
-                                    key="nonfoil"
-                                    value="FOIL"
-                                    disabled={!values?.bulkCard?.foil_printing}
-                                >
-                                    Foil
-                                </MenuItem>
-                                <MenuItem
-                                    key="foil"
-                                    value="NONFOIL"
-                                    disabled={
-                                        !values?.bulkCard?.nonfoil_printing
+                                <InputLabel>Finish</InputLabel>
+                                <Select
+                                    label="Finish"
+                                    value={values.finish}
+                                    onChange={(e) =>
+                                        setFieldValue(
+                                            'finish',
+                                            e.target.value as string
+                                        )
                                     }
                                 >
-                                    Nonfoil
-                                </MenuItem>
-                            </Select>
-                        </FormControl>
-                        <ControlledDropdown
-                            name="condition"
-                            label="Condition"
-                            options={cardConditions}
-                            value={values.condition}
-                            onChange={(v) => setFieldValue('condition', v)}
-                        />
-                        <IntegerInput
-                            label="Quantity"
-                            name="quantity"
-                            value={values.quantity}
-                            onChange={(v) => setFieldValue('quantity', v)}
-                        />
-                        <div>
+                                    <MenuItem
+                                        key="nonfoil"
+                                        value="FOIL"
+                                        disabled={
+                                            !values?.bulkCard?.foil_printing
+                                        }
+                                    >
+                                        Foil
+                                    </MenuItem>
+                                    <MenuItem
+                                        key="foil"
+                                        value="NONFOIL"
+                                        disabled={
+                                            !values?.bulkCard?.nonfoil_printing
+                                        }
+                                    >
+                                        Nonfoil
+                                    </MenuItem>
+                                </Select>
+                            </FormControl>
+                        </Grid>
+                        <Grid item xs={4}>
+                            <ControlledDropdown
+                                name="condition"
+                                label="Condition"
+                                options={cardConditions}
+                                value={values.condition}
+                                onChange={(v) => setFieldValue('condition', v)}
+                            />
+                        </Grid>
+                        <Grid item xs={4}>
+                            <IntegerInput
+                                label="Quantity"
+                                name="quantity"
+                                value={values.quantity}
+                                onChange={(v) => setFieldValue('quantity', v)}
+                            />
+                        </Grid>
+                        <Grid item>
+                            <Button onClick={() => handleSubmit()}>
+                                Submit!
+                            </Button>
+                        </Grid>
+                    </Grid>
+                    <Grid item xs={4}>
+                        <div
+                            // TODO: Extract this style
+                            style={{ maxWidth: 200, height: 'auto' }}
+                        >
                             <CardImage image={currentCardImage} />
                         </div>
                     </Grid>
                 </Grid>
-                <button onClick={() => handleSubmit()}>Submit!</button>
             </form>
         </Container>
     );

--- a/frontend/src/BulkInventory/BulkInventory.tsx
+++ b/frontend/src/BulkInventory/BulkInventory.tsx
@@ -1,20 +1,30 @@
-import { Container } from '@material-ui/core';
+import { Container, Grid } from '@material-ui/core';
 import React, { FC } from 'react';
 import { useState } from 'react';
+import CardImage from '../common/CardImage';
 import { BulkCard } from './bulkInventoryQuery';
 import BulkSearchBar from './BulkSearchBar';
 
 const BulkInventory: FC = () => {
     const [bulkCard, setBulkCard] = useState<BulkCard | null>(null);
+    const [currentCardImage, setCurrentCardImage] = useState<string>('');
 
     return (
         <Container>
-            {/* <pre>{JSON.stringify(bulkCard, null, 2)}</pre> */}
-            <BulkSearchBar
-                value={bulkCard ? bulkCard.name : ''}
-                onChange={(v) => setBulkCard(v)}
-            />
-            <div>this is some content</div>
+            <Grid container spacing={2}>
+                <Grid item xs={6}>
+                    <BulkSearchBar
+                        value={bulkCard ? bulkCard.name : ''}
+                        onChange={(v) => setBulkCard(v)}
+                        onHighlight={(o) => setCurrentCardImage(o?.image || '')}
+                    />
+                </Grid>
+                <Grid item xs={6}>
+                    <div>
+                        <CardImage image={currentCardImage} />
+                    </div>
+                </Grid>
+            </Grid>
         </Container>
     );
 };

--- a/frontend/src/BulkInventory/BulkInventory.tsx
+++ b/frontend/src/BulkInventory/BulkInventory.tsx
@@ -28,6 +28,13 @@ interface FormValues {
 
 const BulkInventory: FC = () => {
     const [currentCardImage, setCurrentCardImage] = useState<string>('');
+    const [submittedCards, setSubmittedCards] = useState<FormValues[]>([]);
+
+    const onSubmit = async (values: FormValues) => {
+        alert(JSON.stringify(values, null, 2));
+        setSubmittedCards([values, ...submittedCards]);
+        resetForm();
+    };
 
     const { values, setFieldValue, handleSubmit, resetForm } = useFormik<
         FormValues
@@ -38,10 +45,7 @@ const BulkInventory: FC = () => {
             quantity: '1',
             condition: 'NM',
         },
-        onSubmit: async (v: FormValues) => {
-            alert(JSON.stringify(v, null, 2));
-            resetForm();
-        },
+        onSubmit,
     });
 
     useEffect(() => {
@@ -103,7 +107,7 @@ const BulkInventory: FC = () => {
                                         key="nonfoil"
                                         value="FOIL"
                                         disabled={
-                                            !values?.bulkCard?.foil_printing
+                                            !values.bulkCard?.foil_printing
                                         }
                                     >
                                         Foil
@@ -112,7 +116,7 @@ const BulkInventory: FC = () => {
                                         key="foil"
                                         value="NONFOIL"
                                         disabled={
-                                            !values?.bulkCard?.nonfoil_printing
+                                            !values.bulkCard?.nonfoil_printing
                                         }
                                     >
                                         Nonfoil
@@ -140,7 +144,10 @@ const BulkInventory: FC = () => {
                             />
                         </Grid>
                         <Grid item>
-                            <Button onClick={() => handleSubmit()}>
+                            <Button
+                                onClick={() => handleSubmit()}
+                                disabled={!values.bulkCard}
+                            >
                                 Submit!
                             </Button>
                         </Grid>
@@ -152,6 +159,9 @@ const BulkInventory: FC = () => {
                         >
                             <CardImage image={currentCardImage} />
                         </div>
+                    </Grid>
+                    <Grid item xs={12}>
+                        <pre>{JSON.stringify({ submittedCards }, null, 2)}</pre>
                     </Grid>
                 </Grid>
             </form>

--- a/frontend/src/BulkInventory/BulkInventory.tsx
+++ b/frontend/src/BulkInventory/BulkInventory.tsx
@@ -4,6 +4,7 @@ import {
     FormControl,
     Grid,
     InputLabel,
+    makeStyles,
     MenuItem,
     Select,
 } from '@material-ui/core';
@@ -22,6 +23,22 @@ import { SectionText } from '../ui/Typography';
 type Finish = 'FOIL' | 'NONFOIL';
 type Condition = 'NM' | 'LP' | 'MP' | 'HP';
 
+const useStyles = makeStyles(({ palette }) => ({
+    imageContainer: { maxWidth: 200, height: 'auto' },
+    placeholderImage: {
+        background: `repeating-linear-gradient(
+            45deg,
+            ${palette.grey[200]},
+            ${palette.grey[200]} 10px,
+            ${palette.grey[300]} 10px,
+            ${palette.grey[300]} 20px
+          )`,
+        borderRadius: 10,
+        height: 280,
+        width: 200,
+    },
+}));
+
 export interface FormValues {
     bulkCard: BulkCard | null;
     finish: Finish;
@@ -30,6 +47,7 @@ export interface FormValues {
 }
 
 const BulkInventory: FC = () => {
+    const { imageContainer, placeholderImage } = useStyles();
     const [currentCardImage, setCurrentCardImage] = useState<string>('');
     const [submittedCards, setSubmittedCards] = useState<FormValues[]>([]);
     const createToast = useToastContext();
@@ -39,7 +57,7 @@ const BulkInventory: FC = () => {
         setSubmittedCards([values, ...submittedCards]);
         if (values.bulkCard) {
             createToast({
-                message: `Added ${values.quantity}x ${values.bulkCard.name}`,
+                message: `Added ${values.quantity}x ${values.bulkCard.name} to inventory`,
                 severity: 'success',
             });
         }
@@ -82,102 +100,121 @@ const BulkInventory: FC = () => {
     }, [values.bulkCard]);
 
     return (
-        <Container>
-            <form>
-                <Grid container spacing={2}>
-                    <Grid item container spacing={2} xs={8}>
-                        <Grid item xs={12}>
-                            <BulkSearchBar
-                                value={values.bulkCard}
-                                onChange={(v) => setFieldValue('bulkCard', v)}
-                                onHighlight={(o) =>
-                                    setCurrentCardImage(o?.image || '')
-                                }
-                            />
-                        </Grid>
-                        <Grid item xs={4}>
-                            <FormControl
-                                variant="outlined"
-                                size="small"
-                                fullWidth
-                                disabled={!values.bulkCard}
-                            >
-                                <InputLabel>Finish</InputLabel>
-                                <Select
-                                    label="Finish"
-                                    value={values.finish}
-                                    onChange={(e) =>
-                                        setFieldValue(
-                                            'finish',
-                                            e.target.value as string
-                                        )
+        <Container maxWidth="md">
+            <Grid container spacing={3}>
+                <Grid item xs={8}>
+                    <form>
+                        <Grid container spacing={3} xs={12}>
+                            <Grid item xs={12}>
+                                <SectionText>Card search</SectionText>
+                                <br />
+                                <BulkSearchBar
+                                    value={values.bulkCard}
+                                    onChange={(v) =>
+                                        setFieldValue('bulkCard', v)
                                     }
+                                    onHighlight={(o) =>
+                                        setCurrentCardImage(o?.image || '')
+                                    }
+                                />
+                            </Grid>
+                            <Grid item xs={4}>
+                                <FormControl
+                                    variant="outlined"
+                                    size="small"
+                                    fullWidth
+                                    disabled={!values.bulkCard}
                                 >
-                                    <MenuItem
-                                        key="nonfoil"
-                                        value="FOIL"
-                                        disabled={
-                                            !values.bulkCard?.foil_printing
+                                    <InputLabel>Finish</InputLabel>
+                                    <Select
+                                        label="Finish"
+                                        value={values.finish}
+                                        onChange={(e) =>
+                                            setFieldValue(
+                                                'finish',
+                                                e.target.value as string
+                                            )
                                         }
                                     >
-                                        Foil
-                                    </MenuItem>
-                                    <MenuItem
-                                        key="foil"
-                                        value="NONFOIL"
-                                        disabled={
-                                            !values.bulkCard?.nonfoil_printing
-                                        }
-                                    >
-                                        Nonfoil
-                                    </MenuItem>
-                                </Select>
-                            </FormControl>
+                                        <MenuItem
+                                            key="nonfoil"
+                                            value="FOIL"
+                                            disabled={
+                                                !values.bulkCard?.foil_printing
+                                            }
+                                        >
+                                            Foil
+                                        </MenuItem>
+                                        <MenuItem
+                                            key="foil"
+                                            value="NONFOIL"
+                                            disabled={
+                                                !values.bulkCard
+                                                    ?.nonfoil_printing
+                                            }
+                                        >
+                                            Nonfoil
+                                        </MenuItem>
+                                    </Select>
+                                </FormControl>
+                            </Grid>
+                            <Grid item xs={4}>
+                                <ControlledDropdown
+                                    disabled={!values.bulkCard}
+                                    name="condition"
+                                    label="Condition"
+                                    options={cardConditions}
+                                    value={values.condition}
+                                    onChange={(v) =>
+                                        setFieldValue('condition', v)
+                                    }
+                                />
+                            </Grid>
+                            <Grid item xs={4}>
+                                <IntegerInput
+                                    label="Quantity"
+                                    name="quantity"
+                                    value={values.quantity}
+                                    onChange={(v) =>
+                                        setFieldValue('quantity', v)
+                                    }
+                                    disabled={!values.bulkCard}
+                                />
+                            </Grid>
+                            <Grid item xs={12}>
+                                <Button
+                                    fullWidth
+                                    type="submit"
+                                    primary
+                                    onClick={() => handleSubmit()}
+                                    disabled={!values.bulkCard}
+                                >
+                                    Add to inventory
+                                </Button>
+                            </Grid>
                         </Grid>
-                        <Grid item xs={4}>
-                            <ControlledDropdown
-                                disabled={!values.bulkCard}
-                                name="condition"
-                                label="Condition"
-                                options={cardConditions}
-                                value={values.condition}
-                                onChange={(v) => setFieldValue('condition', v)}
-                            />
-                        </Grid>
-                        <Grid item xs={4}>
-                            <IntegerInput
-                                label="Quantity"
-                                name="quantity"
-                                value={values.quantity}
-                                onChange={(v) => setFieldValue('quantity', v)}
-                                disabled={!values.bulkCard}
-                            />
-                        </Grid>
-                        <Grid item>
-                            <Button
-                                onClick={() => handleSubmit()}
-                                disabled={!values.bulkCard}
-                            >
-                                Submit!
-                            </Button>
-                        </Grid>
-                    </Grid>
-                    <Grid item xs={4}>
-                        <div
-                            // TODO: Extract this style
-                            style={{ maxWidth: 200, height: 'auto' }}
-                        >
+                    </form>
+                </Grid>
+                <Grid item xs={4}>
+                    <SectionText>Card preview</SectionText>
+                    <br />
+                    {currentCardImage ? (
+                        <div className={imageContainer}>
                             <CardImage image={currentCardImage} />
                         </div>
-                    </Grid>
-                    {submittedCards.length > 0 && (
-                        <Grid item xs={12}>
-                            <SectionText>Recently added cards</SectionText>
-                            <SubmittedCardsTable cards={submittedCards} />
-                        </Grid>
+                    ) : (
+                        <div className={imageContainer}>
+                            <div className={placeholderImage} />
+                        </div>
                     )}
                 </Grid>
-            </form>
+            </Grid>
+            {submittedCards.length > 0 && (
+                <div>
+                    <SectionText>Recently added cards</SectionText>
+                    <SubmittedCardsTable cards={submittedCards} />
+                </div>
+            )}
         </Container>
     );
 };

--- a/frontend/src/BulkInventory/BulkInventory.tsx
+++ b/frontend/src/BulkInventory/BulkInventory.tsx
@@ -122,6 +122,7 @@ const BulkInventory: FC = () => {
                         </Grid>
                         <Grid item xs={4}>
                             <ControlledDropdown
+                                disabled={!values.bulkCard}
                                 name="condition"
                                 label="Condition"
                                 options={cardConditions}
@@ -135,6 +136,7 @@ const BulkInventory: FC = () => {
                                 name="quantity"
                                 value={values.quantity}
                                 onChange={(v) => setFieldValue('quantity', v)}
+                                disabled={!values.bulkCard}
                             />
                         </Grid>
                         <Grid item>

--- a/frontend/src/BulkInventory/BulkInventory.tsx
+++ b/frontend/src/BulkInventory/BulkInventory.tsx
@@ -1,9 +1,19 @@
 import { Container } from '@material-ui/core';
 import React, { FC } from 'react';
+import { useState } from 'react';
+import { BulkCard } from './bulkInventoryQuery';
+import BulkSearchBar from './BulkSearchBar';
 
 const BulkInventory: FC = () => {
+    const [bulkCard, setBulkCard] = useState<BulkCard | null>(null);
+
     return (
         <Container>
+            <pre>{JSON.stringify(bulkCard, null, 2)}</pre>
+            <BulkSearchBar
+                value={bulkCard ? bulkCard.name : ''}
+                onChange={(v) => setBulkCard(v)}
+            />
             <div>this is some content</div>
         </Container>
     );

--- a/frontend/src/BulkInventory/BulkInventory.tsx
+++ b/frontend/src/BulkInventory/BulkInventory.tsx
@@ -16,11 +16,13 @@ import { BulkCard } from './bulkInventoryQuery';
 import BulkSearchBar from './BulkSearchBar';
 import Button from '../ui/Button';
 import { useToastContext } from '../ui/ToastContext';
+import SubmittedCardsTable from './SubmittedCardsTable';
+import { SectionText } from '../ui/Typography';
 
 type Finish = 'FOIL' | 'NONFOIL';
 type Condition = 'NM' | 'LP' | 'MP' | 'HP';
 
-interface FormValues {
+export interface FormValues {
     bulkCard: BulkCard | null;
     finish: Finish;
     quantity: string;
@@ -168,9 +170,12 @@ const BulkInventory: FC = () => {
                             <CardImage image={currentCardImage} />
                         </div>
                     </Grid>
-                    <Grid item xs={12}>
-                        <pre>{JSON.stringify({ submittedCards }, null, 2)}</pre>
-                    </Grid>
+                    {submittedCards.length > 0 && (
+                        <Grid item xs={12}>
+                            <SectionText>Recently added cards</SectionText>
+                            <SubmittedCardsTable cards={submittedCards} />
+                        </Grid>
+                    )}
                 </Grid>
             </form>
         </Container>

--- a/frontend/src/BulkInventory/BulkInventory.tsx
+++ b/frontend/src/BulkInventory/BulkInventory.tsx
@@ -9,7 +9,7 @@ const BulkInventory: FC = () => {
 
     return (
         <Container>
-            <pre>{JSON.stringify(bulkCard, null, 2)}</pre>
+            {/* <pre>{JSON.stringify(bulkCard, null, 2)}</pre> */}
             <BulkSearchBar
                 value={bulkCard ? bulkCard.name : ''}
                 onChange={(v) => setBulkCard(v)}

--- a/frontend/src/BulkInventory/BulkInventory.tsx
+++ b/frontend/src/BulkInventory/BulkInventory.tsx
@@ -1,3 +1,4 @@
+import React, { FC, useEffect, useState } from 'react';
 import {
     Container,
     FormControl,
@@ -7,10 +8,10 @@ import {
     Select,
 } from '@material-ui/core';
 import { useFormik } from 'formik';
-import React, { FC } from 'react';
-import { useEffect } from 'react';
-import { useState } from 'react';
 import CardImage from '../common/CardImage';
+import ControlledDropdown from '../ui/ControlledDropdown';
+import IntegerInput from '../ui/IntegerInput';
+import { cardConditions } from '../utils/dropdownOptions';
 import { BulkCard } from './bulkInventoryQuery';
 import BulkSearchBar from './BulkSearchBar';
 
@@ -20,18 +21,18 @@ type Condition = 'NM' | 'LP' | 'MP' | 'HP';
 interface FormValues {
     bulkCard: BulkCard | null;
     finish: Finish;
-    quanitity: number;
+    quantity: string;
     condition: Condition;
 }
 
 const BulkInventory: FC = () => {
     const [currentCardImage, setCurrentCardImage] = useState<string>('');
 
-    const { values, setFieldValue } = useFormik<FormValues>({
+    const { values, setFieldValue, handleSubmit } = useFormik<FormValues>({
         initialValues: {
             bulkCard: null,
             finish: 'NONFOIL',
-            quanitity: 1,
+            quantity: '1',
             condition: 'NM',
         },
         onSubmit: async (v: FormValues) => {
@@ -41,6 +42,12 @@ const BulkInventory: FC = () => {
 
     useEffect(() => {
         if (values.bulkCard) {
+            // Reset condtion when cards change
+            setFieldValue('condition', 'NM');
+
+            // Reset quantity when cards change
+            setFieldValue('quantity', '1');
+
             // If _only_ a foil printing exists, set to foil
             if (!values.bulkCard.nonfoil_printing) {
                 setFieldValue('finish', 'FOIL');
@@ -54,7 +61,7 @@ const BulkInventory: FC = () => {
             // Otherwise both exist, default to nonfoil
             setFieldValue('finish', 'NONFOIL');
         }
-    }, [values]);
+    }, [values.bulkCard]);
 
     return (
         <Container>
@@ -106,11 +113,25 @@ const BulkInventory: FC = () => {
                                 </MenuItem>
                             </Select>
                         </FormControl>
+                        <ControlledDropdown
+                            name="condition"
+                            label="Condition"
+                            options={cardConditions}
+                            value={values.condition}
+                            onChange={(v) => setFieldValue('condition', v)}
+                        />
+                        <IntegerInput
+                            label="Quantity"
+                            name="quantity"
+                            value={values.quantity}
+                            onChange={(v) => setFieldValue('quantity', v)}
+                        />
                         <div>
                             <CardImage image={currentCardImage} />
                         </div>
                     </Grid>
                 </Grid>
+                <button onClick={() => handleSubmit()}>Submit!</button>
             </form>
         </Container>
     );

--- a/frontend/src/BulkInventory/BulkInventory.tsx
+++ b/frontend/src/BulkInventory/BulkInventory.tsx
@@ -14,7 +14,7 @@ const BulkInventory: FC = () => {
             <Grid container spacing={2}>
                 <Grid item xs={6}>
                     <BulkSearchBar
-                        value={bulkCard ? bulkCard.name : ''}
+                        value={bulkCard}
                         onChange={(v) => setBulkCard(v)}
                         onHighlight={(o) => setCurrentCardImage(o?.image || '')}
                     />

--- a/frontend/src/BulkInventory/BulkInventory.tsx
+++ b/frontend/src/BulkInventory/BulkInventory.tsx
@@ -1,0 +1,12 @@
+import { Container } from '@material-ui/core';
+import React, { FC } from 'react';
+
+const BulkInventory: FC = () => {
+    return (
+        <Container>
+            <div>this is some content</div>
+        </Container>
+    );
+};
+
+export default BulkInventory;

--- a/frontend/src/BulkInventory/BulkInventory.tsx
+++ b/frontend/src/BulkInventory/BulkInventory.tsx
@@ -1,30 +1,117 @@
-import { Container, Grid } from '@material-ui/core';
+import {
+    Container,
+    FormControl,
+    Grid,
+    InputLabel,
+    MenuItem,
+    Select,
+} from '@material-ui/core';
+import { useFormik } from 'formik';
 import React, { FC } from 'react';
+import { useEffect } from 'react';
 import { useState } from 'react';
 import CardImage from '../common/CardImage';
 import { BulkCard } from './bulkInventoryQuery';
 import BulkSearchBar from './BulkSearchBar';
 
+type Finish = 'FOIL' | 'NONFOIL';
+type Condition = 'NM' | 'LP' | 'MP' | 'HP';
+
+interface FormValues {
+    bulkCard: BulkCard | null;
+    finish: Finish;
+    quanitity: number;
+    condition: Condition;
+}
+
 const BulkInventory: FC = () => {
-    const [bulkCard, setBulkCard] = useState<BulkCard | null>(null);
     const [currentCardImage, setCurrentCardImage] = useState<string>('');
+
+    const { values, setFieldValue } = useFormik<FormValues>({
+        initialValues: {
+            bulkCard: null,
+            finish: 'NONFOIL',
+            quanitity: 1,
+            condition: 'NM',
+        },
+        onSubmit: async (v: FormValues) => {
+            alert(JSON.stringify(v, null, 2));
+        },
+    });
+
+    useEffect(() => {
+        if (values.bulkCard) {
+            // If _only_ a foil printing exists, set to foil
+            if (!values.bulkCard.nonfoil_printing) {
+                setFieldValue('finish', 'FOIL');
+                return;
+            }
+            // If _only_ a nonfoil printing exists, set to nonfoil
+            if (!values.bulkCard.foil_printing) {
+                setFieldValue('finish', 'NONFOIL');
+                return;
+            }
+            // Otherwise both exist, default to nonfoil
+            setFieldValue('finish', 'NONFOIL');
+        }
+    }, [values]);
 
     return (
         <Container>
-            <Grid container spacing={2}>
-                <Grid item xs={6}>
-                    <BulkSearchBar
-                        value={bulkCard}
-                        onChange={(v) => setBulkCard(v)}
-                        onHighlight={(o) => setCurrentCardImage(o?.image || '')}
-                    />
+            <pre>{JSON.stringify({ values }, null, 2)}</pre>
+            <form>
+                <Grid container spacing={2}>
+                    <Grid item xs={6}>
+                        <BulkSearchBar
+                            value={values.bulkCard}
+                            onChange={(v) => setFieldValue('bulkCard', v)}
+                            onHighlight={(o) =>
+                                setCurrentCardImage(o?.image || '')
+                            }
+                        />
+                    </Grid>
+                    <Grid item xs={6}>
+                        <FormControl
+                            variant="outlined"
+                            size="small"
+                            fullWidth
+                            disabled={!values.bulkCard}
+                        >
+                            <InputLabel>Finish</InputLabel>
+                            <Select
+                                label="Finish"
+                                value={values.finish}
+                                onChange={(e) =>
+                                    setFieldValue(
+                                        'finish',
+                                        e.target.value as string
+                                    )
+                                }
+                            >
+                                <MenuItem
+                                    key="nonfoil"
+                                    value="FOIL"
+                                    disabled={!values?.bulkCard?.foil_printing}
+                                >
+                                    Foil
+                                </MenuItem>
+                                <MenuItem
+                                    key="foil"
+                                    value="NONFOIL"
+                                    disabled={
+                                        !values?.bulkCard?.nonfoil_printing
+                                    }
+                                >
+                                    Nonfoil
+                                </MenuItem>
+                            </Select>
+                        </FormControl>
+                        <div>
+                            <CardImage image={currentCardImage} />
+                        </div>
+                    </Grid>
                 </Grid>
-                <Grid item xs={6}>
-                    <div>
-                        <CardImage image={currentCardImage} />
-                    </div>
-                </Grid>
-            </Grid>
+            </form>
         </Container>
     );
 };

--- a/frontend/src/BulkInventory/BulkInventory.tsx
+++ b/frontend/src/BulkInventory/BulkInventory.tsx
@@ -29,7 +29,9 @@ interface FormValues {
 const BulkInventory: FC = () => {
     const [currentCardImage, setCurrentCardImage] = useState<string>('');
 
-    const { values, setFieldValue, handleSubmit } = useFormik<FormValues>({
+    const { values, setFieldValue, handleSubmit, resetForm } = useFormik<
+        FormValues
+    >({
         initialValues: {
             bulkCard: null,
             finish: 'NONFOIL',
@@ -38,6 +40,7 @@ const BulkInventory: FC = () => {
         },
         onSubmit: async (v: FormValues) => {
             alert(JSON.stringify(v, null, 2));
+            resetForm();
         },
     });
 

--- a/frontend/src/BulkInventory/BulkInventory.tsx
+++ b/frontend/src/BulkInventory/BulkInventory.tsx
@@ -15,6 +15,7 @@ import { cardConditions } from '../utils/dropdownOptions';
 import { BulkCard } from './bulkInventoryQuery';
 import BulkSearchBar from './BulkSearchBar';
 import Button from '../ui/Button';
+import { useToastContext } from '../ui/ToastContext';
 
 type Finish = 'FOIL' | 'NONFOIL';
 type Condition = 'NM' | 'LP' | 'MP' | 'HP';
@@ -29,10 +30,17 @@ interface FormValues {
 const BulkInventory: FC = () => {
     const [currentCardImage, setCurrentCardImage] = useState<string>('');
     const [submittedCards, setSubmittedCards] = useState<FormValues[]>([]);
+    const createToast = useToastContext();
 
     const onSubmit = async (values: FormValues) => {
         alert(JSON.stringify(values, null, 2));
         setSubmittedCards([values, ...submittedCards]);
+        if (values.bulkCard) {
+            createToast({
+                message: `Added ${values.quantity}x ${values.bulkCard.name}`,
+                severity: 'success',
+            });
+        }
         resetForm();
     };
 

--- a/frontend/src/BulkInventory/BulkSearchBar.tsx
+++ b/frontend/src/BulkInventory/BulkSearchBar.tsx
@@ -7,6 +7,8 @@ import { TextField, makeStyles, Typography } from '@material-ui/core';
 import SearchIcon from '@material-ui/icons/Search';
 import bulkInventoryQuery, { BulkCard } from './bulkInventoryQuery';
 import SetIcon from '../ui/SetIcon';
+import { useEffect } from 'react';
+import { useRef } from 'react';
 
 export type Option = BulkCard;
 
@@ -30,6 +32,18 @@ const BulkSearchBar: FC<Props> = ({ value, onChange, onHighlight }) => {
     const [loading, setLoading] = useState<boolean>(false);
     const [options, setOptions] = useState<Option[]>([]);
     const [internalValue, setInternalValue] = useState<Option | null>(value);
+    const ref = useRef<HTMLInputElement>();
+
+    useEffect(() => {
+        // If `value` is `null` on prop change, set the internal value to `null` as well
+        if (!value) {
+            setInternalValue(null);
+        }
+        // Focus the input when it is cleared
+        if (ref && ref.current) {
+            ref.current.focus();
+        }
+    }, [value]);
 
     const fetchResults = async (v: string) => {
         setLoading(true);
@@ -115,12 +129,16 @@ const BulkSearchBar: FC<Props> = ({ value, onChange, onHighlight }) => {
                     popupIndicatorOpen: classes.popupIndicatorOpen,
                 }}
                 renderInput={(params) => (
-                    <TextField
-                        {...params}
-                        label="Enter a card title"
-                        variant="outlined"
-                        size="small"
-                    />
+                    <div ref={params.InputProps.ref}>
+                        <TextField
+                            inputProps={{ ref }}
+                            {...params.inputProps}
+                            fullWidth
+                            label="Enter a card title"
+                            variant="outlined"
+                            size="small"
+                        />
+                    </div>
                 )}
             />
         </>

--- a/frontend/src/BulkInventory/BulkSearchBar.tsx
+++ b/frontend/src/BulkInventory/BulkSearchBar.tsx
@@ -45,6 +45,7 @@ const BulkSearchBar: FC<Props> = ({ value, onChange, onHighlight }) => {
 
     const handleSearchChange = async (_: ChangeEvent<{}>, val: string) => {
         setInputValue(val);
+        setInternalValue(null);
 
         // Skip undefined and short internalValues
         if (!val || val.length < 3) {
@@ -63,6 +64,7 @@ const BulkSearchBar: FC<Props> = ({ value, onChange, onHighlight }) => {
         // If the user clears the input, then we need to reset the state
         if (reason === 'clear') {
             onChange(null);
+            setInternalValue(null);
             return;
         }
 

--- a/frontend/src/BulkInventory/BulkSearchBar.tsx
+++ b/frontend/src/BulkInventory/BulkSearchBar.tsx
@@ -1,0 +1,123 @@
+import React, { ChangeEvent, FC, useCallback, useState } from 'react';
+import _ from 'lodash';
+import $ from 'jquery';
+import Autocomplete, {
+    AutocompleteChangeReason,
+} from '@material-ui/lab/Autocomplete';
+import { TextField, makeStyles, Typography } from '@material-ui/core';
+import SearchIcon from '@material-ui/icons/Search';
+import bulkInventoryQuery, { BulkCard } from './bulkInventoryQuery';
+import SetIcon from '../ui/SetIcon';
+
+export type Option = BulkCard;
+
+const useStyles = makeStyles({
+    /*
+     * Prevents the option-list icon from rotating 180 degrees to preserve orientation of custom icon
+     */
+    popupIndicatorOpen: {
+        transform: 'rotate(0deg)',
+    },
+});
+
+interface Props {
+    value: string;
+    onChange: (result: Option | null) => void;
+}
+
+const BulkSearchBar: FC<Props> = ({ value, onChange }) => {
+    const classes = useStyles();
+    const [loading, setLoading] = useState<boolean>(false);
+    const [results, setResults] = useState<Option[]>([]);
+    const [internalValue, setInternalValue] = useState<Option | null>(null);
+    const [inputValue, setInputValue] = useState<string>(value);
+
+    const fetchResults = async (v: string) => {
+        setLoading(true);
+        const data = await bulkInventoryQuery(v);
+        setResults(data);
+        setLoading(false);
+    };
+
+    // Cache so it doesn't create a new instance each render
+    const debouncedFetch = useCallback(_.debounce(fetchResults, 500), []);
+
+    const handleSearchChange = async (_: ChangeEvent<{}>, val: string) => {
+        setInputValue(val);
+
+        // Skip undefined and short internalValues
+        if (!val || val.length < 3) {
+            setResults([]);
+            return;
+        }
+
+        await debouncedFetch(val);
+    };
+
+    const handleResultSelect = async (
+        _: ChangeEvent<{}>,
+        value: Option | null,
+        reason: AutocompleteChangeReason
+    ) => {
+        // If the user clears the input, then we need to reset the state
+        if (reason === 'clear') {
+            onChange(null);
+            return;
+        }
+
+        // This line is a hacky way to get around the fact that if we just select(), then
+        // when the user manually clicks the first (or any) result in the resultlist, it does not select,
+        // presumably because there is some collision between selecting the resultList element and focusing the input
+        setTimeout(() => $('#searchBar').select(), 10);
+
+        try {
+            setLoading(true);
+            setInternalValue(value);
+            await onChange(value);
+            setLoading(false);
+        } catch (e) {
+            console.log(e);
+        }
+    };
+
+    return (
+        <Autocomplete
+            id="searchBar"
+            autoHighlight
+            selectOnFocus
+            value={internalValue}
+            inputValue={inputValue}
+            onInputChange={handleSearchChange}
+            onChange={handleResultSelect}
+            loading={loading}
+            options={results}
+            getOptionLabel={(o) => o.display_name}
+            getOptionSelected={(o, v) => o.scryfall_id === v.scryfall_id}
+            renderOption={(o) => {
+                return (
+                    <>
+                        <Typography>{o.display_name}</Typography>
+                        <SetIcon set={o.set_abbreviation} rarity={o.rarity} />
+                    </>
+                );
+            }}
+            placeholder="Enter a card title"
+            closeIcon={null}
+            popupIcon={<SearchIcon />}
+            noOptionsText="No results found"
+            classes={{
+                popupIndicatorOpen: classes.popupIndicatorOpen,
+            }}
+            renderInput={(params) => (
+                <TextField
+                    {...params}
+                    label="Enter a card title"
+                    variant="outlined"
+                    size="small"
+                />
+            )}
+        />
+    );
+};
+
+export default BulkSearchBar;

--- a/frontend/src/BulkInventory/BulkSearchBar.tsx
+++ b/frontend/src/BulkInventory/BulkSearchBar.tsx
@@ -1,6 +1,5 @@
 import React, { ChangeEvent, FC, useCallback, useState } from 'react';
 import _ from 'lodash';
-import $ from 'jquery';
 import Autocomplete, {
     AutocompleteChangeReason,
 } from '@material-ui/lab/Autocomplete';
@@ -31,7 +30,6 @@ const BulkSearchBar: FC<Props> = ({ value, onChange, onHighlight }) => {
     const [loading, setLoading] = useState<boolean>(false);
     const [options, setOptions] = useState<Option[]>([]);
     const [internalValue, setInternalValue] = useState<Option | null>(value);
-    const [inputValue, setInputValue] = useState<string>('');
 
     const fetchResults = async (v: string) => {
         setLoading(true);
@@ -44,9 +42,6 @@ const BulkSearchBar: FC<Props> = ({ value, onChange, onHighlight }) => {
     const debouncedFetch = useCallback(_.debounce(fetchResults, 750), []);
 
     const handleSearchChange = async (_: ChangeEvent<{}>, val: string) => {
-        setInputValue(val);
-        setInternalValue(null);
-
         // Skip undefined and short internalValues
         if (!val || val.length < 3) {
             setOptions([]);
@@ -68,11 +63,6 @@ const BulkSearchBar: FC<Props> = ({ value, onChange, onHighlight }) => {
             return;
         }
 
-        // This line is a hacky way to get around the fact that if we just select(), then
-        // when the user manually clicks the first (or any) result in the resultlist, it does not select,
-        // presumably because there is some collision between selecting the resultList element and focusing the input
-        setTimeout(() => $('#searchBar').select(), 10);
-
         try {
             setLoading(true);
             setInternalValue(value);
@@ -85,18 +75,11 @@ const BulkSearchBar: FC<Props> = ({ value, onChange, onHighlight }) => {
 
     return (
         <>
-            <div>
-                <pre>{JSON.stringify({ inputValue }, null, 2)}</pre>
-            </div>
-            <div>
-                <pre>{JSON.stringify({ internalValue }, null, 2)}</pre>
-            </div>
             <Autocomplete
                 id="searchBar"
                 autoHighlight
                 selectOnFocus
                 value={internalValue}
-                inputValue={inputValue}
                 onInputChange={handleSearchChange}
                 onChange={handleResultSelect}
                 loading={loading}

--- a/frontend/src/BulkInventory/BulkSearchBar.tsx
+++ b/frontend/src/BulkInventory/BulkSearchBar.tsx
@@ -21,7 +21,7 @@ const useStyles = makeStyles({
 });
 
 interface Props {
-    value: string;
+    value: Option | null;
     onChange: (result: Option | null) => void;
     onHighlight?: (o: Option | null) => void;
 }
@@ -30,8 +30,8 @@ const BulkSearchBar: FC<Props> = ({ value, onChange, onHighlight }) => {
     const classes = useStyles();
     const [loading, setLoading] = useState<boolean>(false);
     const [options, setOptions] = useState<Option[]>([]);
-    const [internalValue, setInternalValue] = useState<Option | null>(null);
-    const [inputValue, setInputValue] = useState<string>(value);
+    const [internalValue, setInternalValue] = useState<Option | null>(value);
+    const [inputValue, setInputValue] = useState<string>('');
 
     const fetchResults = async (v: string) => {
         setLoading(true);

--- a/frontend/src/BulkInventory/BulkSearchBar.tsx
+++ b/frontend/src/BulkInventory/BulkSearchBar.tsx
@@ -28,26 +28,29 @@ interface Props {
 const BulkSearchBar: FC<Props> = ({ value, onChange }) => {
     const classes = useStyles();
     const [loading, setLoading] = useState<boolean>(false);
-    const [results, setResults] = useState<Option[]>([]);
+    const [options, setOptions] = useState<Option[]>([]);
     const [internalValue, setInternalValue] = useState<Option | null>(null);
     const [inputValue, setInputValue] = useState<string>(value);
 
     const fetchResults = async (v: string) => {
         setLoading(true);
+        console.log('loading');
         const data = await bulkInventoryQuery(v);
-        setResults(data);
+        console.log({ data });
+        await setOptions(data);
+        console.log({ results: options });
         setLoading(false);
     };
 
     // Cache so it doesn't create a new instance each render
-    const debouncedFetch = useCallback(_.debounce(fetchResults, 500), []);
+    const debouncedFetch = useCallback(_.debounce(fetchResults, 750), []);
 
     const handleSearchChange = async (_: ChangeEvent<{}>, val: string) => {
         setInputValue(val);
 
         // Skip undefined and short internalValues
         if (!val || val.length < 3) {
-            setResults([]);
+            setOptions([]);
             return;
         }
 
@@ -81,42 +84,60 @@ const BulkSearchBar: FC<Props> = ({ value, onChange }) => {
     };
 
     return (
-        <Autocomplete
-            id="searchBar"
-            autoHighlight
-            selectOnFocus
-            value={internalValue}
-            inputValue={inputValue}
-            onInputChange={handleSearchChange}
-            onChange={handleResultSelect}
-            loading={loading}
-            options={results}
-            getOptionLabel={(o) => o.display_name}
-            getOptionSelected={(o, v) => o.scryfall_id === v.scryfall_id}
-            renderOption={(o) => {
-                return (
-                    <>
-                        <Typography>{o.display_name}</Typography>
-                        <SetIcon set={o.set_abbreviation} rarity={o.rarity} />
-                    </>
-                );
-            }}
-            placeholder="Enter a card title"
-            closeIcon={null}
-            popupIcon={<SearchIcon />}
-            noOptionsText="No results found"
-            classes={{
-                popupIndicatorOpen: classes.popupIndicatorOpen,
-            }}
-            renderInput={(params) => (
-                <TextField
-                    {...params}
-                    label="Enter a card title"
-                    variant="outlined"
-                    size="small"
-                />
-            )}
-        />
+        <>
+            <div>
+                <pre>{JSON.stringify({ inputValue }, null, 2)}</pre>
+            </div>
+            <div>
+                <pre>{JSON.stringify({ internalValue }, null, 2)}</pre>
+            </div>
+            <div>
+                <pre>
+                    {JSON.stringify({ options: options.length }, null, 2)}
+                </pre>
+            </div>
+            <Autocomplete
+                id="searchBar"
+                autoHighlight
+                selectOnFocus
+                value={internalValue}
+                inputValue={inputValue}
+                onInputChange={handleSearchChange}
+                onChange={handleResultSelect}
+                loading={loading}
+                options={options}
+                getOptionLabel={(o) => o.display_name}
+                filterOptions={(x) => x}
+                getOptionSelected={(o, v) => o.display_name === v.display_name}
+                renderOption={(o) => {
+                    return (
+                        <>
+                            {/* <pre>{JSON.stringify(o, null, 1)}</pre> */}
+                            <Typography>{o.display_name}</Typography>
+                            <SetIcon
+                                set={o.set_abbreviation}
+                                rarity={o.rarity}
+                            />
+                        </>
+                    );
+                }}
+                placeholder="Enter a card title"
+                closeIcon={null}
+                popupIcon={<SearchIcon />}
+                noOptionsText="No results found"
+                classes={{
+                    popupIndicatorOpen: classes.popupIndicatorOpen,
+                }}
+                renderInput={(params) => (
+                    <TextField
+                        {...params}
+                        label="Enter a card title"
+                        variant="outlined"
+                        size="small"
+                    />
+                )}
+            />
+        </>
     );
 };
 

--- a/frontend/src/BulkInventory/BulkSearchBar.tsx
+++ b/frontend/src/BulkInventory/BulkSearchBar.tsx
@@ -35,11 +35,8 @@ const BulkSearchBar: FC<Props> = ({ value, onChange, onHighlight }) => {
 
     const fetchResults = async (v: string) => {
         setLoading(true);
-        console.log('loading');
         const data = await bulkInventoryQuery(v);
-        console.log({ data });
         await setOptions(data);
-        console.log({ results: options });
         setLoading(false);
     };
 
@@ -92,11 +89,6 @@ const BulkSearchBar: FC<Props> = ({ value, onChange, onHighlight }) => {
             <div>
                 <pre>{JSON.stringify({ internalValue }, null, 2)}</pre>
             </div>
-            <div>
-                <pre>
-                    {JSON.stringify({ options: options.length }, null, 2)}
-                </pre>
-            </div>
             <Autocomplete
                 id="searchBar"
                 autoHighlight
@@ -108,8 +100,10 @@ const BulkSearchBar: FC<Props> = ({ value, onChange, onHighlight }) => {
                 loading={loading}
                 options={options}
                 getOptionLabel={(o) => o.display_name}
-                filterOptions={(x) => x}
-                getOptionSelected={(o, v) => o.display_name === v.display_name}
+                // We do not want to filter options based on user input
+                // This overrides the default behavior
+                filterOptions={(o) => o}
+                getOptionSelected={(o, v) => o.scryfall_id === v.scryfall_id}
                 onHighlightChange={(_, o) => {
                     if (onHighlight) {
                         onHighlight(o);
@@ -117,13 +111,15 @@ const BulkSearchBar: FC<Props> = ({ value, onChange, onHighlight }) => {
                 }}
                 renderOption={(o) => {
                     return (
-                        <>
-                            <Typography>{o.display_name}</Typography>
+                        <div>
+                            <Typography component="span">
+                                {o.display_name}
+                            </Typography>
                             <SetIcon
                                 set={o.set_abbreviation}
                                 rarity={o.rarity}
                             />
-                        </>
+                        </div>
                     );
                 }}
                 placeholder="Enter a card title"

--- a/frontend/src/BulkInventory/BulkSearchBar.tsx
+++ b/frontend/src/BulkInventory/BulkSearchBar.tsx
@@ -23,9 +23,10 @@ const useStyles = makeStyles({
 interface Props {
     value: string;
     onChange: (result: Option | null) => void;
+    onHighlight?: (o: Option | null) => void;
 }
 
-const BulkSearchBar: FC<Props> = ({ value, onChange }) => {
+const BulkSearchBar: FC<Props> = ({ value, onChange, onHighlight }) => {
     const classes = useStyles();
     const [loading, setLoading] = useState<boolean>(false);
     const [options, setOptions] = useState<Option[]>([]);
@@ -109,10 +110,14 @@ const BulkSearchBar: FC<Props> = ({ value, onChange }) => {
                 getOptionLabel={(o) => o.display_name}
                 filterOptions={(x) => x}
                 getOptionSelected={(o, v) => o.display_name === v.display_name}
+                onHighlightChange={(_, o) => {
+                    if (onHighlight) {
+                        onHighlight(o);
+                    }
+                }}
                 renderOption={(o) => {
                     return (
                         <>
-                            {/* <pre>{JSON.stringify(o, null, 1)}</pre> */}
                             <Typography>{o.display_name}</Typography>
                             <SetIcon
                                 set={o.set_abbreviation}

--- a/frontend/src/BulkInventory/SubmittedCardsTable.tsx
+++ b/frontend/src/BulkInventory/SubmittedCardsTable.tsx
@@ -40,7 +40,11 @@ const SubmittedCardsTable: FC<Props> = ({ cards }) => {
                             const { bulkCard, quantity, finish, condition } = c;
 
                             return (
-                                <TableRow key={c.bulkCard.scryfall_id}>
+                                <TableRow
+                                    key={`${
+                                        c.bulkCard.scryfall_id
+                                    }-${Math.random()}`}
+                                >
                                     <TableCell>
                                         {bulkCard.display_name}
                                     </TableCell>

--- a/frontend/src/BulkInventory/SubmittedCardsTable.tsx
+++ b/frontend/src/BulkInventory/SubmittedCardsTable.tsx
@@ -1,0 +1,60 @@
+import React, { FC } from 'react';
+import {
+    Paper,
+    Table,
+    TableBody,
+    TableCell,
+    TableContainer,
+    TableHead,
+    TableRow,
+} from '@material-ui/core';
+import { FormValues } from './BulkInventory';
+
+interface Props {
+    cards: FormValues[];
+}
+
+const SubmittedCardsTable: FC<Props> = ({ cards }) => {
+    return (
+        <TableContainer component={Paper} variant="outlined">
+            <Table size="small">
+                <TableHead>
+                    <TableRow>
+                        <TableCell>
+                            <b>Name</b>
+                        </TableCell>
+                        <TableCell>
+                            <b>Quantity</b>
+                        </TableCell>
+                        <TableCell>
+                            <b>Finish</b>
+                        </TableCell>
+                        <TableCell>
+                            <b>Condition</b>
+                        </TableCell>
+                    </TableRow>
+                </TableHead>
+                <TableBody>
+                    {cards.map((c) => {
+                        if (c.bulkCard) {
+                            const { bulkCard, quantity, finish, condition } = c;
+
+                            return (
+                                <TableRow key={c.bulkCard.scryfall_id}>
+                                    <TableCell>
+                                        {bulkCard.display_name}
+                                    </TableCell>
+                                    <TableCell>{quantity}</TableCell>
+                                    <TableCell>{finish}</TableCell>
+                                    <TableCell>{condition}</TableCell>
+                                </TableRow>
+                            );
+                        }
+                    })}
+                </TableBody>
+            </Table>
+        </TableContainer>
+    );
+};
+
+export default SubmittedCardsTable;

--- a/frontend/src/BulkInventory/bulkInventoryQuery.ts
+++ b/frontend/src/BulkInventory/bulkInventoryQuery.ts
@@ -11,6 +11,8 @@ export interface BulkCard {
     rarity: string;
     foil_printing: boolean;
     nonfoil_printing: boolean;
+    frame: string;
+    image: string;
 }
 
 const bulkInventoryQuery = async (cardName: string) => {

--- a/frontend/src/BulkInventory/bulkInventoryQuery.ts
+++ b/frontend/src/BulkInventory/bulkInventoryQuery.ts
@@ -1,0 +1,31 @@
+import axios from 'axios';
+import makeAuthHeader from '../utils/makeAuthHeader';
+import { GET_BULK_CARDS } from '../utils/api_resources';
+
+interface BulkCard {
+    scryfall_id: string;
+    name: string;
+    display_name: string;
+    set_abbreviation: string;
+    set_name: string;
+    rarity: string;
+    foil_printing: boolean;
+    nonfoil_printing: boolean;
+}
+
+const bulkInventoryQuery = async (cardName: string) => {
+    try {
+        const { data } = await axios.get<BulkCard[]>(GET_BULK_CARDS, {
+            params: {
+                cardName,
+            },
+            headers: makeAuthHeader(),
+        });
+
+        return data;
+    } catch (err) {
+        throw err;
+    }
+};
+
+export default bulkInventoryQuery;

--- a/frontend/src/BulkInventory/bulkInventoryQuery.ts
+++ b/frontend/src/BulkInventory/bulkInventoryQuery.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 import makeAuthHeader from '../utils/makeAuthHeader';
 import { GET_BULK_CARDS } from '../utils/api_resources';
 
-interface BulkCard {
+export interface BulkCard {
     scryfall_id: string;
     name: string;
     display_name: string;

--- a/frontend/src/NavBar/NavLinks.tsx
+++ b/frontend/src/NavBar/NavLinks.tsx
@@ -9,6 +9,7 @@ import VisibilityIcon from '@material-ui/icons/Visibility';
 import ViewListIcon from '@material-ui/icons/ViewList';
 import ExitToAppIcon from '@material-ui/icons/ExitToApp';
 import EqualizerIcon from '@material-ui/icons/Equalizer';
+import QueueIcon from '@material-ui/icons/Queue';
 
 const NavLinks: FC<{}> = () => {
     const { pathname } = useLocation();
@@ -26,6 +27,18 @@ const NavLinks: FC<{}> = () => {
                     <AddIcon color="primary" />
                 </ListItemIcon>
                 Manage Inventory
+            </ListItem>
+            <ListItem
+                button
+                component={RouterLink}
+                to="/bulk-add"
+                selected={pathname === '/bulk-add'}
+                replace
+            >
+                <ListItemIcon>
+                    <QueueIcon color="primary" />
+                </ListItemIcon>
+                Bulk Inventory
             </ListItem>
             <ListItem
                 button

--- a/frontend/src/NavBar/NavLinks.tsx
+++ b/frontend/src/NavBar/NavLinks.tsx
@@ -38,7 +38,7 @@ const NavLinks: FC<{}> = () => {
                 <ListItemIcon>
                     <QueueIcon color="primary" />
                 </ListItemIcon>
-                Bulk Inventory
+                Bulk Entry
             </ListItem>
             <ListItem
                 button

--- a/frontend/src/common/CardImage.tsx
+++ b/frontend/src/common/CardImage.tsx
@@ -12,6 +12,8 @@ const useStyles = makeStyles(({ zIndex }) => ({
         boxShadow: '2px 2px 5px 0 rgba(0,0,0,.25)',
         zIndex: zIndex.appBar,
         transition: 'all .2s ease-in-out',
+        maxWidth: '100%',
+        maxHeight: '100%',
     },
     hoveredStyle: {
         transform: 'scale(1.75)',

--- a/frontend/src/ui/IntegerInput.tsx
+++ b/frontend/src/ui/IntegerInput.tsx
@@ -11,6 +11,7 @@ interface Props {
 const IntegerInput: FC<Props> = ({ value, onChange, label, name }) => {
     return (
         <TextField
+            fullWidth
             type="number"
             size="small"
             variant="outlined"

--- a/frontend/src/ui/IntegerInput.tsx
+++ b/frontend/src/ui/IntegerInput.tsx
@@ -1,14 +1,21 @@
 import React, { FC } from 'react';
 import { TextField } from '@material-ui/core';
+import { TextFieldProps } from '@material-ui/core';
 
-interface Props {
+type Props = Omit<TextFieldProps, 'value' | 'onChange' | 'label' | 'name'> & {
     value: string;
     onChange: (v: string) => void;
     label: string;
     name: string;
-}
+};
 
-const IntegerInput: FC<Props> = ({ value, onChange, label, name }) => {
+const IntegerInput: FC<Props> = ({
+    value,
+    onChange,
+    label,
+    name,
+    ...props
+}) => {
     return (
         <TextField
             fullWidth
@@ -33,6 +40,7 @@ const IntegerInput: FC<Props> = ({ value, onChange, label, name }) => {
             onChange={(e) => {
                 onChange(e.target.value);
             }}
+            {...props}
         />
     );
 };

--- a/frontend/src/ui/IntegerInput.tsx
+++ b/frontend/src/ui/IntegerInput.tsx
@@ -1,0 +1,39 @@
+import React, { FC } from 'react';
+import { TextField } from '@material-ui/core';
+
+interface Props {
+    value: string;
+    onChange: (v: string) => void;
+    label: string;
+    name: string;
+}
+
+const IntegerInput: FC<Props> = ({ value, onChange, label, name }) => {
+    return (
+        <TextField
+            type="number"
+            size="small"
+            variant="outlined"
+            label={label}
+            name={name}
+            value={value}
+            InputProps={{
+                inputProps: {
+                    min: 1,
+                },
+            }}
+            onBlur={(e) => {
+                const value = e.target.value;
+                const transformed = parseInt(value);
+                if (isNaN(transformed) || transformed < 1) {
+                    return onChange('1');
+                }
+            }}
+            onChange={(e) => {
+                onChange(e.target.value);
+            }}
+        />
+    );
+};
+
+export default IntegerInput;

--- a/frontend/src/ui/IntegerInput.tsx
+++ b/frontend/src/ui/IntegerInput.tsx
@@ -35,6 +35,8 @@ const IntegerInput: FC<Props> = ({
                 const transformed = parseInt(value);
                 if (isNaN(transformed) || transformed < 1) {
                     return onChange('1');
+                } else {
+                    onChange(transformed.toString());
                 }
             }}
             onChange={(e) => {

--- a/frontend/src/ui/ToastContext.tsx
+++ b/frontend/src/ui/ToastContext.tsx
@@ -9,11 +9,11 @@ interface ToastArgs {
     message: string;
 }
 
-interface ToastContext {
+interface IToastContext {
     createToast: ({ severity, message }: ToastArgs) => void;
 }
 
-const ToastContext = createContext<ToastContext>({
+const ToastContext = createContext<IToastContext>({
     createToast: () => null,
 });
 

--- a/frontend/src/ui/ToastContext.tsx
+++ b/frontend/src/ui/ToastContext.tsx
@@ -1,0 +1,52 @@
+import { Snackbar } from '@material-ui/core';
+import { Alert, AlertProps } from '@material-ui/lab';
+import React, { FC, useContext, createContext, useState } from 'react';
+
+type Severity = AlertProps['severity'];
+
+interface ToastArgs {
+    severity: Severity;
+    message: string;
+}
+
+interface ToastContext {
+    createToast: ({ severity, message }: ToastArgs) => void;
+}
+
+const ToastContext = createContext<ToastContext>({
+    createToast: () => null,
+});
+
+const ToastProvider: FC = ({ children }) => {
+    const [open, setOpen] = useState<boolean>(false);
+    const [severity, setSeverity] = useState<Severity>('success');
+    const [message, setMessage] = useState<string>('');
+    const handleClose = () => setOpen(false);
+
+    const createToast = ({ severity, message }: ToastArgs) => {
+        setSeverity(severity);
+        setMessage(message);
+        setOpen(true);
+    };
+
+    return (
+        <ToastContext.Provider value={{ createToast }}>
+            <Snackbar
+                open={open}
+                autoHideDuration={3000}
+                anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+                onClose={handleClose}
+            >
+                <Alert severity={severity}>{message}</Alert>
+            </Snackbar>
+            {children}
+        </ToastContext.Provider>
+    );
+};
+
+export const useToastContext = () => {
+    const { createToast } = useContext(ToastContext);
+    return createToast;
+};
+
+export default ToastProvider;

--- a/frontend/src/utils/api_resources.ts
+++ b/frontend/src/utils/api_resources.ts
@@ -30,6 +30,7 @@ export const GET_ALL_SALES = `${getPrefix()}/auth/allSales`;
 export const GET_CARDS_WITH_INFO_PUBLIC = `${getPrefix()}/getCardsWithInfo`;
 export const GET_CARDS_WITH_INFO = `${getPrefix()}/auth/getCardsWithInfo`;
 export const GET_REPORT = `${getPrefix()}/auth/getSalesReport`;
+export const GET_BULK_CARDS = `${getPrefix()}/auth/bulkSearch`;
 export const AUTOCOMPLETE = `${getPrefix()}/autocomplete`;
 export const SCRYFALL_SEARCH = 'https://api.scryfall.com/cards/search';
 export const GET_LIVE_PRICE = `https://us-central1-clubhouse-collection.cloudfunctions.net/getPriceFromTcg${env}`;

--- a/monolith/interactors/ScryfallCard.ts
+++ b/monolith/interactors/ScryfallCard.ts
@@ -55,6 +55,7 @@ export default interface ScryfallCard {
     prices: Prices;
     related_uris: RelatedUris;
     purchase_uris: PurchaseUris;
+    image_uris?: ImageUris;
 }
 
 export interface CardFacesEntity {

--- a/monolith/interactors/ScryfallCard.ts
+++ b/monolith/interactors/ScryfallCard.ts
@@ -27,6 +27,7 @@ export default interface ScryfallCard {
     nonfoil: boolean;
     oversized: boolean;
     promo: boolean;
+    promo_types: string[];
     reprint: boolean;
     variation: boolean;
     set: string;

--- a/monolith/interactors/getCardPrintings.ts
+++ b/monolith/interactors/getCardPrintings.ts
@@ -30,6 +30,12 @@ class BulkCard {
     }
 }
 
+/**
+ * We clamp a max number of return objects to prevent results with hundreds
+ * of results (such as basic lands) to slow rendering in the client
+ */
+const MAX_RESULTS = 50;
+
 async function getCardPrintings(cardName: string) {
     try {
         const db = await getDatabaseConnection();
@@ -64,7 +70,14 @@ async function getCardPrintings(cardName: string) {
             .aggregate(pipeline)
             .toArray();
 
-        return cards.map((c) => new BulkCard(c));
+        const bulk = cards.map((c) => new BulkCard(c));
+
+        return (
+            bulk
+                // Sort names to order the shortest matches first
+                .sort((a, b) => a.name.length - b.name.length)
+                .slice(0, MAX_RESULTS)
+        );
     } catch (err) {
         console.log(err);
         throw err;

--- a/monolith/interactors/getCardPrintings.ts
+++ b/monolith/interactors/getCardPrintings.ts
@@ -3,6 +3,19 @@ import getDatabaseConnection from '../database';
 import stripPunctuation from '../lib/stripPunctuation';
 import ScryfallCard from './ScryfallCard';
 
+const getCardImage = (card: ScryfallCard) => {
+    let myImage: string;
+
+    try {
+        // If normal prop doesn't exist, move to catch block for flip card faces
+        myImage = card.image_uris.normal;
+    } catch (e) {
+        myImage = card.card_faces[0].image_uris.normal;
+    }
+
+    return myImage;
+};
+
 /**
  * Creates a detailed user-friendly name for cards to discern what they are, without imagery
  */
@@ -31,6 +44,8 @@ function cardDisplayName(card: ScryfallCard): string {
     const isExtendedArt =
         card.frame_effects && card.frame_effects.includes('extendedart');
 
+    const isRetroBorder = card.frame && card.frame.includes('1997');
+
     if (isPrereleasePromo) treatments.push('Prerelease promo');
     if (isPromoPackPromo) treatments.push('Promo pack');
     if (isStampedPromo) treatments.push('Stamped');
@@ -38,6 +53,7 @@ function cardDisplayName(card: ScryfallCard): string {
     if (isBorderless) treatments.push('Borderless');
     if (isEtched) treatments.push('Etched');
     if (isExtendedArt) treatments.push('Extended art');
+    if (isRetroBorder) treatments.push('Retro frame');
 
     const separator = treatments.length > 0 ? ' - ' : '';
 
@@ -53,6 +69,8 @@ class BulkCard {
     public rarity: string;
     public foil_printing: boolean;
     public nonfoil_printing: boolean;
+    public frame: string;
+    public image: string;
 
     constructor(card: ScryfallCard) {
         this.scryfall_id = card.id;
@@ -63,6 +81,8 @@ class BulkCard {
         this.rarity = card.rarity;
         this.foil_printing = card.foil;
         this.nonfoil_printing = card.nonfoil;
+        this.frame = card.frame;
+        this.image = getCardImage(card);
     }
 }
 
@@ -92,7 +112,7 @@ async function getCardPrintings(cardName: string) {
         const search = {
             index: 'autocomplete',
             autocomplete: {
-                query: modifiedName,
+                query: cardName,
                 path: 'name',
                 tokenOrder: 'sequential',
             },

--- a/monolith/interactors/getCardPrintings.ts
+++ b/monolith/interactors/getCardPrintings.ts
@@ -1,5 +1,6 @@
 import { Collection } from '../common/types';
 import getDatabaseConnection from '../database';
+import stripPunctuation from '../lib/stripPunctuation';
 import ScryfallCard from './ScryfallCard';
 
 /**
@@ -65,9 +66,20 @@ class BulkCard {
     }
 }
 
+const replacePunctuation = (str: string): string => {
+    return str.replace(/[.,\/#!$%\^&\*;:{}=\-_`~()]/g, ' ');
+};
+
 async function getCardPrintings(cardName: string) {
     try {
         const db = await getDatabaseConnection();
+        // Modify the input string so it cooperates
+        // with the search implementation
+        // We remove punctuation as well as multiple spaces
+        const modifiedName = replacePunctuation(cardName).replace(
+            / +(?= )/g,
+            ''
+        );
 
         const pipeline = [];
 
@@ -80,7 +92,7 @@ async function getCardPrintings(cardName: string) {
         const search = {
             index: 'autocomplete',
             autocomplete: {
-                query: cardName,
+                query: modifiedName,
                 path: 'name',
                 tokenOrder: 'sequential',
             },

--- a/monolith/interactors/getCardPrintings.ts
+++ b/monolith/interactors/getCardPrintings.ts
@@ -1,0 +1,65 @@
+import { Collection } from '../common/types';
+import getDatabaseConnection from '../database';
+import ScryfallCard from './ScryfallCard';
+
+// etched: boolean
+// found in frame effects
+// borderless: boolean
+// found in border_color
+// showcase: boolean
+// found in frame effects
+class BulkCard {
+    public scryfall_id: string;
+    public name: string;
+    public set_abbreviation: string;
+    public set_name: string;
+    public rarity: string;
+    public frame_effects: string[] | null;
+    public foil: boolean;
+    public nonfoil: boolean;
+    public border_color: string;
+
+    constructor(card: ScryfallCard) {
+        this.scryfall_id = card.id;
+        this.name = card.name;
+        this.set_abbreviation = card.set;
+        this.set_name = card.set_name;
+        this.rarity = card.rarity;
+        this.frame_effects = card.frame_effects;
+        this.foil = card.foil;
+        this.nonfoil = card.nonfoil;
+        this.border_color = card.border_color;
+    }
+}
+
+async function getCardPrintings(cardName: string) {
+    try {
+        const db = await getDatabaseConnection();
+
+        const pipeline = [];
+
+        // Text match on card title
+        const search = {
+            index: 'autocomplete',
+            autocomplete: {
+                query: cardName,
+                path: 'name',
+                tokenOrder: 'sequential',
+            },
+        };
+
+        pipeline.push({ $search: search });
+
+        const cards = await db
+            .collection(Collection.scryfallBulkCards)
+            .aggregate(pipeline)
+            .toArray();
+
+        return cards.map((c) => new BulkCard(c));
+    } catch (err) {
+        console.log(err);
+        throw err;
+    }
+}
+
+export default getCardPrintings;

--- a/monolith/interactors/getCardPrintings.ts
+++ b/monolith/interactors/getCardPrintings.ts
@@ -2,50 +2,7 @@ import { Collection } from '../common/types';
 import getDatabaseConnection from '../database';
 import ScryfallCard from './ScryfallCard';
 import cardImageUrl from '../lib/cardImageUrl';
-
-/**
- * Creates a detailed user-friendly name for cards to discern what they are, without imagery
- */
-function cardDisplayName(card: ScryfallCard): string {
-    const treatments: string[] = [];
-    const baseTitle = card.name;
-    const setName = card.set_name;
-
-    const isPrereleasePromo =
-        card.promo_types && card.promo_types.includes('prerelease');
-
-    const isPromoPackPromo =
-        card.promo_types && card.promo_types.includes('promopack');
-
-    const isStampedPromo =
-        card.promo_types && card.promo_types.includes('stamped');
-
-    const isShowcase =
-        card.frame_effects && card.frame_effects.includes('showcase');
-
-    const isBorderless = card.border_color === 'borderless';
-
-    const isEtched =
-        card.frame_effects && card.frame_effects.includes('etched');
-
-    const isExtendedArt =
-        card.frame_effects && card.frame_effects.includes('extendedart');
-
-    const isRetroBorder = card.frame && card.frame.includes('1997');
-
-    if (isPrereleasePromo) treatments.push('Prerelease promo');
-    if (isPromoPackPromo) treatments.push('Promo pack');
-    if (isStampedPromo) treatments.push('Stamped');
-    if (isShowcase) treatments.push('Showcase');
-    if (isBorderless) treatments.push('Borderless');
-    if (isEtched) treatments.push('Etched');
-    if (isExtendedArt) treatments.push('Extended art');
-    if (isRetroBorder) treatments.push('Retro frame');
-
-    const separator = treatments.length > 0 ? ' - ' : '';
-
-    return `${baseTitle} - ${setName}${separator}${treatments.join(', ')}`;
-}
+import cardDisplayName from '../lib/cardDisplayName';
 
 class BulkCard {
     public scryfall_id: string;

--- a/monolith/interactors/getCardPrintings.ts
+++ b/monolith/interactors/getCardPrintings.ts
@@ -1,20 +1,7 @@
 import { Collection } from '../common/types';
 import getDatabaseConnection from '../database';
-import stripPunctuation from '../lib/stripPunctuation';
 import ScryfallCard from './ScryfallCard';
-
-const getCardImage = (card: ScryfallCard) => {
-    let myImage: string;
-
-    try {
-        // If normal prop doesn't exist, move to catch block for flip card faces
-        myImage = card.image_uris.normal;
-    } catch (e) {
-        myImage = card.card_faces[0].image_uris.normal;
-    }
-
-    return myImage;
-};
+import cardImageUrl from '../lib/cardImageUrl';
 
 /**
  * Creates a detailed user-friendly name for cards to discern what they are, without imagery
@@ -82,24 +69,13 @@ class BulkCard {
         this.foil_printing = card.foil;
         this.nonfoil_printing = card.nonfoil;
         this.frame = card.frame;
-        this.image = getCardImage(card);
+        this.image = cardImageUrl(card);
     }
 }
-
-const replacePunctuation = (str: string): string => {
-    return str.replace(/[.,\/#!$%\^&\*;:{}=\-_`~()]/g, ' ');
-};
 
 async function getCardPrintings(cardName: string) {
     try {
         const db = await getDatabaseConnection();
-        // Modify the input string so it cooperates
-        // with the search implementation
-        // We remove punctuation as well as multiple spaces
-        const modifiedName = replacePunctuation(cardName).replace(
-            / +(?= )/g,
-            ''
-        );
 
         const pipeline = [];
 

--- a/monolith/interactors/getCardPrintings.ts
+++ b/monolith/interactors/getCardPrintings.ts
@@ -48,6 +48,11 @@ async function getCardPrintings(cardName: string) {
                 query: cardName,
                 path: 'name',
                 tokenOrder: 'sequential',
+                fuzzy: {
+                    maxEdits: 1,
+                    maxExpansions: 50,
+                    prefixLength: 3,
+                },
             },
         };
 

--- a/monolith/interactors/getCardPrintings.ts
+++ b/monolith/interactors/getCardPrintings.ts
@@ -2,33 +2,66 @@ import { Collection } from '../common/types';
 import getDatabaseConnection from '../database';
 import ScryfallCard from './ScryfallCard';
 
-// etched: boolean
-// found in frame effects
-// borderless: boolean
-// found in border_color
-// showcase: boolean
-// found in frame effects
+/**
+ * Creates a detailed user-friendly name for cards to discern what they are, without imagery
+ */
+function cardDisplayName(card: ScryfallCard): string {
+    const treatments: string[] = [];
+    const baseTitle = card.name;
+    const setName = card.set_name;
+
+    const isPrereleasePromo =
+        card.promo_types && card.promo_types.includes('prerelease');
+
+    const isPromoPackPromo =
+        card.promo_types && card.promo_types.includes('promopack');
+
+    const isStampedPromo =
+        card.promo_types && card.promo_types.includes('stamped');
+
+    const isShowcase =
+        card.frame_effects && card.frame_effects.includes('showcase');
+
+    const isBorderless = card.border_color === 'borderless';
+
+    const isEtched =
+        card.frame_effects && card.frame_effects.includes('etched');
+
+    const isExtendedArt =
+        card.frame_effects && card.frame_effects.includes('extendedart');
+
+    if (isPrereleasePromo) treatments.push('Prerelease promo');
+    if (isPromoPackPromo) treatments.push('Promo pack');
+    if (isStampedPromo) treatments.push('Stamped');
+    if (isShowcase) treatments.push('Showcase');
+    if (isBorderless) treatments.push('Borderless');
+    if (isEtched) treatments.push('Etched');
+    if (isExtendedArt) treatments.push('Extended art');
+
+    const separator = treatments.length > 0 ? ' - ' : '';
+
+    return `${baseTitle} - ${setName}${separator}${treatments.join(', ')}`;
+}
+
 class BulkCard {
     public scryfall_id: string;
     public name: string;
+    public display_name: string;
     public set_abbreviation: string;
     public set_name: string;
     public rarity: string;
-    public frame_effects: string[] | null;
-    public foil: boolean;
-    public nonfoil: boolean;
-    public border_color: string;
+    public foil_printing: boolean;
+    public nonfoil_printing: boolean;
 
     constructor(card: ScryfallCard) {
         this.scryfall_id = card.id;
         this.name = card.name;
+        this.display_name = cardDisplayName(card);
         this.set_abbreviation = card.set;
         this.set_name = card.set_name;
         this.rarity = card.rarity;
-        this.frame_effects = card.frame_effects;
-        this.foil = card.foil;
-        this.nonfoil = card.nonfoil;
-        this.border_color = card.border_color;
+        this.foil_printing = card.foil;
+        this.nonfoil_printing = card.nonfoil;
     }
 }
 
@@ -37,6 +70,11 @@ async function getCardPrintings(cardName: string) {
         const db = await getDatabaseConnection();
 
         const pipeline = [];
+
+        // Match only english cards
+        const match = {
+            lang: 'en',
+        };
 
         // Text match on card title
         const search = {
@@ -49,6 +87,7 @@ async function getCardPrintings(cardName: string) {
         };
 
         pipeline.push({ $search: search });
+        pipeline.push({ $match: match });
 
         const cards = await db
             .collection(Collection.scryfallBulkCards)

--- a/monolith/lib/cardDisplayName.ts
+++ b/monolith/lib/cardDisplayName.ts
@@ -1,0 +1,47 @@
+import ScryfallCard from '../interactors/ScryfallCard';
+
+/**
+ * Creates a detailed user-friendly name for cards to discern what they are, without imagery
+ */
+function cardDisplayName(card: ScryfallCard): string {
+    const treatments: string[] = [];
+    const baseTitle = card.name;
+    const setName = card.set_name;
+
+    const isPrereleasePromo =
+        card.promo_types && card.promo_types.includes('prerelease');
+
+    const isPromoPackPromo =
+        card.promo_types && card.promo_types.includes('promopack');
+
+    const isStampedPromo =
+        card.promo_types && card.promo_types.includes('stamped');
+
+    const isShowcase =
+        card.frame_effects && card.frame_effects.includes('showcase');
+
+    const isBorderless = card.border_color === 'borderless';
+
+    const isEtched =
+        card.frame_effects && card.frame_effects.includes('etched');
+
+    const isExtendedArt =
+        card.frame_effects && card.frame_effects.includes('extendedart');
+
+    const isRetroBorder = card.frame && card.frame.includes('1997');
+
+    if (isPrereleasePromo) treatments.push('Prerelease promo');
+    if (isPromoPackPromo) treatments.push('Promo pack');
+    if (isStampedPromo) treatments.push('Stamped');
+    if (isShowcase) treatments.push('Showcase');
+    if (isBorderless) treatments.push('Borderless');
+    if (isEtched) treatments.push('Etched');
+    if (isExtendedArt) treatments.push('Extended art');
+    if (isRetroBorder) treatments.push('Retro frame');
+
+    const separator = treatments.length > 0 ? ' - ' : '';
+
+    return `${baseTitle} - ${setName}${separator}${treatments.join(', ')}`;
+}
+
+export default cardDisplayName;

--- a/monolith/lib/cardImageUrl.ts
+++ b/monolith/lib/cardImageUrl.ts
@@ -1,0 +1,16 @@
+import ScryfallCard from '../interactors/ScryfallCard';
+
+const cardImageUrl = (card: ScryfallCard) => {
+    let myImage: string;
+
+    try {
+        // If normal prop doesn't exist, move to catch block for flip card faces
+        myImage = card.image_uris.normal;
+    } catch (e) {
+        myImage = card.card_faces[0].image_uris.normal;
+    }
+
+    return myImage;
+};
+
+export default cardImageUrl;

--- a/monolith/lib/stripPunctuation.ts
+++ b/monolith/lib/stripPunctuation.ts
@@ -1,0 +1,5 @@
+const stripPunctuation = (str: string): string => {
+    return str.replace(/[.,\/#!$%\^&\*;:{}=\-_`~()]/g, '');
+};
+
+export default stripPunctuation;

--- a/monolith/lib/stripPunctuation.ts
+++ b/monolith/lib/stripPunctuation.ts
@@ -1,5 +1,0 @@
-const stripPunctuation = (str: string): string => {
-    return str.replace(/[.,\/#!$%\^&\*;:{}=\-_`~()]/g, '');
-};
-
-export default stripPunctuation;

--- a/monolith/routes/auth.ts
+++ b/monolith/routes/auth.ts
@@ -54,6 +54,7 @@ import {
 import moment from 'moment';
 import getReceivingById from '../interactors/getReceivingById';
 import getSalesReport from '../interactors/getSalesReport';
+import getCardPrintings from '../interactors/getCardPrintings';
 
 /**
  * Middleware to check for Bearer token by validating JWT
@@ -589,6 +590,33 @@ router.get('/getSalesReport', async (req: RequestWithUserInfo, res) => {
         });
 
         res.status(200).send(message);
+    } catch (err) {
+        console.error(new Error(err));
+        res.status(500).send(err.message);
+    }
+});
+
+interface BulkSearchQuery {
+    cardName: string;
+}
+
+router.get('/bulkSearch', async (req: RequestWithUserInfo, res) => {
+    const schema = Joi.object<BulkSearchQuery>({
+        cardName: Joi.string().required(),
+    });
+
+    const { error, value }: JoiValidation<BulkSearchQuery> = schema.validate(
+        req.query,
+        { abortEarly: false }
+    );
+
+    if (error) {
+        return res.status(400).json(error);
+    }
+
+    try {
+        const cards = await getCardPrintings(value.cardName);
+        res.status(200).json(cards);
     } catch (err) {
         console.error(new Error(err));
         res.status(500).send(err.message);

--- a/monolith/routes/index.ts
+++ b/monolith/routes/index.ts
@@ -26,7 +26,7 @@ router.post('/jwt', async (req: JwtRequest, res) => {
     });
 
     if (error) {
-        res.status(400).json(error);
+        return res.status(400).json(error);
     }
 
     try {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/15024562/128936699-f060a580-ac15-4c99-9add-01f814c717da.png)
![image](https://user-images.githubusercontent.com/15024562/128936725-b39fd805-d9a8-4abc-ac00-da8f01e525ca.png)

## Summary 
This PR introduces the first pass towards a "bulk entry" feature, allowing users to quickly and efficiently add cards to inventory without the overhead of using the "Manage Inventory" tab.

## The problem
Store location 2 frequently receives stacks of cards (as opposed to Store 1, which gathers most of their inventory from customer receiving via buylist). Employees came to me with concerns that: 
1. Searching for cards with multiple printings was cumbersome, and
2. Piles of cards take hours to receive.

Ultimately, I understood that we needed a more streamlined UI to mitigate clicking and scrolling. Searching "Birds of Paradise", for instance, in the management view means scrolling through dozens of printings simply to enter a `1` and hit submit.

## The solution
Now, users may bulk add by querying for a card title, which populates a dropdown with _every_ individual printing of the card available. From there, it's trivial to arrow up or down, press `enter` to select, and `enter` again to submit. Compounded, this will save a tremendous amount of time.

## Misc improvements
In my quest to eliminate `semantic-ui-react` from the codebase, I took this opportunity to generalize a Toast provider context which we can use throughout the application. I suspect a future PR will integrate this app-wide.