### PR TITLE
Centralize request header config

### DIFF
--- a/frontend/src/BrowseInventory/filteredCardsQuery.ts
+++ b/frontend/src/BrowseInventory/filteredCardsQuery.ts
@@ -1,6 +1,5 @@
-import axios from 'axios';
+import http from '../common/http';
 import { GET_CARDS_BY_FILTER } from '../utils/api_resources';
-import makeAuthHeader from '../utils/makeAuthHeader';
 import { FinishCondition } from '../utils/ScryfallCard';
 
 export interface Filters {
@@ -40,9 +39,8 @@ interface ResponseData {
 const filteredCardsQuery = async (filters: Filters, page: number) => {
     const params: Params = { ...filters, page };
 
-    const { data } = await axios.get<ResponseData>(GET_CARDS_BY_FILTER, {
+    const { data } = await http.get<ResponseData>(GET_CARDS_BY_FILTER, {
         params,
-        headers: makeAuthHeader(),
     });
 
     return data;

--- a/frontend/src/BrowseInventory/setNameQuery.ts
+++ b/frontend/src/BrowseInventory/setNameQuery.ts
@@ -1,12 +1,9 @@
-import axios from 'axios';
+import http from '../common/http';
 import { GET_SET_NAMES } from '../utils/api_resources';
-import makeAuthHeader from '../utils/makeAuthHeader';
 
 const setNameQuery = async () => {
     try {
-        const { data } = await axios.get<string[]>(GET_SET_NAMES, {
-            headers: makeAuthHeader(),
-        });
+        const { data } = await http.get<string[]>(GET_SET_NAMES);
 
         return data;
     } catch (err) {

--- a/frontend/src/BrowseReceiving/browseReceivingQuery.ts
+++ b/frontend/src/BrowseReceiving/browseReceivingQuery.ts
@@ -1,8 +1,7 @@
-import axios from 'axios';
+import http from '../common/http';
 import { ClubhouseLocation } from '../context/AuthProvider';
 import { Trade } from '../context/ReceivingContext';
 import { RECEIVING } from '../utils/api_resources';
-import makeAuthHeader from '../utils/makeAuthHeader';
 import { FinishCondition } from '../utils/ScryfallCard';
 
 export interface ReceivedCard {
@@ -47,9 +46,8 @@ const browseReceivingQuery = async ({
     endDate,
 }: Payload) => {
     try {
-        const { data } = await axios.get<Received[]>(RECEIVING, {
+        const { data } = await http.get<Received[]>(RECEIVING, {
             params: { cardName, startDate, endDate },
-            headers: makeAuthHeader(),
         });
         return data;
     } catch (err) {

--- a/frontend/src/BrowseReceiving/receivedByIdQuery.ts
+++ b/frontend/src/BrowseReceiving/receivedByIdQuery.ts
@@ -1,8 +1,7 @@
-import axios from 'axios';
+import http from '../common/http';
 import { ClubhouseLocation } from '../context/AuthProvider';
 import { Trade } from '../context/ReceivingContext';
 import { RECEIVING } from '../utils/api_resources';
-import makeAuthHeader from '../utils/makeAuthHeader';
 import { FinishCondition, ScryfallApiCard } from '../utils/ScryfallCard';
 
 interface ReceivedUser {
@@ -38,9 +37,7 @@ export interface Received {
 }
 
 const receivedByIdQuery = async (receivedId: string) => {
-    const { data } = await axios.get<Received>(`${RECEIVING}/${receivedId}`, {
-        headers: makeAuthHeader(),
-    });
+    const { data } = await http.get<Received>(`${RECEIVING}/${receivedId}`);
 
     // We still need to convert ScryfallApiCard to ScryfallCard downstream
     return data;

--- a/frontend/src/BrowseSales/browseSalesQuery.ts
+++ b/frontend/src/BrowseSales/browseSalesQuery.ts
@@ -1,7 +1,6 @@
-import axios from 'axios';
+import http from '../common/http';
 import { SaleListCard } from '../context/SaleContext';
 import { GET_SALES_BY_TITLE } from '../utils/api_resources';
-import makeAuthHeader from '../utils/makeAuthHeader';
 
 interface SaleData {
     total: string;
@@ -22,9 +21,8 @@ interface Payload {
 
 const browseSalesQuery = async ({ cardName }: Payload) => {
     try {
-        const { data } = await axios.get<Sale[]>(GET_SALES_BY_TITLE, {
+        const { data } = await http.get<Sale[]>(GET_SALES_BY_TITLE, {
             params: { cardName: cardName },
-            headers: makeAuthHeader(),
         });
         return data;
     } catch (err) {

--- a/frontend/src/BulkInventory/bulkInventoryQuery.ts
+++ b/frontend/src/BulkInventory/bulkInventoryQuery.ts
@@ -1,6 +1,5 @@
-import axios from 'axios';
+import http from '../common/http';
 import { GET_BULK_CARDS } from '../utils/api_resources';
-import makeAuthHeader from '../utils/makeAuthHeader';
 
 export interface BulkCard {
     scryfall_id: string;
@@ -17,11 +16,10 @@ export interface BulkCard {
 
 const bulkInventoryQuery = async (cardName: string) => {
     try {
-        const { data } = await axios.get<BulkCard[]>(GET_BULK_CARDS, {
+        const { data } = await http.get<BulkCard[]>(GET_BULK_CARDS, {
             params: {
                 cardName,
             },
-            headers: makeAuthHeader(),
         });
 
         return data;

--- a/frontend/src/ManageInventory/addCardToInventoryQuery.ts
+++ b/frontend/src/ManageInventory/addCardToInventoryQuery.ts
@@ -1,6 +1,5 @@
-import axios from 'axios';
+import http from '../common/http';
 import { ADD_CARD_TO_INVENTORY } from '../utils/api_resources';
-import makeAuthHeader from '../utils/makeAuthHeader';
 import { QOH } from '../utils/ScryfallCard';
 
 interface CardInfo {
@@ -25,10 +24,9 @@ interface ResponseData {
 
 const addCardToInventoryQuery = async (payload: Payload) => {
     try {
-        const { data } = await axios.post<ResponseData>(
+        const { data } = await http.post<ResponseData>(
             ADD_CARD_TO_INVENTORY,
-            payload,
-            { headers: makeAuthHeader() }
+            payload
         );
 
         return data;

--- a/frontend/src/Reporting/reportingQuery.ts
+++ b/frontend/src/Reporting/reportingQuery.ts
@@ -1,6 +1,5 @@
-import Axios from 'axios';
+import http from '../common/http';
 import { GET_REPORT } from '../utils/api_resources';
-import makeAuthHeader from '../utils/makeAuthHeader';
 import {
     Finish,
     FinishCondition,
@@ -33,9 +32,8 @@ interface Args {
 
 const reportingQuery = async ({ startDate, endDate }: Args) => {
     try {
-        const { data } = await Axios.get<ResponseData>(GET_REPORT, {
+        const { data } = await http.get<ResponseData>(GET_REPORT, {
             params: { startDate, endDate },
-            headers: makeAuthHeader(),
         });
         return data;
     } catch (err) {

--- a/frontend/src/Sale/getSuspendedSalesQuery.ts
+++ b/frontend/src/Sale/getSuspendedSalesQuery.ts
@@ -1,13 +1,10 @@
-import axios from 'axios';
+import http from '../common/http';
 import { SuspendedSale } from '../context/getSuspendedSaleQuery';
 import { SUSPEND_SALE } from '../utils/api_resources';
-import makeAuthHeader from '../utils/makeAuthHeader';
 
 const getSuspendedSalesQuery = async () => {
     try {
-        const { data } = await axios.get<SuspendedSale[]>(SUSPEND_SALE, {
-            headers: makeAuthHeader(),
-        });
+        const { data } = await http.get<SuspendedSale[]>(SUSPEND_SALE);
 
         return data;
     } catch (err) {

--- a/frontend/src/common/http.ts
+++ b/frontend/src/common/http.ts
@@ -1,11 +1,15 @@
 import axios, { AxiosRequestConfig } from 'axios';
 import makeAuthHeader from '../utils/makeAuthHeader';
 
-const instance = axios.create();
+const http = axios.create();
 
-instance.interceptors.request.use((config: AxiosRequestConfig) => {
+/**
+ * This is essentially Axios middleware that sets the header prior to
+ * continuing the request pipeline
+ */
+http.interceptors.request.use((config: AxiosRequestConfig) => {
     config.headers = makeAuthHeader();
     return config;
 });
 
-export default instance;
+export default http;

--- a/frontend/src/common/http.ts
+++ b/frontend/src/common/http.ts
@@ -1,0 +1,11 @@
+import axios, { AxiosRequestConfig } from 'axios';
+import makeAuthHeader from '../utils/makeAuthHeader';
+
+const instance = axios.create();
+
+instance.interceptors.request.use((config: AxiosRequestConfig) => {
+    config.headers = makeAuthHeader();
+    return config;
+});
+
+export default instance;

--- a/frontend/src/context/cardSearchQuery.ts
+++ b/frontend/src/context/cardSearchQuery.ts
@@ -1,6 +1,5 @@
-import axios from 'axios';
+import http from '../common/http';
 import { GET_CARDS_WITH_INFO } from '../utils/api_resources';
-import makeAuthHeader from '../utils/makeAuthHeader';
 import { ScryfallApiCard, ScryfallCard } from '../utils/ScryfallCard';
 
 interface Params {
@@ -14,14 +13,13 @@ interface Params {
  */
 const cardSearchQuery = async ({ cardName, inStockOnly }: Params) => {
     try {
-        const { data } = await axios.get<ScryfallApiCard[]>(
+        const { data } = await http.get<ScryfallApiCard[]>(
             GET_CARDS_WITH_INFO,
             {
                 params: {
                     title: cardName,
                     matchInStock: inStockOnly,
                 },
-                headers: makeAuthHeader(),
             }
         );
 

--- a/frontend/src/context/createSuspendedSaleQuery.ts
+++ b/frontend/src/context/createSuspendedSaleQuery.ts
@@ -1,6 +1,5 @@
-import axios from 'axios';
+import http from '../common/http';
 import { SUSPEND_SALE } from '../utils/api_resources';
-import makeAuthHeader from '../utils/makeAuthHeader';
 import { SaleListCard } from './SaleContext';
 
 interface Payload {
@@ -15,9 +14,7 @@ interface ResponseData {
 
 const createSuspendedSaleQuery = async (payload: Payload) => {
     try {
-        const { data } = await axios.post<ResponseData>(SUSPEND_SALE, payload, {
-            headers: makeAuthHeader(),
-        });
+        const { data } = await http.post<ResponseData>(SUSPEND_SALE, payload);
 
         return data;
     } catch (err) {

--- a/frontend/src/context/deleteSuspendedSaleQuery.ts
+++ b/frontend/src/context/deleteSuspendedSaleQuery.ts
@@ -1,12 +1,9 @@
-import axios from 'axios';
+import http from '../common/http';
 import { SUSPEND_SALE } from '../utils/api_resources';
-import makeAuthHeader from '../utils/makeAuthHeader';
 
 const deleteSuspendedSaleQuery = async (saleId: string) => {
     try {
-        const { data } = await axios.delete<void>(`${SUSPEND_SALE}/${saleId}`, {
-            headers: makeAuthHeader(),
-        });
+        const { data } = await http.delete<void>(`${SUSPEND_SALE}/${saleId}`);
         return data;
     } catch (err) {
         throw err;

--- a/frontend/src/context/finishSaleQuery.tsx
+++ b/frontend/src/context/finishSaleQuery.tsx
@@ -1,6 +1,5 @@
-import axios from 'axios';
+import http from '../common/http';
 import { FINISH_SALE } from '../utils/api_resources';
-import makeAuthHeader from '../utils/makeAuthHeader';
 import { SaleListCard } from './SaleContext';
 
 interface Payload {
@@ -17,9 +16,7 @@ interface ResponseData {
 
 const finishSaleQuery = async (payload: Payload) => {
     try {
-        const { data } = await axios.post<ResponseData>(FINISH_SALE, payload, {
-            headers: makeAuthHeader(),
-        });
+        const { data } = await http.post<ResponseData>(FINISH_SALE, payload);
 
         return data;
     } catch (err) {

--- a/frontend/src/context/getSuspendedSaleQuery.ts
+++ b/frontend/src/context/getSuspendedSaleQuery.ts
@@ -1,6 +1,5 @@
-import axios from 'axios';
+import http from '../common/http';
 import { SUSPEND_SALE } from '../utils/api_resources';
-import makeAuthHeader from '../utils/makeAuthHeader';
 import { SaleListCard } from './SaleContext';
 
 export interface SuspendedSale {
@@ -12,11 +11,8 @@ export interface SuspendedSale {
 
 const getSuspendedSaleQuery = async (saleId: string) => {
     try {
-        const { data } = await axios.get<SuspendedSale>(
-            `${SUSPEND_SALE}/${saleId}`,
-            {
-                headers: makeAuthHeader(),
-            }
+        const { data } = await http.get<SuspendedSale>(
+            `${SUSPEND_SALE}/${saleId}`
         );
 
         return data;

--- a/frontend/src/context/loginQuery.ts
+++ b/frontend/src/context/loginQuery.ts
@@ -1,6 +1,5 @@
-import axios from 'axios';
+import http from '../common/http';
 import { LOGIN } from '../utils/api_resources';
-import makeAuthHeader from '../utils/makeAuthHeader';
 
 type ClubhouseLocation = 'ch1' | 'ch2';
 
@@ -14,15 +13,11 @@ const loginQuery = async (
     currentLocation: ClubhouseLocation
 ) => {
     try {
-        const { data } = await axios.post<ResponseData>(
-            LOGIN,
-            {
-                username: username.toLowerCase(),
-                password,
-                currentLocation,
-            },
-            { headers: makeAuthHeader() }
-        );
+        const { data } = await http.post<ResponseData>(LOGIN, {
+            username: username.toLowerCase(),
+            password,
+            currentLocation,
+        });
 
         return data;
     } catch (err) {

--- a/frontend/src/context/receivingQuery.tsx
+++ b/frontend/src/context/receivingQuery.tsx
@@ -1,6 +1,5 @@
-import axios from 'axios';
+import http from '../common/http';
 import { RECEIVE_CARDS } from '../utils/api_resources';
-import makeAuthHeader from '../utils/makeAuthHeader';
 import { Trade } from './ReceivingContext';
 
 interface ReceivingQueryCard {
@@ -29,11 +28,11 @@ const receivingQuery = async ({
 }: Payload) => {
     try {
         // We do not expect to use the return type, so we designate it `void`
-        const { data } = await axios.post<void>(
-            RECEIVE_CARDS,
-            { cards, customerName, customerContact },
-            { headers: makeAuthHeader() }
-        );
+        const { data } = await http.post<void>(RECEIVE_CARDS, {
+            cards,
+            customerName,
+            customerContact,
+        });
 
         return data;
     } catch (err) {


### PR DESCRIPTION
## Summary
Like `express` on the backend, outbound requests in `axios` can follow a pipeline of middleware, called interceptors. Rather than set the headers in each outgoing query's file, I extracted out a custom `http` module that sets the header before issuing a request, helping centralize this logic.