### PR TITLE
Prevent html5 default validation

### DIFF
--- a/frontend/src/Receiving/ReceivingSearchItem.tsx
+++ b/frontend/src/Receiving/ReceivingSearchItem.tsx
@@ -144,7 +144,7 @@ const ReceivingSearchItem: FC<Props> = ({ card }) => {
                 />
             }
         >
-            <form onSubmit={handleSubmit}>
+            <form onSubmit={handleSubmit} noValidate>
                 <Grid container alignItems="center" spacing={2}>
                     <Grid item>
                         <TextField


### PR DESCRIPTION
## Summary
Users could not press 'enter' to submit a received card to the list, because html5 validation prevented them from doing so. Here we pass `noValidate` to our `form` tag to override this behavior.