### PR TITLE
Extract QOH type

### DIFF
--- a/frontend/src/ManageInventory/addCardToInventoryQuery.ts
+++ b/frontend/src/ManageInventory/addCardToInventoryQuery.ts
@@ -20,7 +20,7 @@ interface ResponseData {
     _id: string;
     name: string;
     set: string;
-    qoh: Partial<QOH>;
+    qoh: QOH;
 }
 
 const addCardToInventoryQuery = async (payload: Payload) => {

--- a/frontend/src/Sale/SaleSearchCard.tsx
+++ b/frontend/src/Sale/SaleSearchCard.tsx
@@ -24,10 +24,7 @@ interface ConditionOptions {
  * @param {Object} qoh
  * @param {String} id
  */
-function createConditionOptions(
-    qoh: Partial<QOH>,
-    id: string
-): ConditionOptions[] {
+function createConditionOptions(qoh: QOH, id: string): ConditionOptions[] {
     const removeZeroedQuantites = _.pickBy(qoh, (p) => p && p > 0); // Quantites of zero not included
 
     return Object.entries(removeZeroedQuantites).map((d) => {

--- a/frontend/src/common/QohLabels.tsx
+++ b/frontend/src/common/QohLabels.tsx
@@ -6,7 +6,7 @@ import parseQoh from '../utils/parseQoh';
 import { QOH } from '../utils/ScryfallCard';
 
 export const createInventoryLineItems = (
-    inventoryQty: Partial<QOH>,
+    inventoryQty: QOH,
     matchStrings: (keyof QOH)[]
 ): string[] => {
     const matches = matchStrings
@@ -24,7 +24,7 @@ export const createInventoryLineItems = (
 };
 
 interface Props {
-    inventoryQty: Partial<QOH>;
+    inventoryQty: QOH;
 }
 
 interface LabelWithPopupProps {

--- a/frontend/src/context/InventoryContext.tsx
+++ b/frontend/src/context/InventoryContext.tsx
@@ -6,7 +6,7 @@ interface Props {}
 
 interface Context {
     searchResults: ScryfallCard[];
-    changeCardQuantity: (id: string, qoh: Partial<QOH>) => void;
+    changeCardQuantity: (id: string, qoh: QOH) => void;
     handleSearchSelect: (term: string) => void;
 }
 
@@ -28,7 +28,7 @@ const InventoryProvider: FC<Props> = ({ children }) => {
         setSearchResults(cards);
     };
 
-    const changeCardQuantity = (id: string, qoh: Partial<QOH>) => {
+    const changeCardQuantity = (id: string, qoh: QOH) => {
         const copiedState = [...searchResults];
         const targetIndex = copiedState.findIndex((e) => e.id === id);
         copiedState[targetIndex].qoh = qoh;

--- a/frontend/src/utils/ScryfallCard.ts
+++ b/frontend/src/utils/ScryfallCard.ts
@@ -31,7 +31,7 @@ export type FinishCondition =
     | 'NONFOIL_MP'
     | 'NONFOIL_HP';
 
-export interface QOH {
+export type QOH = Partial<{
     FOIL_NM: number;
     FOIL_LP: number;
     FOIL_MP: number;
@@ -40,7 +40,7 @@ export interface QOH {
     NONFOIL_LP: number;
     NONFOIL_MP: number;
     NONFOIL_HP: number;
-}
+}>;
 
 export interface ImageURIs {
     normal: string;
@@ -72,7 +72,7 @@ export interface ScryfallApiCard {
     display_name: string;
     cardImage: string;
     color_identity: string[];
-    qoh?: Partial<QOH>;
+    qoh?: QOH;
     quantity?: number;
     qtyToSell?: number;
     finishCondition?: string;
@@ -109,7 +109,7 @@ export class ScryfallCard {
     public color_identity: string[];
     public promo_types: string[];
     public tcgplayer_id: number | null;
-    public qoh: Partial<QOH>;
+    public qoh: QOH;
 
     public constructor(card: ScryfallApiCard) {
         this.id = card.id;

--- a/frontend/src/utils/parseQoh.test.ts
+++ b/frontend/src/utils/parseQoh.test.ts
@@ -2,7 +2,7 @@ import parseQoh from './parseQoh';
 import { QOH } from './ScryfallCard';
 
 test('Parse QOH', () => {
-    const mock: Partial<QOH> = {
+    const mock: QOH = {
         FOIL_HP: 3,
         FOIL_LP: 2,
         NONFOIL_HP: 4,

--- a/frontend/src/utils/parseQoh.ts
+++ b/frontend/src/utils/parseQoh.ts
@@ -1,6 +1,6 @@
 import { QOH } from './ScryfallCard';
 
-export default function parseQoh(qoh: Partial<QOH>) {
+export default function parseQoh(qoh: QOH) {
     const foilQty =
         (qoh?.FOIL_NM || 0) +
         (qoh?.FOIL_LP || 0) +

--- a/monolith/common/types.ts
+++ b/monolith/common/types.ts
@@ -77,16 +77,16 @@ export const frames = ['borderless', 'extendedArt', 'showcase'] as const;
 
 export type Frame = typeof frames[number];
 
-export interface QOH {
-    FOIL_NM?: number;
-    FOIL_LP?: number;
-    FOIL_MP?: number;
-    FOIL_HP?: number;
-    NONFOIL_NM?: number;
-    NONFOIL_LP?: number;
-    NONFOIL_MP?: number;
-    NONFOIL_HP?: number;
-}
+export type QOH = Partial<{
+    FOIL_NM: number;
+    FOIL_LP: number;
+    FOIL_MP: number;
+    FOIL_HP: number;
+    NONFOIL_NM: number;
+    NONFOIL_LP: number;
+    NONFOIL_MP: number;
+    NONFOIL_HP: number;
+}>;
 
 export interface RequestWithUserInfo extends Request {
     locations: string[];

--- a/monolith/interactors/getSalesReport.ts
+++ b/monolith/interactors/getSalesReport.ts
@@ -18,7 +18,7 @@ interface CountByPrinting {
     quantity_sold: number;
     card_title: string;
     card_metadata: ScryfallCard;
-    quantity_on_hand: Partial<QOH>;
+    quantity_on_hand: QOH;
 }
 
 interface CountByCardName {

--- a/monolith/lib/parseQoh.ts
+++ b/monolith/lib/parseQoh.ts
@@ -3,7 +3,7 @@ import { QOH } from '../common/types';
 /**
  * This function parses the `qoh` object from mongo into something more presentable
  */
-export default function parseQoh(qoh: Partial<QOH>): {
+export default function parseQoh(qoh: QOH): {
     foilQty: number;
     nonfoilQty: number;
 } {


### PR DESCRIPTION
# Summary
This centralizes the QOH type of `Partial<QOH>` in each respective frontend and backend types files. We were repeating this utility type elsewhere, and should never expect queries to return it with all properties guaranteed as the data structure itself _is_ Partial. 