### PR TITLE
Prevent negative prices from being submitted in receiving

### DIFF
--- a/frontend/src/Receiving/ReceivingSearchItem.test.tsx
+++ b/frontend/src/Receiving/ReceivingSearchItem.test.tsx
@@ -121,3 +121,21 @@ test('submission button disabling correctly', async () => {
     fireEvent.change(await cashPriceInput(), { target: { value: 0 } });
     expect(await button()).toBeDisabled();
 });
+
+test('should not be allowed to enter negative prices', async () => {
+    const mockCard = new ScryfallCard(bop);
+
+    await render(<ReceivingSearchItem card={mockCard} />);
+    const creditPriceInput = currentByLabelText('Credit Price');
+    const cashPriceInput = currentByLabelText('Cash Price');
+    const marketPriceInput = currentByLabelText('Market Price');
+    const button = currentButton('Add to list');
+
+    fireEvent.change(await creditPriceInput(), { target: { value: -4.56 } });
+    expect(await button()).toBeDisabled();
+
+    fireEvent.change(await cashPriceInput(), { target: { value: -4.56 } });
+    fireEvent.change(await marketPriceInput(), { target: { value: -4.56 } });
+
+    expect(await button()).toBeDisabled();
+});

--- a/frontend/src/Receiving/ReceivingSearchItem.test.tsx
+++ b/frontend/src/Receiving/ReceivingSearchItem.test.tsx
@@ -136,6 +136,5 @@ test('should not be allowed to enter negative prices', async () => {
 
     fireEvent.change(await cashPriceInput(), { target: { value: -4.56 } });
     fireEvent.change(await marketPriceInput(), { target: { value: -4.56 } });
-
     expect(await button()).toBeDisabled();
 });

--- a/frontend/src/Receiving/ReceivingSearchItem.tsx
+++ b/frontend/src/Receiving/ReceivingSearchItem.tsx
@@ -53,6 +53,11 @@ const validate = ({
     if (!selectedFinish) errors.selectedFinish = 'error';
     if (!selectedCondition) errors.selectedCondition = 'error';
 
+    // Cash, credit, and market prices should not be negative
+    if (cashPrice < 0) errors.cashPrice = 'Cannot be negative';
+    if (creditPrice < 0) errors.creditPrice = 'Cannot be negative';
+    if (marketPrice < 0) errors.marketPrice = 'Cannot be negative';
+
     return errors;
 };
 


### PR DESCRIPTION
## Summary
Users could potentially type negative prices into receiving and submit them. This PR fixes that, with testing.