### PR TITLE
Added bundle analysis tools

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -45,7 +45,8 @@
                 "@types/uuid": "^8.3.0",
                 "dotenv": "^8.2.0",
                 "prettier": "2.1.1",
-                "puppeteer": "^2.1.1"
+                "puppeteer": "^2.1.1",
+                "source-map-explorer": "^2.5.2"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -6907,6 +6908,18 @@
                 "node-int64": "^0.4.0"
             }
         },
+        "node_modules/btoa": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
+            "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
+            "dev": true,
+            "bin": {
+                "btoa": "bin/btoa.js"
+            },
+            "engines": {
+                "node": ">= 0.4.0"
+            }
+        },
         "node_modules/buffer": {
             "version": "4.9.2",
             "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
@@ -10413,6 +10426,15 @@
             "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
             "optional": true
         },
+        "node_modules/filelist": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.2.tgz",
+            "integrity": "sha512-z7O0IS8Plc39rTCq6i6iHxk43duYOn8uFJiWSewIq0Bww1RNybVHSCjahmcC87ZqAm4OTvFzlzeGu3XAzG1ctQ==",
+            "dev": true,
+            "dependencies": {
+                "minimatch": "^3.0.4"
+            }
+        },
         "node_modules/filesize": {
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/filesize/-/filesize-6.1.0.tgz",
@@ -12531,6 +12553,30 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/jake": {
+            "version": "10.8.2",
+            "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.2.tgz",
+            "integrity": "sha512-eLpKyrfG3mzvGE2Du8VoPbeSkRry093+tyNjdYaBbJS9v17knImYGNXQCUV0gLxQtF82m3E8iRb/wdSQZLoq7A==",
+            "dev": true,
+            "dependencies": {
+                "async": "0.9.x",
+                "chalk": "^2.4.2",
+                "filelist": "^1.0.1",
+                "minimatch": "^3.0.4"
+            },
+            "bin": {
+                "jake": "bin/cli.js"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/jake/node_modules/async": {
+            "version": "0.9.2",
+            "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+            "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
+            "dev": true
         },
         "node_modules/jest": {
             "version": "26.6.0",
@@ -20260,6 +20306,206 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/source-map-explorer": {
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/source-map-explorer/-/source-map-explorer-2.5.2.tgz",
+            "integrity": "sha512-gBwOyCcHPHcdLbgw6Y6kgoH1uLKL6hN3zz0xJcNI2lpnElZliIlmSYAjUVwAWnc7+HscoTyh1ScR7ITtFuEnxg==",
+            "dev": true,
+            "dependencies": {
+                "btoa": "^1.2.1",
+                "chalk": "^4.1.0",
+                "convert-source-map": "^1.7.0",
+                "ejs": "^3.1.5",
+                "escape-html": "^1.0.3",
+                "glob": "^7.1.6",
+                "gzip-size": "^6.0.0",
+                "lodash": "^4.17.20",
+                "open": "^7.3.1",
+                "source-map": "^0.7.3",
+                "temp": "^0.9.4",
+                "yargs": "^16.2.0"
+            },
+            "bin": {
+                "sme": "bin/cli.js",
+                "source-map-explorer": "bin/cli.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/source-map-explorer/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/source-map-explorer/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/source-map-explorer/node_modules/cliui": {
+            "version": "7.0.4",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+            "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+            "dev": true,
+            "dependencies": {
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.0",
+                "wrap-ansi": "^7.0.0"
+            }
+        },
+        "node_modules/source-map-explorer/node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/source-map-explorer/node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true
+        },
+        "node_modules/source-map-explorer/node_modules/ejs": {
+            "version": "3.1.6",
+            "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.6.tgz",
+            "integrity": "sha512-9lt9Zse4hPucPkoP7FHDF0LQAlGyF9JVpnClFLFH3aSSbxmyoqINRpp/9wePWJTUl4KOQwRL72Iw3InHPDkoGw==",
+            "dev": true,
+            "dependencies": {
+                "jake": "^10.6.1"
+            },
+            "bin": {
+                "ejs": "bin/cli.js"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/source-map-explorer/node_modules/gzip-size": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
+            "integrity": "sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==",
+            "dev": true,
+            "dependencies": {
+                "duplexer": "^0.1.2"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/source-map-explorer/node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/source-map-explorer/node_modules/source-map": {
+            "version": "0.7.3",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+            "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+            "dev": true,
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/source-map-explorer/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/source-map-explorer/node_modules/wrap-ansi": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/source-map-explorer/node_modules/y18n": {
+            "version": "5.0.8",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+            "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/source-map-explorer/node_modules/yargs": {
+            "version": "16.2.0",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+            "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+            "dev": true,
+            "dependencies": {
+                "cliui": "^7.0.2",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "require-directory": "^2.1.1",
+                "string-width": "^4.2.0",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^20.2.2"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/source-map-explorer/node_modules/yargs-parser": {
+            "version": "20.2.9",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+            "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/source-map-resolve": {
             "version": "0.5.3",
             "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
@@ -21037,6 +21283,19 @@
             },
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/temp": {
+            "version": "0.9.4",
+            "resolved": "https://registry.npmjs.org/temp/-/temp-0.9.4.tgz",
+            "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
+            "dev": true,
+            "dependencies": {
+                "mkdirp": "^0.5.1",
+                "rimraf": "~2.6.2"
+            },
+            "engines": {
+                "node": ">=6.0.0"
             }
         },
         "node_modules/temp-dir": {
@@ -29386,6 +29645,12 @@
                 "node-int64": "^0.4.0"
             }
         },
+        "btoa": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
+            "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
+            "dev": true
+        },
         "buffer": {
             "version": "4.9.2",
             "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
@@ -32172,6 +32437,15 @@
             "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
             "optional": true
         },
+        "filelist": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.2.tgz",
+            "integrity": "sha512-z7O0IS8Plc39rTCq6i6iHxk43duYOn8uFJiWSewIq0Bww1RNybVHSCjahmcC87ZqAm4OTvFzlzeGu3XAzG1ctQ==",
+            "dev": true,
+            "requires": {
+                "minimatch": "^3.0.4"
+            }
+        },
         "filesize": {
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/filesize/-/filesize-6.1.0.tgz",
@@ -33823,6 +34097,26 @@
             "requires": {
                 "html-escaper": "^2.0.0",
                 "istanbul-lib-report": "^3.0.0"
+            }
+        },
+        "jake": {
+            "version": "10.8.2",
+            "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.2.tgz",
+            "integrity": "sha512-eLpKyrfG3mzvGE2Du8VoPbeSkRry093+tyNjdYaBbJS9v17knImYGNXQCUV0gLxQtF82m3E8iRb/wdSQZLoq7A==",
+            "dev": true,
+            "requires": {
+                "async": "0.9.x",
+                "chalk": "^2.4.2",
+                "filelist": "^1.0.1",
+                "minimatch": "^3.0.4"
+            },
+            "dependencies": {
+                "async": {
+                    "version": "0.9.2",
+                    "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+                    "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
+                    "dev": true
+                }
             }
         },
         "jest": {
@@ -39900,6 +40194,150 @@
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
             "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         },
+        "source-map-explorer": {
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/source-map-explorer/-/source-map-explorer-2.5.2.tgz",
+            "integrity": "sha512-gBwOyCcHPHcdLbgw6Y6kgoH1uLKL6hN3zz0xJcNI2lpnElZliIlmSYAjUVwAWnc7+HscoTyh1ScR7ITtFuEnxg==",
+            "dev": true,
+            "requires": {
+                "btoa": "^1.2.1",
+                "chalk": "^4.1.0",
+                "convert-source-map": "^1.7.0",
+                "ejs": "^3.1.5",
+                "escape-html": "^1.0.3",
+                "glob": "^7.1.6",
+                "gzip-size": "^6.0.0",
+                "lodash": "^4.17.20",
+                "open": "^7.3.1",
+                "source-map": "^0.7.3",
+                "temp": "^0.9.4",
+                "yargs": "^16.2.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+                    "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "cliui": {
+                    "version": "7.0.4",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+                    "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+                    "dev": true,
+                    "requires": {
+                        "string-width": "^4.2.0",
+                        "strip-ansi": "^6.0.0",
+                        "wrap-ansi": "^7.0.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "ejs": {
+                    "version": "3.1.6",
+                    "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.6.tgz",
+                    "integrity": "sha512-9lt9Zse4hPucPkoP7FHDF0LQAlGyF9JVpnClFLFH3aSSbxmyoqINRpp/9wePWJTUl4KOQwRL72Iw3InHPDkoGw==",
+                    "dev": true,
+                    "requires": {
+                        "jake": "^10.6.1"
+                    }
+                },
+                "gzip-size": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
+                    "integrity": "sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==",
+                    "dev": true,
+                    "requires": {
+                        "duplexer": "^0.1.2"
+                    }
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.7.3",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+                    "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                },
+                "wrap-ansi": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+                    "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.0.0",
+                        "string-width": "^4.1.0",
+                        "strip-ansi": "^6.0.0"
+                    }
+                },
+                "y18n": {
+                    "version": "5.0.8",
+                    "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+                    "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+                    "dev": true
+                },
+                "yargs": {
+                    "version": "16.2.0",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+                    "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+                    "dev": true,
+                    "requires": {
+                        "cliui": "^7.0.2",
+                        "escalade": "^3.1.1",
+                        "get-caller-file": "^2.0.5",
+                        "require-directory": "^2.1.1",
+                        "string-width": "^4.2.0",
+                        "y18n": "^5.0.5",
+                        "yargs-parser": "^20.2.2"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "20.2.9",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+                    "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+                    "dev": true
+                }
+            }
+        },
         "source-map-resolve": {
             "version": "0.5.3",
             "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
@@ -40516,6 +40954,16 @@
                     "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
                     "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
                 }
+            }
+        },
+        "temp": {
+            "version": "0.9.4",
+            "resolved": "https://registry.npmjs.org/temp/-/temp-0.9.4.tgz",
+            "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
+            "dev": true,
+            "requires": {
+                "mkdirp": "^0.5.1",
+                "rimraf": "~2.6.2"
             }
         },
         "temp-dir": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,6 +30,7 @@
         "uuid": "^3.4.0"
     },
     "scripts": {
+        "analyze": "source-map-explorer 'build/static/js/*.js'",
         "start": "REACT_APP_ENVIRONMENT=development react-scripts start",
         "build": "react-scripts build",
         "test": "react-scripts test",
@@ -68,6 +69,7 @@
         "@types/uuid": "^8.3.0",
         "dotenv": "^8.2.0",
         "prettier": "2.1.1",
-        "puppeteer": "^2.1.1"
+        "puppeteer": "^2.1.1",
+        "source-map-explorer": "^2.5.2"
     }
 }


### PR DESCRIPTION
## Summary
Adding `source-map-explorer` and its associated `npm` script for bundle analysis. SUIR is still huge! And so is `lodash`. Have to get rid of both eventually.