### PR TITLE
Min, max price filters

### DIFF
--- a/frontend/src/BrowseInventory/BrowseInventory.tsx
+++ b/frontend/src/BrowseInventory/BrowseInventory.tsx
@@ -5,7 +5,10 @@ import BrowseInventoryForm, {
 } from './BrowseInventoryForm';
 import BrowseInventoryRow from './BrowseInventoryRow';
 import _ from 'lodash';
-import filteredCardsQuery, { ResponseCard } from './filteredCardsQuery';
+import filteredCardsQuery, {
+    Filters,
+    ResponseCard,
+} from './filteredCardsQuery';
 import Placeholder from '../ui/Placeholder';
 import SearchIcon from '@material-ui/icons/Search';
 import {
@@ -59,11 +62,17 @@ const BrowseInventory: FC = () => {
         try {
             setState({ ...state, isLoading: true });
 
-            const queryFilters = {
+            // Translates form types to the necessary types the query requires
+            const queryFilters: Filters = {
                 title: filters.title || undefined,
                 setName: filters.setName || undefined,
                 format: filters.format || undefined,
-                price: Number(filters.price) || undefined,
+                minPrice: filters.minPrice
+                    ? Number(filters.minPrice)
+                    : undefined,
+                maxPrice: filters.maxPrice
+                    ? Number(filters.maxPrice)
+                    : undefined,
                 finish: filters.finish || undefined,
                 colors:
                     filters.colorsArray.length > 0
@@ -86,7 +95,6 @@ const BrowseInventory: FC = () => {
                 type: filters.typeLine || undefined,
                 frame: filters.frame || undefined,
                 sortByDirection: filters.sortByDirection,
-                priceOperator: filters.priceOperator,
                 sortBy: filters.sortBy,
             };
 

--- a/frontend/src/BrowseInventory/BrowseInventory.tsx
+++ b/frontend/src/BrowseInventory/BrowseInventory.tsx
@@ -1,11 +1,11 @@
 import React, { FC, useState } from 'react';
-import BrowseInventoryForm, { initialFilters } from './BrowseInventoryForm';
+import BrowseInventoryForm, {
+    FormValues,
+    initialFilters,
+} from './BrowseInventoryForm';
 import BrowseInventoryRow from './BrowseInventoryRow';
 import _ from 'lodash';
-import filteredCardsQuery, {
-    Filters,
-    ResponseCard,
-} from './filteredCardsQuery';
+import filteredCardsQuery, { ResponseCard } from './filteredCardsQuery';
 import Placeholder from '../ui/Placeholder';
 import SearchIcon from '@material-ui/icons/Search';
 import {
@@ -40,7 +40,7 @@ interface State {
     currentPage: number;
     numPages: number;
     isLoading: boolean;
-    cachedFilters: Filters;
+    cachedFilters: FormValues;
     searchTouched: boolean;
 }
 
@@ -55,11 +55,45 @@ const BrowseInventory: FC = () => {
         searchTouched: false, // Tracks whether the user has initially searched for the 'no results' message
     });
 
-    const fetchData = async (filters: Filters, page: number) => {
+    const fetchData = async (filters: FormValues, page: number) => {
         try {
             setState({ ...state, isLoading: true });
 
-            const { cards, total } = await filteredCardsQuery(filters, page);
+            const queryFilters = {
+                title: filters.title || undefined,
+                setName: filters.setName || undefined,
+                format: filters.format || undefined,
+                price: Number(filters.price) || undefined,
+                finish: filters.finish || undefined,
+                colors:
+                    filters.colorsArray.length > 0
+                        ? filters.colorsArray
+                              .map((c) => {
+                                  const colorsMap: Record<string, string> = {
+                                      White: 'W',
+                                      Blue: 'U',
+                                      Black: 'B',
+                                      Red: 'R',
+                                      Green: 'G',
+                                  };
+
+                                  return colorsMap[c];
+                              })
+                              .sort()
+                              .join('')
+                        : undefined,
+                colorSpecificity: filters.colorSpecificity || undefined,
+                type: filters.typeLine || undefined,
+                frame: filters.frame || undefined,
+                sortByDirection: filters.sortByDirection,
+                priceOperator: filters.priceOperator,
+                sortBy: filters.sortBy,
+            };
+
+            const { cards, total } = await filteredCardsQuery(
+                queryFilters,
+                page
+            );
 
             const numPages = Math.ceil(total / LIMIT);
 

--- a/frontend/src/BrowseInventory/BrowseInventoryForm.tsx
+++ b/frontend/src/BrowseInventory/BrowseInventoryForm.tsx
@@ -1,7 +1,6 @@
 import React, { FC, useEffect, useState } from 'react';
 import { FormikHelpers, useFormik } from 'formik';
 import setNameQuery from './setNameQuery';
-import { Filters } from './filteredCardsQuery';
 import ControlledSearchBar from '../ui/ControlledSearchBar';
 import ControlledDropdown, { DropdownOption } from '../ui/ControlledDropdown';
 import ControlledMultiSelect from '../ui/ControlledMultiSelect';
@@ -90,7 +89,7 @@ const frameOptions: DropdownOption[] = [
     { key: 'showcase', value: 'showcase', text: 'Showcase' },
 ];
 
-interface FormValues {
+export interface FormValues {
     title: string;
     setName: string;
     format: string;
@@ -126,7 +125,7 @@ const validate = () => {
 };
 
 interface Props {
-    doSubmit: (v: Filters, page: number) => Promise<void>;
+    doSubmit: (v: FormValues, page: number) => Promise<void>;
 }
 
 const FormContainer = withStyles(({ spacing }) => ({
@@ -146,39 +145,7 @@ const BrowseInventoryForm: FC<Props> = ({ doSubmit }) => {
     ) => {
         try {
             await doSubmit(
-                {
-                    title: values.title || undefined,
-                    setName: values.setName || undefined,
-                    format: values.format || undefined,
-                    price: Number(values.price) || undefined,
-                    finish: values.finish || undefined,
-                    colors:
-                        values.colorsArray.length > 0
-                            ? values.colorsArray
-                                  .map((c) => {
-                                      const colorsMap: Record<
-                                          string,
-                                          string
-                                      > = {
-                                          White: 'W',
-                                          Blue: 'U',
-                                          Black: 'B',
-                                          Red: 'R',
-                                          Green: 'G',
-                                      };
-
-                                      return colorsMap[c];
-                                  })
-                                  .sort()
-                                  .join('')
-                            : undefined,
-                    colorSpecificity: values.colorSpecificity || undefined,
-                    type: values.typeLine || undefined,
-                    frame: values.frame || undefined,
-                    sortByDirection: values.sortByDirection,
-                    priceOperator: values.priceOperator,
-                    sortBy: values.sortBy,
-                },
+                values,
                 // Always start at page 1 after filtering
                 1
             );

--- a/frontend/src/BrowseInventory/BrowseInventoryForm.tsx
+++ b/frontend/src/BrowseInventory/BrowseInventoryForm.tsx
@@ -93,14 +93,14 @@ export interface FormValues {
     title: string;
     setName: string;
     format: string;
-    price: number;
+    minPrice: string;
+    maxPrice: string;
     finish: string;
     colorsArray: string[];
     colorSpecificity: string;
     typeLine: string;
     frame: string;
     sortByDirection: number;
-    priceOperator: string;
     sortBy: string;
 }
 
@@ -108,8 +108,8 @@ export const initialFilters: FormValues = {
     title: '',
     setName: '',
     format: '',
-    price: 0,
-    priceOperator: 'gte',
+    minPrice: '',
+    maxPrice: '',
     finish: '',
     sortBy: 'price',
     colorsArray: [],
@@ -253,22 +253,26 @@ const BrowseInventoryForm: FC<Props> = ({ doSubmit }) => {
                     />
                 </Grid>
                 <Grid item xs={12} sm={6}>
-                    <ControlledDropdown
-                        name="priceOperator"
-                        label="Price operator"
-                        options={priceOperatorDropdownOptions}
-                        value={values.priceOperator}
-                        onChange={(v) => setFieldValue('priceOperator', v)}
-                    />
+                    <FormControl fullWidth>
+                        <TextField
+                            label="Minimum price"
+                            variant="outlined"
+                            size="small"
+                            placeholder="Enter a price"
+                            name="minPrice"
+                            type="number"
+                            onChange={handleChange}
+                        />
+                    </FormControl>
                 </Grid>
                 <Grid item xs={12} sm={6}>
                     <FormControl fullWidth>
                         <TextField
-                            label="Price filter"
+                            label="Maximum price"
                             variant="outlined"
                             size="small"
                             placeholder="Enter a price"
-                            name="price"
+                            name="maxPrice"
                             type="number"
                             onChange={handleChange}
                         />

--- a/frontend/src/BrowseInventory/filteredCardsQuery.ts
+++ b/frontend/src/BrowseInventory/filteredCardsQuery.ts
@@ -3,18 +3,18 @@ import { GET_CARDS_BY_FILTER } from '../utils/api_resources';
 import makeAuthHeader from '../utils/makeAuthHeader';
 import { FinishCondition } from '../utils/ScryfallCard';
 
-interface Filters {
+export interface Filters {
     title?: string;
     setName?: string;
     format?: string;
-    price?: number;
+    minPrice?: number;
+    maxPrice?: number;
     finish?: string;
     colors?: string;
     colorSpecificity?: string;
     type?: string;
     frame?: string;
     sortByDirection: number;
-    priceOperator: string;
     sortBy: string;
 }
 

--- a/frontend/src/BrowseInventory/filteredCardsQuery.ts
+++ b/frontend/src/BrowseInventory/filteredCardsQuery.ts
@@ -3,7 +3,7 @@ import { GET_CARDS_BY_FILTER } from '../utils/api_resources';
 import makeAuthHeader from '../utils/makeAuthHeader';
 import { FinishCondition } from '../utils/ScryfallCard';
 
-export interface Filters {
+interface Filters {
     title?: string;
     setName?: string;
     format?: string;

--- a/monolith/common/types.ts
+++ b/monolith/common/types.ts
@@ -26,10 +26,6 @@ export const finishConditions = [
 
 export type FinishCondition = typeof finishConditions[number];
 
-export const priceFilters = ['gte', 'lte', 'gt', 'lt'] as const;
-
-export type PriceFilter = typeof priceFilters[number];
-
 export const formatLegalities = [
     'standard',
     'future',

--- a/monolith/common/validations.ts
+++ b/monolith/common/validations.ts
@@ -5,7 +5,6 @@ import {
     finishConditions,
     formatLegalities,
     frames,
-    priceFilters,
     sortBy,
     sortByDirection,
     Trade,
@@ -21,9 +20,6 @@ export const validSort = Joi.string().valid(...sortBy);
 export const validColorSpecificity = Joi.string().valid(...colorSpecificity);
 export const validTypeline = Joi.string().valid(...typeLines);
 export const validFrame = Joi.string().valid(...frames);
-export const validPriceOperator = Joi.string()
-    .valid(...priceFilters)
-    .required();
 export const validSortDirection = Joi.number()
     .valid(...sortByDirection)
     .required();

--- a/monolith/controllers/getCardsByFilterController.ts
+++ b/monolith/controllers/getCardsByFilterController.ts
@@ -6,7 +6,6 @@ import {
     validFinish,
     validFormatLegalities,
     validFrame,
-    validPriceOperator,
     validSort,
     validSortDirection,
     validString,
@@ -19,7 +18,6 @@ import {
     FormatLegality,
     Frame,
     JoiValidation,
-    PriceFilter,
     RequestWithUserInfo,
     SortBy,
     SortByDirection,
@@ -36,7 +34,6 @@ export interface GetCardsByFilterQuery {
     colorSpecificity?: ColorSpecificity;
     type?: TypeLine;
     frame?: Frame;
-    priceOperator: PriceFilter;
     sortByDirection: SortByDirection;
     page: number;
     maxPrice?: number;
@@ -57,7 +54,6 @@ const getCardsByFilterController: Controller<RequestWithUserInfo> = async (
         colorSpecificity: validColorSpecificity,
         type: validTypeline,
         frame: validFrame,
-        priceOperator: validPriceOperator,
         sortByDirection: validSortDirection,
         maxPrice: Joi.number(),
         minPrice: Joi.number(),

--- a/monolith/controllers/getCardsByFilterController.ts
+++ b/monolith/controllers/getCardsByFilterController.ts
@@ -30,7 +30,6 @@ export interface GetCardsByFilterQuery {
     title?: string;
     setName?: string;
     format?: FormatLegality;
-    price?: number;
     finish?: Finish;
     colors?: string;
     sortBy?: SortBy;
@@ -40,6 +39,8 @@ export interface GetCardsByFilterQuery {
     priceOperator: PriceFilter;
     sortByDirection: SortByDirection;
     page: number;
+    maxPrice?: number;
+    minPrice?: number;
 }
 
 const getCardsByFilterController: Controller<RequestWithUserInfo> = async (
@@ -50,7 +51,6 @@ const getCardsByFilterController: Controller<RequestWithUserInfo> = async (
         title: validString,
         setName: validString,
         format: validFormatLegalities,
-        price: Joi.number().positive().allow(0),
         finish: validFinish,
         colors: validString,
         sortBy: validSort,
@@ -59,6 +59,8 @@ const getCardsByFilterController: Controller<RequestWithUserInfo> = async (
         frame: validFrame,
         priceOperator: validPriceOperator,
         sortByDirection: validSortDirection,
+        maxPrice: Joi.number(),
+        minPrice: Joi.number(),
         page: Joi.number().integer().min(1).required(),
     });
 

--- a/monolith/interactors/getCardsByFilter.ts
+++ b/monolith/interactors/getCardsByFilter.ts
@@ -11,7 +11,8 @@ const LIMIT = 100;
  * title - name of the card
  * setName - the full name of the set
  * format - format in which the card is legal
- * priceNum - the price to query on. Used in conjunciton with priceFilter
+ * maxPrice - maximum queryable card price
+ * minPrice - minimum queryable card price
  * priceFilter - gt, gte, lt, or lte. Used with Mongo aggregation to find price relations
  * finish - `FOIL` or `NONFOIL`
  * sortBy - `name` or `price`
@@ -141,6 +142,11 @@ const getCardsByFilter = async (
 
         aggregation.push({ $unwind: '$inventory' });
 
+        // Always ensure results are in stock
+        aggregation.push({
+            $match: { [`inventory.v`]: { $gt: 0 } },
+        });
+
         // Post-unwind, we add estimated pricing from Sryfall
         aggregation.push({
             $addFields: {
@@ -186,46 +192,64 @@ const getCardsByFilter = async (
             },
         });
 
-        // Building the end match
-        const endMatch: {
-            colors_string_length?: any;
-            colors_string?: string;
-            price?: any;
-        } = {};
-
         // End match foiling logic
         if (finish === 'FOIL') {
-            endMatch['inventory.k'] = {
-                $in: ['FOIL_NM', 'FOIL_LP', 'FOIL_MP', 'FOIL_HP'],
-            };
+            aggregation.push({
+                $match: {
+                    'inventory.k': {
+                        $in: ['FOIL_NM', 'FOIL_LP', 'FOIL_MP', 'FOIL_HP'],
+                    },
+                },
+            });
         } else if (finish === 'NONFOIL') {
-            endMatch['inventory.k'] = {
-                $in: ['NONFOIL_NM', 'NONFOIL_LP', 'NONFOIL_MP', 'NONFOIL_HP'],
-            };
+            aggregation.push({
+                $match: {
+                    'inventory.k': {
+                        $in: [
+                            'NONFOIL_NM',
+                            'NONFOIL_LP',
+                            'NONFOIL_MP',
+                            'NONFOIL_HP',
+                        ],
+                    },
+                },
+            });
         }
 
         // End match format legality logic
-        if (format)
-            endMatch[`legalities.${format}`] = { $in: ['restricted', 'legal'] };
+        if (format) {
+            aggregation.push({
+                $match: {
+                    [`legalities.${format}`]: { $in: ['restricted', 'legal'] },
+                },
+            });
+        }
 
         // End match colors matching logic
-        if (colors) endMatch.colors_string = colors;
+        if (colors) {
+            aggregation.push({
+                $match: { colors_string: colors },
+            });
+        }
 
         // Match monocolor, multicolor, or colorless
         if (colorSpecificity) {
             if (colorSpecificity === 'colorless') {
-                endMatch.colors_string_length = { $eq: 0 };
+                aggregation.push({
+                    $match: { colors_string_length: { $eq: 0 } },
+                });
             }
             if (colorSpecificity === 'mono') {
-                endMatch.colors_string_length = { $eq: 1 };
+                aggregation.push({
+                    $match: { colors_string_length: { $eq: 1 } },
+                });
             }
             if (colorSpecificity === 'multi') {
-                endMatch.colors_string_length = { $gt: 1 };
+                aggregation.push({
+                    $match: { colors_string_length: { $gt: 1 } },
+                });
             }
         }
-
-        // Always ensure results are in stock
-        endMatch[`inventory.v`] = { $gt: 0 };
 
         // Price filtering logic
         if (maxPrice) {
@@ -239,8 +263,6 @@ const getCardsByFilter = async (
                 $match: { price: { $gte: minPrice } },
             });
         }
-
-        aggregation.push({ $match: endMatch });
 
         // Add sane inventory fields
         aggregation.push({

--- a/monolith/interactors/getCardsByFilter.ts
+++ b/monolith/interactors/getCardsByFilter.ts
@@ -26,8 +26,6 @@ const getCardsByFilter = async (
         title,
         setName,
         format,
-        price,
-        priceOperator,
         finish,
         colors,
         sortBy,
@@ -36,6 +34,8 @@ const getCardsByFilter = async (
         page,
         type,
         frame,
+        maxPrice,
+        minPrice,
     }: GetCardsByFilterQuery,
     location: ClubhouseLocation
 ) => {
@@ -228,8 +228,16 @@ const getCardsByFilter = async (
         endMatch[`inventory.v`] = { $gt: 0 };
 
         // Price filtering logic
-        if (price && priceOperator) {
-            endMatch.price = { [`$${priceOperator}`]: price };
+        if (maxPrice) {
+            aggregation.push({
+                $match: { price: { $lte: maxPrice } },
+            });
+        }
+
+        if (minPrice) {
+            aggregation.push({
+                $match: { price: { $gte: minPrice } },
+            });
         }
 
         aggregation.push({ $match: endMatch });


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/15024562/129790984-03e512b1-dc89-4487-848a-be4291f0dff5.png)

## Summary
This PR improves upon previously implemented price-filtering by introducing min and max prices for a given inventory query, which easily allows staff to hone in on not only prices less than or greater than a singular price, but also on a range of prices. This is extremely useful for inventory ordering, format inclusion (2DH staples), and curating physical store displays.

Additionally, I chose to rescope Formik form types here. Previously, we were translating from form to query types in the form component, and that logic should live a level up in the parent. So, rather than passing down a `doSubmit` prop with signature `(formValues: FilterQueryTypes) => void` and having to cast these types in the form itself, we use `(formValues: FormTypes) => void` instead. Now, we can invoke `doSubmit` with the form values, and the parent submission handler will convert these types to necessary query types.

