### PR TITLE
Removed foil warning in tests

### DIFF
--- a/frontend/src/common/Chip.tsx
+++ b/frontend/src/common/Chip.tsx
@@ -15,10 +15,10 @@ const useStyles = makeStyles({
     },
 });
 
-const Chip: FC<Props> = (props) => {
+const Chip: FC<Props> = ({ foil, ...props }) => {
     const { foilContainer, border } = useStyles();
 
-    if (props.foil) {
+    if (foil) {
         return <MUIChip {...props} className={clsx(foilContainer, border)} />;
     }
 


### PR DESCRIPTION
## Summary
Spreading these props separately from `foil` prevented the warning, as `foil` is not a valid prop in MUI's `Chip` component.