### PR TITLE
Refactor receiving context methods and testing

### DIFF
--- a/frontend/src/Receiving/Receiving.tsx
+++ b/frontend/src/Receiving/Receiving.tsx
@@ -1,9 +1,9 @@
 import { Grid } from '@material-ui/core';
 import SearchIcon from '@material-ui/icons/Search';
-import React, { FC, useContext, useEffect, useState } from 'react';
+import React, { FC, useEffect, useState } from 'react';
 import { Prompt } from 'react-router';
 import TotalCardsLabel from '../common/TotalCardsLabel';
-import { ReceivingContext } from '../context/ReceivingContext';
+import { useReceivingContext } from '../context/ReceivingContext';
 import TotalStoreInventory from '../ManageInventory/TotalStoreInventory';
 import ControlledSearchBar from '../ui/ControlledSearchBar';
 import Loading from '../ui/Loading';
@@ -25,7 +25,7 @@ const Receiving: FC<Props> = () => {
         receivingList,
         handleSearchSelect,
         resetSearchResults,
-    } = useContext(ReceivingContext);
+    } = useReceivingContext();
 
     /**
      * Reset the search results on unmount to clear store

--- a/frontend/src/Receiving/ReceivingCartItem.tsx
+++ b/frontend/src/Receiving/ReceivingCartItem.tsx
@@ -2,13 +2,13 @@ import { Box, Grid, IconButton, ListItem, Typography } from '@material-ui/core';
 import AttachMoneyIcon from '@material-ui/icons/AttachMoney';
 import CloseIcon from '@material-ui/icons/Close';
 import CreditCardIcon from '@material-ui/icons/CreditCard';
-import React, { FC, useContext } from 'react';
+import React, { FC } from 'react';
 import Chip from '../common/Chip';
 import Price from '../common/Price';
 import {
     ReceivingCard,
-    ReceivingContext,
     Trade,
+    useReceivingContext,
 } from '../context/ReceivingContext';
 import CardImageTooltip from '../ui/CardImageTooltip';
 import SetIcon from '../ui/SetIcon';
@@ -20,21 +20,19 @@ interface Props {
 // Defines whether it uses cash or credit for trade types
 const TRADE_TYPE = { CASH: 'CASH', CREDIT: 'CREDIT' };
 
-const ReceivingCartItem: FC<Props> = ({
-    card: {
+const ReceivingCartItem: FC<Props> = ({ card }) => {
+    const {
         display_name,
         set,
         rarity,
         cashPrice,
         creditPrice,
         finishCondition,
-        uuid_key,
         tradeType,
         cardImage,
-    },
-}) => {
+    } = card;
     const { CASH, CREDIT } = TRADE_TYPE;
-    const { removeFromList, activeTradeType } = useContext(ReceivingContext);
+    const { removeFromList, activeTradeType } = useReceivingContext();
 
     return (
         <ListItem>
@@ -74,20 +72,20 @@ const ReceivingCartItem: FC<Props> = ({
                 <Grid item>
                     <IconButton
                         color={tradeType === CASH ? 'primary' : undefined}
-                        onClick={() => activeTradeType(uuid_key, Trade.Cash)}
+                        onClick={() => activeTradeType(card, Trade.Cash)}
                         disabled={cashPrice === 0}
                     >
                         <AttachMoneyIcon />
                     </IconButton>
                     <IconButton
                         color={tradeType === CREDIT ? 'primary' : undefined}
-                        onClick={() => activeTradeType(uuid_key, Trade.Credit)}
+                        onClick={() => activeTradeType(card, Trade.Credit)}
                         disabled={creditPrice === 0}
                     >
                         <CreditCardIcon />
                     </IconButton>
                     <IconButton
-                        onClick={() => removeFromList(uuid_key)}
+                        onClick={() => removeFromList(card)}
                         color="secondary"
                     >
                         <CloseIcon />

--- a/frontend/src/Receiving/ReceivingListModal.tsx
+++ b/frontend/src/Receiving/ReceivingListModal.tsx
@@ -1,8 +1,8 @@
 import { FormikErrors, useFormik } from 'formik';
-import React, { FC, useContext, useState } from 'react';
+import React, { FC, useState } from 'react';
 import { Button, Form, Header, List, Modal } from 'semantic-ui-react';
 import Price from '../common/Price';
-import { ReceivingContext, Trade } from '../context/ReceivingContext';
+import { Trade, useReceivingContext } from '../context/ReceivingContext';
 import sum from '../utils/sum';
 
 interface Props {}
@@ -44,7 +44,7 @@ const ReceivingListModal: FC<Props> = () => {
     const [loading, setLoading] = useState(false);
     const [showModal, setShowModal] = useState(false);
 
-    const { receivingList, commitToInventory } = useContext(ReceivingContext);
+    const { receivingList, commitToInventory } = useReceivingContext();
 
     const onSubmit = async ({ customerName, customerContact }: FormValues) => {
         setLoading(true);

--- a/frontend/src/Receiving/ReceivingListTotals.tsx
+++ b/frontend/src/Receiving/ReceivingListTotals.tsx
@@ -1,8 +1,8 @@
 import { Box, Grid, Paper, Typography } from '@material-ui/core';
-import React, { FC, useContext, useState } from 'react';
+import React, { FC, useState } from 'react';
 import { Button, Modal } from 'semantic-ui-react';
 import Price from '../common/Price';
-import { ReceivingContext, Trade } from '../context/ReceivingContext';
+import { Trade, useReceivingContext } from '../context/ReceivingContext';
 import sum from '../utils/sum';
 import CashReport from './CashReport';
 import printCashReport from './printCashReport';
@@ -13,7 +13,7 @@ interface Props {}
 const ReceivingListTotals: FC<Props> = () => {
     const { Cash, Credit } = Trade;
     const [showCashModal, setShowCashModal] = useState(false);
-    const { receivingList, selectAll } = useContext(ReceivingContext);
+    const { receivingList, selectAll } = useReceivingContext();
 
     const openCashModal = () => setShowCashModal(true);
     const closeCashModal = () => setShowCashModal(false);

--- a/frontend/src/Receiving/ReceivingSearchItem.tsx
+++ b/frontend/src/Receiving/ReceivingSearchItem.tsx
@@ -1,9 +1,9 @@
 import { Box, Grid } from '@material-ui/core';
 import { FormikErrors, useFormik } from 'formik';
 import $ from 'jquery';
-import React, { ChangeEvent, FC, FocusEvent, useContext } from 'react';
+import React, { ChangeEvent, FC, FocusEvent } from 'react';
 import CardImage from '../common/CardImage';
-import { ReceivingContext } from '../context/ReceivingContext';
+import { useReceivingContext } from '../context/ReceivingContext';
 import Button from '../ui/Button';
 import CardHeader from '../ui/CardHeader';
 import CardRowContainer from '../ui/CardRowContainer';
@@ -71,7 +71,7 @@ const ReceivingSearchItem: FC<Props> = ({ card }) => {
     const finishDisabled = checkCardFinish(card.nonfoil, card.foil)
         .finishDisabled;
 
-    const { addToList } = useContext(ReceivingContext);
+    const { addToList } = useReceivingContext();
 
     const handleFocus = (
         e: FocusEvent<HTMLInputElement | HTMLTextAreaElement>

--- a/frontend/src/context/ReceivingContext.test.tsx
+++ b/frontend/src/context/ReceivingContext.test.tsx
@@ -1,0 +1,139 @@
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { FC } from 'react';
+import { ScryfallCard } from '../utils/ScryfallCard';
+import currentButton from '../utils/testing/currentButton';
+import birdsOfParadise from '../utils/testing/fixtures/birdsOfParadise';
+import blackLotus from '../utils/testing/fixtures/blackLotus';
+import ReceivingProvider, {
+    ReceivingCard,
+    Trade,
+    useReceivingContext,
+} from './ReceivingContext';
+
+const bop = new ScryfallCard(birdsOfParadise);
+const lotus = new ScryfallCard(blackLotus);
+
+const ToggleTrade = () => {
+    const { selectAll } = useReceivingContext();
+
+    return (
+        <div>
+            <button onClick={() => selectAll(Trade.Cash)}>Toggle Cash</button>
+            <button onClick={() => selectAll(Trade.Credit)}>
+                Toggle Credit
+            </button>
+        </div>
+    );
+};
+
+const AddButton: FC<{ card: ScryfallCard }> = ({ card }) => {
+    const { addToList } = useReceivingContext();
+
+    const onAdd = () =>
+        addToList(1, card, {
+            marketPrice: 3.33,
+            cashPrice: 2.22,
+            creditPrice: 1.11,
+            finishCondition: 'NONFOIL_NM',
+        });
+
+    return <button onClick={onAdd}>Add</button>;
+};
+
+const RemoveButton: FC<{ card: ReceivingCard }> = ({ card }) => {
+    const { removeFromList } = useReceivingContext();
+    const onRemove = () => removeFromList(card);
+
+    return <button onClick={onRemove}>Remove {card.name}</button>;
+};
+
+const ReceivingList = () => {
+    const { receivingList } = useReceivingContext();
+    return (
+        <div>
+            {receivingList.map((r) => (
+                <div key={r.uuid_key}>
+                    <p>{r.name}</p>
+                    <p>{r.tradeType}</p>
+                    <RemoveButton card={r} />
+                </div>
+            ))}
+        </div>
+    );
+};
+
+test('receiving context adding to list', async () => {
+    render(
+        <ReceivingProvider>
+            <ReceivingList />
+            <AddButton card={bop} />
+        </ReceivingProvider>
+    );
+
+    const button = await currentButton('Add')();
+    fireEvent.click(button);
+    await screen.findByText('Birds of Paradise');
+});
+
+test('remove from list', async () => {
+    render(
+        <ReceivingProvider>
+            <ReceivingList />
+            <AddButton card={bop} />
+        </ReceivingProvider>
+    );
+
+    const addButton = await currentButton('Add')();
+    fireEvent.click(addButton);
+    await screen.findByText('Birds of Paradise');
+    const removeButton = await currentButton('Remove Birds of Paradise')();
+    fireEvent.click(removeButton);
+    expect(screen.queryByText('Birds of Paradise')).not.toBeInTheDocument();
+});
+
+test('add multiple items to list and preserve order', async () => {
+    render(
+        <ReceivingProvider>
+            <ReceivingList />
+            <AddButton card={bop} />
+            <AddButton card={lotus} />
+        </ReceivingProvider>
+    );
+
+    const buttons = await screen.findAllByText('Add');
+    buttons.forEach((b) => fireEvent.click(b));
+    await screen.findByText('Birds of Paradise');
+    await screen.findByText('Black Lotus');
+
+    const remove = await currentButton('Remove Birds of Paradise')();
+    fireEvent.click(remove);
+
+    await screen.findByText('Black Lotus');
+    expect(screen.queryByText('Birds of Paradise')).not.toBeInTheDocument();
+});
+
+test('toggle correct trade types', async () => {
+    render(
+        <ReceivingProvider>
+            <ReceivingList />
+            <AddButton card={bop} />
+            <AddButton card={lotus} />
+            <ToggleTrade />
+        </ReceivingProvider>
+    );
+
+    const buttons = await screen.findAllByText('Add');
+    buttons.forEach((b) => fireEvent.click(b));
+    await screen.findByText('Birds of Paradise');
+    await screen.findByText('Black Lotus');
+
+    expect(screen.getAllByText('CREDIT').length).toBe(2);
+
+    const toggleCash = await currentButton('Toggle Cash')();
+    fireEvent.click(toggleCash);
+
+    expect(screen.getAllByText('CASH').length).toBe(2);
+});
+
+// TODO: Test commitToInventory and intercept args with mocked axios

--- a/frontend/src/context/ReceivingContext.tsx
+++ b/frontend/src/context/ReceivingContext.tsx
@@ -1,5 +1,5 @@
 import { sortBy } from 'lodash';
-import React, { createContext, FC, useState } from 'react';
+import React, { createContext, FC, useContext, useState } from 'react';
 import { v4 as uuid } from 'uuid';
 import { useToastContext } from '../ui/ToastContext';
 import { ScryfallCard } from '../utils/ScryfallCard';
@@ -34,8 +34,8 @@ interface Context {
         card: ScryfallCard,
         meta: AddToListMeta
     ) => void;
-    removeFromList: (uuid: string) => void;
-    activeTradeType: (uuid: string, tradeType: Trade) => void;
+    removeFromList: (card: ReceivingCard) => void;
+    activeTradeType: (card: ReceivingCard, tradeType: Trade) => void;
     selectAll: (trade: Trade) => void;
     commitToInventory: (
         customerName: string,
@@ -63,7 +63,7 @@ interface AddToListMeta {
     finishCondition: string;
 }
 
-export const ReceivingContext = createContext<Context>(defaultContext);
+const ReceivingContext = createContext<Context>(defaultContext);
 
 const ReceivingProvider: FC<Props> = ({ children }) => {
     const createToast = useToastContext();
@@ -111,19 +111,20 @@ const ReceivingProvider: FC<Props> = ({ children }) => {
     /**
      * Removes a card from the receiving list using the uuid
      */
-    const removeFromList = (uuid_key: string) => {
-        const copiedState = [...receivingList];
-        setReceivingList(copiedState.filter((e) => e.uuid_key !== uuid_key));
+    const removeFromList = (card: ReceivingCard) => {
+        setReceivingList(
+            [...receivingList].filter((e) => e.uuid_key !== card.uuid_key)
+        );
     };
 
     /**
      * Determines whether line-items use cash or credit.
      * Assigns a new trade type.
      */
-    const activeTradeType = (uuid_key: string, tradeType: Trade) => {
+    const activeTradeType = (currentCard: ReceivingCard, tradeType: Trade) => {
         setReceivingList(
             [...receivingList].map((card) => {
-                if (card.uuid_key === uuid_key) {
+                if (card.uuid_key === currentCard.uuid_key) {
                     card.tradeType = TRADE_TYPES[tradeType];
                 }
                 return card;
@@ -221,4 +222,5 @@ const ReceivingProvider: FC<Props> = ({ children }) => {
     );
 };
 
+export const useReceivingContext = () => useContext(ReceivingContext);
 export default ReceivingProvider;


### PR DESCRIPTION
## Summary
This PR creates a testing suite for the receiving context, and alters a few of its methods to accept whole `ReceivingCard` objects rather than `uuid`s, which I believe semantically improve its API.

We also export a wrapper over the `useContext` hook, called `useReceivingContext` to simplify our imports.