### PR TITLE
Fix inventory collection bug

### DIFF
--- a/monolith/interactors/getSalesReport.ts
+++ b/monolith/interactors/getSalesReport.ts
@@ -93,7 +93,7 @@ async function getSalesReport({ location, startDate, endDate }: Args) {
                 // Join on current inventory for current QOH
                 {
                     $lookup: {
-                        from: Collection.cardInventory,
+                        from: collectionFromLocation(location).cardInventory,
                         localField: '_id.scryfall_id',
                         foreignField: '_id',
                         as: 'inventory',


### PR DESCRIPTION
## Summary
Users had reported wrong numbers on quantity on hand values in the reporting table - and they were right! We were pulling exclusively from the Beaverton location. This line change now accurately joins on the intended location.