### PR TITLE
Refactor login to use MUI

### DIFF
--- a/frontend/src/Login/Login.tsx
+++ b/frontend/src/Login/Login.tsx
@@ -1,11 +1,12 @@
+import { Box, Container, makeStyles, Paper } from '@material-ui/core';
 import { FormikErrors, useFormik } from 'formik';
 import React from 'react';
 import { Redirect } from 'react-router-dom';
-import { Button, Form, Segment } from 'semantic-ui-react';
-import styled from 'styled-components';
 import createToast from '../common/createToast';
 import { ClubhouseLocation, useAuthContext } from '../context/AuthProvider';
-import FormikSelectField from '../ui/FormikSelectField';
+import Button from '../ui/Button';
+import ControlledDropdown from '../ui/ControlledDropdown';
+import TextField from '../ui/TextField';
 
 interface FormValues {
     username: string;
@@ -13,22 +14,19 @@ interface FormValues {
     location: ClubhouseLocation | null;
 }
 
-const LoginContainer = styled.div`
-    margin-top: 15px;
-    display: flex;
-    justify-content: center;
-`;
-
-const FormContainer = styled(Segment)`
-    width: 400px;
-    padding: 25px 25px 25px 25px !important;
-`;
-
 const initialFormValues: FormValues = {
     username: '',
     password: '',
     location: null,
 };
+
+const useStyles = makeStyles(({ spacing }) => ({
+    formGap: {
+        '& > *:not(:last-child)': {
+            paddingBottom: spacing(2),
+        },
+    },
+}));
 
 const locationDropdownOptions = [
     {
@@ -62,6 +60,7 @@ const validate = ({ username, password, location }: FormValues) => {
 };
 
 const Login = () => {
+    const { formGap } = useStyles();
     const { isLoggedIn, handleLogin } = useAuthContext();
 
     const onSubmit = async ({ username, password, location }: FormValues) => {
@@ -85,6 +84,7 @@ const Login = () => {
     };
 
     const {
+        values,
         handleChange,
         handleSubmit,
         setFieldValue,
@@ -100,47 +100,55 @@ const Login = () => {
     if (isLoggedIn()) return <Redirect to="/manage-inventory" />;
 
     return (
-        <LoginContainer>
-            <FormContainer raised loading={isSubmitting}>
-                <Form>
-                    <Form.Field>
-                        <label>Username</label>
-                        <Form.Input
-                            error={errors.username}
-                            onChange={handleChange}
-                            name="username"
+        <Container maxWidth="xs">
+            <Paper variant="outlined">
+                <Box p={3}>
+                    <form className={formGap}>
+                        <div>
+                            <TextField
+                                error={errors.username}
+                                name="username"
+                                label="Username"
+                                variant="outlined"
+                                size="small"
+                                fullWidth
+                                onChange={handleChange}
+                            />
+                        </div>
+                        <div>
+                            <TextField
+                                error={errors.password}
+                                name="password"
+                                type="password"
+                                label="Password"
+                                variant="outlined"
+                                size="small"
+                                fullWidth
+                                onChange={handleChange}
+                            />
+                        </div>
+                        <ControlledDropdown
+                            error={errors.location}
+                            value={values.location || ''}
+                            label="Location"
+                            name="location"
+                            options={locationDropdownOptions}
+                            onChange={(v) => {
+                                setFieldValue('location', v);
+                            }}
                         />
-                    </Form.Field>
-                    <Form.Field>
-                        <label>Password</label>
-                        <Form.Input
-                            error={errors.password}
-                            type="password"
-                            onChange={handleChange}
-                            name="password"
-                        />
-                    </Form.Field>
-                    <FormikSelectField
-                        error={errors.location}
-                        label="Location"
-                        name="location"
-                        placeholder="Select location"
-                        options={locationDropdownOptions}
-                        onChange={(v) => {
-                            setFieldValue('location', v);
-                        }}
-                    />
-                    <Button
-                        primary
-                        fluid
-                        type="submit"
-                        onClick={() => handleSubmit()}
-                    >
-                        Submit
-                    </Button>
-                </Form>
-            </FormContainer>
-        </LoginContainer>
+                        <Button
+                            fullWidth
+                            primary
+                            onClick={() => handleSubmit()}
+                            disabled={isSubmitting}
+                        >
+                            Submit
+                        </Button>
+                    </form>
+                </Box>
+            </Paper>
+        </Container>
     );
 };
 

--- a/frontend/src/ui/ControlledDropdown.tsx
+++ b/frontend/src/ui/ControlledDropdown.tsx
@@ -1,5 +1,6 @@
 import {
     FormControl,
+    FormHelperText,
     InputLabel,
     MenuItem,
     Select,
@@ -18,7 +19,8 @@ type ControlledDropdownProps = {
     value: string;
     onChange: (value: string) => void;
     options: DropdownOption[];
-} & Omit<SelectProps, 'name' | 'multiple' | 'value' | 'onChange'>;
+    error?: string;
+} & Omit<SelectProps, 'name' | 'multiple' | 'value' | 'onChange' | 'error'>;
 
 function ControlledDropdown({
     label,
@@ -26,12 +28,14 @@ function ControlledDropdown({
     value,
     onChange,
     options,
+    error,
     ...props
 }: ControlledDropdownProps) {
     return (
         <FormControl variant="outlined" size="small" fullWidth>
             <InputLabel>{label}</InputLabel>
             <Select
+                error={!!error}
                 label={label}
                 name={name}
                 value={value}
@@ -46,6 +50,7 @@ function ControlledDropdown({
                     </MenuItem>
                 ))}
             </Select>
+            {error && <FormHelperText error>{error}</FormHelperText>}
         </FormControl>
     );
 }

--- a/frontend/src/ui/TextField.tsx
+++ b/frontend/src/ui/TextField.tsx
@@ -1,0 +1,21 @@
+import {
+    FormHelperText,
+    TextField as MUITextField,
+    TextFieldProps,
+} from '@material-ui/core';
+import { FC } from 'react';
+
+type Props = {
+    error?: string;
+} & Omit<TextFieldProps, 'error'>;
+
+const TextField: FC<Props> = ({ error, ...props }) => {
+    return (
+        <>
+            <MUITextField error={!!error} {...props} />
+            {error && <FormHelperText error>{error}</FormHelperText>}
+        </>
+    );
+};
+
+export default TextField;


### PR DESCRIPTION
## Summary
This PR moves the login view to Material UI. A new `TextField` component was extracted to compartmentalize rendering user errors, and the `ControlledDropdown` component was polished to include error rendering. 

Naturally, the view now uses MUI components as well.