### PR TITLE
Expose dual-inventory component with zero results

### DIFF
--- a/frontend/src/Sale/Sale.tsx
+++ b/frontend/src/Sale/Sale.tsx
@@ -70,10 +70,10 @@ const Sale: FC<Props> = () => {
                 <Grid item xs={12} lg={8}>
                     <Grid container justify="space-between">
                         <HeaderText>Inventory</HeaderText>
-                        {searchResults.length > 0 && (
+                        {term && (
                             <TotalStoreInventory
                                 searchResults={searchResults}
-                                title={searchResults[0].name}
+                                title={term}
                             />
                         )}
                     </Grid>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/15024562/129070363-b8f8705a-2664-455b-a524-efc26685058d.png)

## Summary
Users should be able to see this component at all times; if the secondary store location has some in stock, but the currently logged-in one does not, it will not render. They will be unable to tell customers that a secondary location has an item. This PR remedies that!