### PR TITLE
Add quantity on hand and estimated pricing to reporting table

### DIFF
--- a/frontend/src/Reporting/Reporting.tsx
+++ b/frontend/src/Reporting/Reporting.tsx
@@ -18,6 +18,7 @@ import {
 import { HeaderText, SectionText } from '../ui/Typography';
 import { uniqueId } from 'lodash';
 import displayFinishCondition from '../utils/finishCondition';
+import { price } from '../utils/price';
 
 interface SearchDates {
     startDate: string;
@@ -86,7 +87,7 @@ const Reporting = () => {
                 <Loading />
             ) : (
                 <Grid container spacing={2}>
-                    <Grid item xs={12} md={6}>
+                    <Grid item xs={12} md={4}>
                         <SectionText>Top cards sold by name</SectionText>
                         <TableContainer component={Paper} variant="outlined">
                             <Table size="small">
@@ -113,7 +114,7 @@ const Reporting = () => {
                             </Table>
                         </TableContainer>
                     </Grid>
-                    <Grid item xs={12} md={6}>
+                    <Grid item xs={12} md={8}>
                         <SectionText>
                             Top cards sold by a single printing
                         </SectionText>
@@ -134,6 +135,9 @@ const Reporting = () => {
                                             <b>Finish (Condition)</b>
                                         </TableCell>
                                         <TableCell>
+                                            <b>Estimated market price</b>
+                                        </TableCell>
+                                        <TableCell>
                                             <b>Quantity on hand</b>
                                         </TableCell>
                                     </TableRow>
@@ -152,6 +156,11 @@ const Reporting = () => {
                                                 {displayFinishCondition(
                                                     c.finish_condition
                                                 )}
+                                            </TableCell>
+                                            <TableCell>
+                                                {c.estimated_price !== null
+                                                    ? price(c.estimated_price)
+                                                    : '—'}
                                             </TableCell>
                                             <TableCell>
                                                 {c.quantity_on_hand}

--- a/frontend/src/Reporting/Reporting.tsx
+++ b/frontend/src/Reporting/Reporting.tsx
@@ -16,7 +16,6 @@ import {
     TableRow,
 } from '@material-ui/core';
 import { HeaderText, SectionText } from '../ui/Typography';
-import { uniqueId } from 'lodash';
 import displayFinishCondition from '../utils/finishCondition';
 import { price } from '../utils/price';
 
@@ -103,7 +102,7 @@ const Reporting = () => {
                                 </TableHead>
                                 <TableBody>
                                     {report.countByCardName.map((c) => (
-                                        <TableRow key={uniqueId()}>
+                                        <TableRow key={c._id}>
                                             <TableCell>
                                                 {c.quantity_sold}
                                             </TableCell>

--- a/frontend/src/Reporting/Reporting.tsx
+++ b/frontend/src/Reporting/Reporting.tsx
@@ -104,7 +104,9 @@ const Reporting = () => {
                                 <TableBody>
                                     {report.countByCardName.map((c) => (
                                         <TableRow key={uniqueId()}>
-                                            <TableCell>{c.count}</TableCell>
+                                            <TableCell>
+                                                {c.quantity_sold}
+                                            </TableCell>
                                             <TableCell>
                                                 {c.card_title}
                                             </TableCell>
@@ -145,7 +147,9 @@ const Reporting = () => {
                                 <TableBody>
                                     {report.countByPrinting.map((c) => (
                                         <TableRow key={c._id}>
-                                            <TableCell>{c.count}</TableCell>
+                                            <TableCell>
+                                                {c.quantity_sold}
+                                            </TableCell>
                                             <TableCell>
                                                 {c.card_title}
                                             </TableCell>

--- a/frontend/src/Reporting/Reporting.tsx
+++ b/frontend/src/Reporting/Reporting.tsx
@@ -17,6 +17,7 @@ import {
 } from '@material-ui/core';
 import { HeaderText, SectionText } from '../ui/Typography';
 import { uniqueId } from 'lodash';
+import displayFinishCondition from '../utils/finishCondition';
 
 interface SearchDates {
     startDate: string;
@@ -30,12 +31,12 @@ enum RangeName {
 
 const allTimeDates: SearchDates = {
     startDate: moment().year(1999).toISOString(),
-    endDate: moment().toISOString(),
+    endDate: moment().add(1, 'days').toISOString(),
 };
 
 const lastMonthDates: SearchDates = {
     startDate: moment().subtract(30, 'days').toISOString(),
-    endDate: moment().toISOString(),
+    endDate: moment().add(1, 'days').toISOString(),
 };
 
 const Reporting = () => {
@@ -127,19 +128,33 @@ const Reporting = () => {
                                             <b>Card name</b>
                                         </TableCell>
                                         <TableCell>
-                                            <b>Set name</b>
+                                            <b>Edition</b>
+                                        </TableCell>
+                                        <TableCell>
+                                            <b>Finish (Condition)</b>
+                                        </TableCell>
+                                        <TableCell>
+                                            <b>Quantity on hand</b>
                                         </TableCell>
                                     </TableRow>
                                 </TableHead>
                                 <TableBody>
                                     {report.countByPrinting.map((c) => (
-                                        <TableRow key={uniqueId()}>
+                                        <TableRow key={c._id}>
                                             <TableCell>{c.count}</TableCell>
                                             <TableCell>
                                                 {c.card_title}
                                             </TableCell>
                                             <TableCell>
                                                 {c.card_metadata.set_name}
+                                            </TableCell>
+                                            <TableCell>
+                                                {displayFinishCondition(
+                                                    c.finish_condition
+                                                )}
+                                            </TableCell>
+                                            <TableCell>
+                                                {c.quantity_on_hand}
                                             </TableCell>
                                         </TableRow>
                                     ))}

--- a/frontend/src/Reporting/reportingQuery.ts
+++ b/frontend/src/Reporting/reportingQuery.ts
@@ -17,6 +17,7 @@ export interface ResponseData {
         estimated_price: number;
     }>;
     countByCardName: Array<{
+        _id: string;
         quantity_sold: number;
         card_title: string;
     }>;

--- a/frontend/src/Reporting/reportingQuery.ts
+++ b/frontend/src/Reporting/reportingQuery.ts
@@ -14,6 +14,7 @@ export interface ResponseData {
         quantity_on_hand: number;
         finish: Finish;
         finish_condition: FinishCondition;
+        estimated_price: number;
     }>;
     countByCardName: Array<{
         count: number;

--- a/frontend/src/Reporting/reportingQuery.ts
+++ b/frontend/src/Reporting/reportingQuery.ts
@@ -8,7 +8,7 @@ export interface ResponseData {
     countByPrinting: Array<{
         _id: string;
         scryfall_id: string;
-        count: number;
+        quantity_sold: number;
         card_title: string;
         card_metadata: ScryfallApiCard;
         quantity_on_hand: number;
@@ -17,7 +17,7 @@ export interface ResponseData {
         estimated_price: number;
     }>;
     countByCardName: Array<{
-        count: number;
+        quantity_sold: number;
         card_title: string;
     }>;
 }

--- a/frontend/src/Reporting/reportingQuery.ts
+++ b/frontend/src/Reporting/reportingQuery.ts
@@ -1,14 +1,16 @@
 import Axios from 'axios';
 import { GET_REPORT } from '../utils/api_resources';
 import makeAuthHeader from '../utils/makeAuthHeader';
-import { ScryfallApiCard } from '../utils/ScryfallCard';
+import { FinishCondition, QOH, ScryfallApiCard } from '../utils/ScryfallCard';
 
 export interface ResponseData {
     countByPrinting: Array<{
+        _id: string;
         count: number;
         card_title: string;
-        scryfall_id: string;
         card_metadata: ScryfallApiCard;
+        quantity_on_hand: number;
+        finish_condition: FinishCondition;
     }>;
     countByCardName: Array<{
         count: number;

--- a/frontend/src/Reporting/reportingQuery.ts
+++ b/frontend/src/Reporting/reportingQuery.ts
@@ -1,15 +1,18 @@
 import Axios from 'axios';
+import { Finish } from '../common/types';
 import { GET_REPORT } from '../utils/api_resources';
 import makeAuthHeader from '../utils/makeAuthHeader';
-import { FinishCondition, QOH, ScryfallApiCard } from '../utils/ScryfallCard';
+import { FinishCondition, ScryfallApiCard } from '../utils/ScryfallCard';
 
 export interface ResponseData {
     countByPrinting: Array<{
         _id: string;
+        scryfall_id: string;
         count: number;
         card_title: string;
         card_metadata: ScryfallApiCard;
         quantity_on_hand: number;
+        finish: Finish;
         finish_condition: FinishCondition;
     }>;
     countByCardName: Array<{

--- a/frontend/src/utils/parseQoh.ts
+++ b/frontend/src/utils/parseQoh.ts
@@ -2,16 +2,16 @@ import { QOH } from './ScryfallCard';
 
 export default function parseQoh(qoh: Partial<QOH>) {
     const foilQty =
-        (qoh.FOIL_NM || 0) +
-        (qoh.FOIL_LP || 0) +
-        (qoh.FOIL_MP || 0) +
-        (qoh.FOIL_HP || 0);
+        (qoh?.FOIL_NM || 0) +
+        (qoh?.FOIL_LP || 0) +
+        (qoh?.FOIL_MP || 0) +
+        (qoh?.FOIL_HP || 0);
 
     const nonfoilQty =
-        (qoh.NONFOIL_NM || 0) +
-        (qoh.NONFOIL_LP || 0) +
-        (qoh.NONFOIL_MP || 0) +
-        (qoh.NONFOIL_HP || 0);
+        (qoh?.NONFOIL_NM || 0) +
+        (qoh?.NONFOIL_LP || 0) +
+        (qoh?.NONFOIL_MP || 0) +
+        (qoh?.NONFOIL_HP || 0);
 
     return [foilQty, nonfoilQty] as const;
 }

--- a/monolith/interactors/getSalesReport.ts
+++ b/monolith/interactors/getSalesReport.ts
@@ -15,14 +15,14 @@ interface CountByPrinting {
         scryfall_id: string;
         finish_condition: FinishCondition;
     };
-    count: number;
+    quantity_sold: number;
     card_title: string;
     card_metadata: ScryfallCard;
     quantity_on_hand: Partial<QOH>;
 }
 
 interface CountByCardName {
-    count: number;
+    quantity_sold: number;
     card_title: string;
 }
 
@@ -64,7 +64,7 @@ async function getSalesReport({ location, startDate, endDate }: Args) {
             },
         };
 
-        const sort = { count: -1 };
+        const sort = { quantity_sold: -1 };
         const limit = 100;
 
         const facet = {
@@ -75,7 +75,7 @@ async function getSalesReport({ location, startDate, endDate }: Args) {
                             scryfall_id: '$scryfall_id',
                             finish_condition: '$finish_condition',
                         },
-                        count: { $sum: '$quantity_sold' },
+                        quantity_sold: { $sum: '$quantity_sold' },
                         card_title: { $first: '$card_title' },
                     },
                 },
@@ -115,13 +115,12 @@ async function getSalesReport({ location, startDate, endDate }: Args) {
                 {
                     $group: {
                         _id: '$card_title',
-                        count: { $sum: '$quantity_sold' },
+                        quantity_sold: { $sum: '$quantity_sold' },
                         card_title: { $first: '$card_title' },
                     },
                 },
                 { $sort: sort },
                 { $limit: limit },
-                { $project: { _id: 0 } }, // Suppress _id we used in $group
             ],
         };
 

--- a/monolith/interactors/getSalesReport.ts
+++ b/monolith/interactors/getSalesReport.ts
@@ -11,7 +11,7 @@ interface Args {
 const createGroupStage = (groupId: string) => {
     return {
         _id: groupId,
-        count: { $sum: 1 },
+        count: { $sum: '$quantity_sold' },
         card_title: { $first: '$card_title' },
     };
 };
@@ -32,6 +32,7 @@ async function getSalesReport({ location, startDate, endDate }: Args) {
             created_at: { $toDate: '$_id' },
             card_id: '$card_list.id',
             card_title: '$card_list.name',
+            quantity_sold: '$card_list.qtyToSell',
         };
 
         const match = {

--- a/monolith/interactors/getSalesReport.ts
+++ b/monolith/interactors/getSalesReport.ts
@@ -154,7 +154,9 @@ async function getSalesReport({ location, startDate, endDate }: Args) {
                 return {
                     ...c,
                     _id: id,
+                    scryfall_id: c._id.scryfall_id,
                     finish_condition: c._id.finish_condition,
+                    finish: nonfoil ? 'NONFOIL' : 'FOIL',
                     quantity_on_hand: nonfoil ? nonfoilQty : foilQty,
                 };
             }),

--- a/monolith/interactors/getSalesReport.ts
+++ b/monolith/interactors/getSalesReport.ts
@@ -158,6 +158,9 @@ async function getSalesReport({ location, startDate, endDate }: Args) {
                     finish_condition: c._id.finish_condition,
                     finish: nonfoil ? 'NONFOIL' : 'FOIL',
                     quantity_on_hand: nonfoil ? nonfoilQty : foilQty,
+                    estimated_price: nonfoil
+                        ? c.card_metadata.prices.usd
+                        : c.card_metadata.prices.usd_foil,
                 };
             }),
             countByCardName: result.countByCardName,

--- a/monolith/lib/isNonfoil.ts
+++ b/monolith/lib/isNonfoil.ts
@@ -1,0 +1,11 @@
+import { FinishCondition } from '../common/types';
+
+/**
+ * Returns whether or not a given finishCondition value is nonfoil
+ */
+const isNonfoil = (val: FinishCondition) => {
+    if (val.includes('NONFOIL')) return true;
+    else return false;
+};
+
+export default isNonfoil;

--- a/monolith/lib/parseQoh.ts
+++ b/monolith/lib/parseQoh.ts
@@ -3,7 +3,7 @@ import { QOH } from '../common/types';
 /**
  * This function parses the `qoh` object from mongo into something more presentable
  */
-export default function parseQoh(qoh: QOH): {
+export default function parseQoh(qoh: Partial<QOH>): {
     foilQty: number;
     nonfoilQty: number;
 } {
@@ -11,16 +11,16 @@ export default function parseQoh(qoh: QOH): {
     let nonfoilQty = 0;
 
     foilQty =
-        (qoh.FOIL_NM || 0) +
-        (qoh.FOIL_LP || 0) +
-        (qoh.FOIL_MP || 0) +
-        (qoh.FOIL_HP || 0);
+        (qoh?.FOIL_NM || 0) +
+        (qoh?.FOIL_LP || 0) +
+        (qoh?.FOIL_MP || 0) +
+        (qoh?.FOIL_HP || 0);
 
     nonfoilQty =
-        (qoh.NONFOIL_NM || 0) +
-        (qoh.NONFOIL_LP || 0) +
-        (qoh.NONFOIL_MP || 0) +
-        (qoh.NONFOIL_HP || 0);
+        (qoh?.NONFOIL_NM || 0) +
+        (qoh?.NONFOIL_LP || 0) +
+        (qoh?.NONFOIL_MP || 0) +
+        (qoh?.NONFOIL_HP || 0);
 
     return {
         foilQty,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/15024562/129960424-6403a5de-b280-4994-9d70-1d8a63fa687f.png)

## Summary
This PR makes edits to the reporting interactor and related frontend component, exposing estimated price and quantity in stock for a given printing by id. 

The challenge here was to join on both the `scryfall_bulk_cards` and `card_inventory` collections, then infer quantity on hand from the `qoh` object based on the card finish. The helper function `isNonfoil` was created to aid this process.

The interactor return data was reshaped to include pricing and quantities on hand, and the frontend query was altered to accept the resultant data type. The view layer was modified as well (pictured above).

Notably, this PR also corrects a bug in totaling counts of cards sold. Previously, I was using `$unwind` and then simply adding up each line item as one entry, totally missing that each sale-card entry has a `qtyToSell` property that indicates how many copies were sold. That's been fixed and the interactor accumulates accordingly.