### PR TITLE
Remove SUIR from suspend sale components

### DIFF
--- a/frontend/src/Sale/PrintList.tsx
+++ b/frontend/src/Sale/PrintList.tsx
@@ -1,6 +1,7 @@
+import { IconButton } from '@material-ui/core';
+import PrintIcon from '@material-ui/icons/Print';
 import React, { FC, useRef } from 'react';
 import { useReactToPrint } from 'react-to-print';
-import { Button, Icon } from 'semantic-ui-react';
 import styled from 'styled-components';
 import Price from '../common/Price';
 import { SaleListCard } from '../context/SaleContext';
@@ -35,9 +36,9 @@ const PrintList: FC<Props> = ({ saleListCards }) => {
     return (
         <>
             <div>
-                <Button size="tiny" onClick={handlePrint} icon>
-                    <Icon name="print" />
-                </Button>
+                <IconButton onClick={handlePrint} size="small">
+                    <PrintIcon />
+                </IconButton>
             </div>
             <PrintWrapper ref={componentRef}>
                 <ul>

--- a/frontend/src/Sale/SuspendSaleButton.tsx
+++ b/frontend/src/Sale/SuspendSaleButton.tsx
@@ -5,8 +5,9 @@ import {
     DialogTitle,
     Grid,
 } from '@material-ui/core';
+import { Alert, AlertTitle } from '@material-ui/lab';
 import React, { FC, useEffect, useState } from 'react';
-import { DropdownProps, Form, Message, TextAreaProps } from 'semantic-ui-react';
+import { DropdownProps, Form, TextAreaProps } from 'semantic-ui-react';
 import styled from 'styled-components';
 import { SuspendedSale } from '../context/getSuspendedSaleQuery';
 import { SaleContext } from '../context/SaleContext';
@@ -113,12 +114,7 @@ const SuspendSaleButton: FC<Props> = ({
                     Sales menu icon
                 </Button>
             </div>
-            <Dialog
-                open={modalOpen}
-                onClose={() => setModalOpen(false)}
-                maxWidth="md"
-                fullWidth
-            >
+            <Dialog open={modalOpen} maxWidth="md" fullWidth>
                 <DialogTitle>Sales menu</DialogTitle>
                 <DialogContent>
                     <Grid container spacing={2}>
@@ -226,10 +222,10 @@ const SuspendSaleButton: FC<Props> = ({
                                 </React.Fragment>
                             )}
                             {sales.length === 0 && (
-                                <Message info>
-                                    <Message.Header>No sales</Message.Header>
+                                <Alert severity="info">
+                                    <AlertTitle>No sales</AlertTitle>
                                     Suspend a sale first
-                                </Message>
+                                </Alert>
                             )}
                         </Grid>
                     </Grid>

--- a/frontend/src/Sale/SuspendSaleButton.tsx
+++ b/frontend/src/Sale/SuspendSaleButton.tsx
@@ -8,10 +8,10 @@ import {
 } from '@material-ui/core';
 import { Alert, AlertTitle } from '@material-ui/lab';
 import React, { FC, useEffect, useState } from 'react';
-import { DropdownProps, Form } from 'semantic-ui-react';
 import { SuspendedSale } from '../context/getSuspendedSaleQuery';
 import { SaleContext } from '../context/SaleContext';
 import Button from '../ui/Button';
+import ControlledDropdown from '../ui/ControlledDropdown';
 import TextField from '../ui/TextField';
 import getSuspendedSalesQuery from './getSuspendedSalesQuery';
 
@@ -127,98 +127,78 @@ const SuspendSaleButton: FC<Props> = ({
                 <DialogContent>
                     <Grid container spacing={2}>
                         {saleListLength > 0 && (
-                            <React.Fragment>
-                                <Grid item xs={6}>
-                                    <h3>Suspend Sale</h3>
-                                    {/* <Form> */}
-                                    <div>
-                                        <TextField
-                                            fullWidth
-                                            label="Customer Name"
-                                            placeholder="Jace, the Mind Sculptor"
-                                            value={customerName}
-                                            onChange={(e) => {
-                                                setCustomerName(
-                                                    e.target.value.substring(
-                                                        0,
-                                                        50
-                                                    )
-                                                );
-                                            }}
-                                        />
-                                    </div>
-                                    <CharLimit text={customerName} limit={50} />
-                                    <div>
-                                        <TextField
-                                            multiline
-                                            minRows={3}
-                                            fullWidth
-                                            label="Notes"
-                                            placeholder="Sometimes, I forget things..."
-                                            value={notes}
-                                            onChange={(e) => {
-                                                setNotes(
-                                                    e.target.value.substring(
-                                                        0,
-                                                        150
-                                                    )
-                                                );
-                                            }}
-                                        />
-                                    </div>
-                                    <CharLimit text={notes} limit={150} />
-                                    <Button
-                                        primary
-                                        disabled={
-                                            disabled ||
-                                            !customerName ||
-                                            loadingBtn.suspendBtn
-                                        }
-                                        onClick={submitSuspendSale}
-                                    >
-                                        Suspend Sale
-                                    </Button>
-                                    {/* </Form> */}
-                                </Grid>
-                            </React.Fragment>
+                            <Grid item xs={6}>
+                                <h3>Suspend Sale</h3>
+                                <div>
+                                    <TextField
+                                        fullWidth
+                                        label="Customer Name"
+                                        placeholder="Jace, the Mind Sculptor"
+                                        value={customerName}
+                                        onChange={(e) => {
+                                            setCustomerName(
+                                                e.target.value.substring(0, 50)
+                                            );
+                                        }}
+                                    />
+                                </div>
+                                <CharLimit text={customerName} limit={50} />
+                                <div>
+                                    <TextField
+                                        multiline
+                                        minRows={3}
+                                        fullWidth
+                                        label="Notes"
+                                        placeholder="Sometimes, I forget things..."
+                                        value={notes}
+                                        onChange={(e) => {
+                                            setNotes(
+                                                e.target.value.substring(0, 150)
+                                            );
+                                        }}
+                                    />
+                                </div>
+                                <CharLimit text={notes} limit={150} />
+                                <Button
+                                    primary
+                                    disabled={
+                                        disabled ||
+                                        !customerName ||
+                                        loadingBtn.suspendBtn
+                                    }
+                                    onClick={submitSuspendSale}
+                                >
+                                    Suspend Sale
+                                </Button>
+                            </Grid>
                         )}
                         <Grid item xs={6}>
                             <h3>Restore Sale</h3>
                             {sales.length > 0 && (
                                 <React.Fragment>
-                                    <Form>
-                                        <Form.Select
-                                            fluid
-                                            label="Previously suspended sales"
-                                            options={sales.map((s) => {
-                                                return {
-                                                    key: s._id,
-                                                    text: s.name,
-                                                    value: s._id,
-                                                };
-                                            })}
-                                            placeholder="Select a sale"
-                                            onChange={(
-                                                e,
-                                                { value }: DropdownProps
-                                            ) => {
-                                                if (typeof value === 'string') {
-                                                    setSaleID(value);
-                                                }
-                                            }}
-                                        />
-                                        <Form.Button
-                                            primary
-                                            disabled={
-                                                disabled ||
-                                                !saleID ||
-                                                loadingBtn.restoreBtn
-                                            }
-                                            onClick={submitRestoreSale}
-                                        >
-                                            Restore Sale
-                                        </Form.Button>
-                                    </Form>
+                                    <ControlledDropdown
+                                        value={saleID}
+                                        name="suspendedsales"
+                                        onChange={(val) => setSaleID(val)}
+                                        options={sales.map((s) => {
+                                            return {
+                                                key: s._id,
+                                                text: s.name,
+                                                value: s._id,
+                                            };
+                                        })}
+                                    />
+                                    <Button
+                                        primary
+                                        disabled={
+                                            disabled ||
+                                            !saleID ||
+                                            loadingBtn.restoreBtn
+                                        }
+                                        onClick={submitRestoreSale}
+                                    >
+                                        Restore Sale
+                                    </Button>
                                 </React.Fragment>
                             )}
                             {sales.length === 0 && (

--- a/frontend/src/Sale/SuspendSaleButton.tsx
+++ b/frontend/src/Sale/SuspendSaleButton.tsx
@@ -1,19 +1,20 @@
-import React, { FC, useEffect, useState } from 'react';
 import {
-    Button,
-    DropdownProps,
-    Form,
+    Dialog,
+    DialogActions,
+    DialogContent,
+    DialogTitle,
     Grid,
-    Message,
-    Modal,
-    TextAreaProps,
-} from 'semantic-ui-react';
+} from '@material-ui/core';
+import React, { FC, useEffect, useState } from 'react';
+import { DropdownProps, Form, Message, TextAreaProps } from 'semantic-ui-react';
 import styled from 'styled-components';
 import { SuspendedSale } from '../context/getSuspendedSaleQuery';
 import { SaleContext } from '../context/SaleContext';
+import Button from '../ui/Button';
 import getSuspendedSalesQuery from './getSuspendedSalesQuery';
 
 interface Props {
+    /** The suspended sale ID */
     id: string;
     saleListLength: number;
     restoreSale: SaleContext['restoreSale'];
@@ -26,11 +27,6 @@ interface SuspendButtonState {
     restoreBtn: boolean;
     deleteBtn: boolean;
 }
-
-const Divider = styled.div`
-    border-left: 1px solid rgba(0, 0, 0, 0.2);
-    height: 100%;
-`;
 
 const ClearMargin = styled.div`
     margin-top: 0px;
@@ -79,17 +75,6 @@ const SuspendSaleButton: FC<Props> = ({
         getSales();
     }, [id]); // If the parent-level suspended-sale _id changes, we fetch again
 
-    const modalTrigger = (
-        <div>
-            <Button
-                size="tiny"
-                id="suspend-sale-btn"
-                onClick={() => setModalOpen(true)}
-                icon="ellipsis horizontal"
-            />
-        </div>
-    );
-
     const submitSuspendSale = async () => {
         setDisabled(true);
         setLoadingBtn({ ...loadingBtn, suspendBtn: true });
@@ -123,13 +108,23 @@ const SuspendSaleButton: FC<Props> = ({
 
     return (
         <React.Fragment>
-            <Modal trigger={modalTrigger} open={modalOpen}>
-                <Modal.Header>Sales menu</Modal.Header>
-                <Modal.Content>
-                    <Grid columns={2} stackable relaxed="very">
+            <div>
+                <Button onClick={() => setModalOpen(true)}>
+                    Sales menu icon
+                </Button>
+            </div>
+            <Dialog
+                open={modalOpen}
+                onClose={() => setModalOpen(false)}
+                maxWidth="md"
+                fullWidth
+            >
+                <DialogTitle>Sales menu</DialogTitle>
+                <DialogContent>
+                    <Grid container spacing={2}>
                         {saleListLength > 0 && (
                             <React.Fragment>
-                                <Grid.Column width="7">
+                                <Grid item xs={6}>
                                     <h3>Suspend Sale</h3>
                                     <Form>
                                         <ClearMargin>
@@ -188,13 +183,10 @@ const SuspendSaleButton: FC<Props> = ({
                                             Suspend Sale
                                         </Form.Button>
                                     </Form>
-                                </Grid.Column>
-                                <Grid.Column width="1">
-                                    <Divider />
-                                </Grid.Column>
+                                </Grid>
                             </React.Fragment>
                         )}
-                        <Grid.Column width="7">
+                        <Grid item xs={6}>
                             <h3>Restore Sale</h3>
                             {sales.length > 0 && (
                                 <React.Fragment>
@@ -221,8 +213,11 @@ const SuspendSaleButton: FC<Props> = ({
                                         />
                                         <Form.Button
                                             primary
-                                            disabled={disabled || !saleID}
-                                            loading={loadingBtn.restoreBtn}
+                                            disabled={
+                                                disabled ||
+                                                !saleID ||
+                                                loadingBtn.restoreBtn
+                                            }
                                             onClick={submitRestoreSale}
                                         >
                                             Restore Sale
@@ -236,15 +231,13 @@ const SuspendSaleButton: FC<Props> = ({
                                     Suspend a sale first
                                 </Message>
                             )}
-                        </Grid.Column>
+                        </Grid>
                     </Grid>
-                </Modal.Content>
-                <Modal.Actions>
+                </DialogContent>
+                <DialogActions>
                     {!!id && (
                         <Button
-                            color="red"
-                            disabled={disabled}
-                            loading={loadingBtn.deleteBtn}
+                            disabled={disabled || loadingBtn.deleteBtn}
                             onClick={submitDeleteSale}
                         >
                             Delete current Sale
@@ -257,8 +250,8 @@ const SuspendSaleButton: FC<Props> = ({
                     >
                         Cancel
                     </Button>
-                </Modal.Actions>
-            </Modal>
+                </DialogActions>
+            </Dialog>
         </React.Fragment>
     );
 };

--- a/frontend/src/Sale/SuspendSaleButton.tsx
+++ b/frontend/src/Sale/SuspendSaleButton.tsx
@@ -1,12 +1,13 @@
 import {
+    Box,
     Dialog,
-    DialogActions,
     DialogContent,
     DialogTitle,
     Grid,
     IconButton,
     makeStyles,
 } from '@material-ui/core';
+import CloseIcon from '@material-ui/icons/Close';
 import MoreHorizIcon from '@material-ui/icons/MoreHoriz';
 import { Alert, AlertTitle } from '@material-ui/lab';
 import React, { FC, useEffect, useState } from 'react';
@@ -118,7 +119,7 @@ const SuspendSaleButton: FC<Props> = ({
     };
 
     return (
-        <React.Fragment>
+        <>
             <div>
                 <IconButton
                     disabled={disabled}
@@ -129,12 +130,26 @@ const SuspendSaleButton: FC<Props> = ({
                 </IconButton>
             </div>
             <Dialog open={modalOpen} maxWidth="md" fullWidth>
-                <DialogTitle>Sales menu</DialogTitle>
+                <DialogTitle>
+                    <Box
+                        display="flex"
+                        justifyContent="space-between"
+                        alignItems="center"
+                    >
+                        <h3>Sales menu</h3>
+                        <IconButton
+                            disabled={disabled}
+                            onClick={() => setModalOpen(false)}
+                        >
+                            <CloseIcon />
+                        </IconButton>
+                    </Box>
+                </DialogTitle>
                 <DialogContent>
                     <Grid container spacing={2}>
                         {saleListLength > 0 && (
                             <Grid item xs={6}>
-                                <h3>Suspend sale</h3>
+                                <h4>Suspend sale</h4>
                                 <div>
                                     <TextField
                                         fullWidth
@@ -167,6 +182,7 @@ const SuspendSaleButton: FC<Props> = ({
                                 <CharLimit text={notes} limit={150} />
                                 <br />
                                 <Button
+                                    fullWidth
                                     primary
                                     disabled={
                                         disabled ||
@@ -180,7 +196,7 @@ const SuspendSaleButton: FC<Props> = ({
                             </Grid>
                         )}
                         <Grid item xs={6}>
-                            <h3>Restore suspended sale</h3>
+                            <h4>Restore suspended sale</h4>
                             {sales.length > 0 && (
                                 <>
                                     <div>
@@ -199,17 +215,38 @@ const SuspendSaleButton: FC<Props> = ({
                                     </div>
                                     <br />
                                     <div>
-                                        <Button
-                                            primary
-                                            disabled={
-                                                disabled ||
-                                                !saleID ||
-                                                loadingBtn.restoreBtn
-                                            }
-                                            onClick={submitRestoreSale}
-                                        >
-                                            Restore Sale
-                                        </Button>
+                                        <Grid container spacing={2}>
+                                            <Grid item xs={6}>
+                                                <Button
+                                                    fullWidth
+                                                    primary
+                                                    disabled={
+                                                        disabled ||
+                                                        !saleID ||
+                                                        loadingBtn.restoreBtn
+                                                    }
+                                                    onClick={submitRestoreSale}
+                                                >
+                                                    Restore Sale
+                                                </Button>
+                                            </Grid>
+                                            {!!id && (
+                                                <Grid item xs={6}>
+                                                    <Button
+                                                        fullWidth
+                                                        disabled={
+                                                            disabled ||
+                                                            loadingBtn.deleteBtn
+                                                        }
+                                                        onClick={
+                                                            submitDeleteSale
+                                                        }
+                                                    >
+                                                        Delete current Sale
+                                                    </Button>
+                                                </Grid>
+                                            )}
+                                        </Grid>
                                     </div>
                                 </>
                             )}
@@ -222,25 +259,8 @@ const SuspendSaleButton: FC<Props> = ({
                         </Grid>
                     </Grid>
                 </DialogContent>
-                <DialogActions>
-                    {!!id && (
-                        <Button
-                            disabled={disabled || loadingBtn.deleteBtn}
-                            onClick={submitDeleteSale}
-                        >
-                            Delete current Sale
-                        </Button>
-                    )}
-                    <Button
-                        primary
-                        disabled={disabled}
-                        onClick={() => setModalOpen(false)}
-                    >
-                        Cancel
-                    </Button>
-                </DialogActions>
             </Dialog>
-        </React.Fragment>
+        </>
     );
 };
 

--- a/frontend/src/Sale/SuspendSaleButton.tsx
+++ b/frontend/src/Sale/SuspendSaleButton.tsx
@@ -4,8 +4,10 @@ import {
     DialogContent,
     DialogTitle,
     Grid,
+    IconButton,
     makeStyles,
 } from '@material-ui/core';
+import MoreHorizIcon from '@material-ui/icons/MoreHoriz';
 import { Alert, AlertTitle } from '@material-ui/lab';
 import React, { FC, useEffect, useState } from 'react';
 import { SuspendedSale } from '../context/getSuspendedSaleQuery';
@@ -118,9 +120,13 @@ const SuspendSaleButton: FC<Props> = ({
     return (
         <React.Fragment>
             <div>
-                <Button onClick={() => setModalOpen(true)}>
-                    Sales menu icon
-                </Button>
+                <IconButton
+                    disabled={disabled}
+                    onClick={() => setModalOpen(true)}
+                    size="small"
+                >
+                    <MoreHorizIcon />
+                </IconButton>
             </div>
             <Dialog open={modalOpen} maxWidth="md" fullWidth>
                 <DialogTitle>Sales menu</DialogTitle>
@@ -128,7 +134,7 @@ const SuspendSaleButton: FC<Props> = ({
                     <Grid container spacing={2}>
                         {saleListLength > 0 && (
                             <Grid item xs={6}>
-                                <h3>Suspend Sale</h3>
+                                <h3>Suspend sale</h3>
                                 <div>
                                     <TextField
                                         fullWidth
@@ -159,6 +165,7 @@ const SuspendSaleButton: FC<Props> = ({
                                     />
                                 </div>
                                 <CharLimit text={notes} limit={150} />
+                                <br />
                                 <Button
                                     primary
                                     disabled={
@@ -173,33 +180,38 @@ const SuspendSaleButton: FC<Props> = ({
                             </Grid>
                         )}
                         <Grid item xs={6}>
-                            <h3>Restore Sale</h3>
+                            <h3>Restore suspended sale</h3>
                             {sales.length > 0 && (
-                                <React.Fragment>
-                                    <ControlledDropdown
-                                        value={saleID}
-                                        name="suspendedsales"
-                                        onChange={(val) => setSaleID(val)}
-                                        options={sales.map((s) => {
-                                            return {
-                                                key: s._id,
-                                                text: s.name,
-                                                value: s._id,
-                                            };
-                                        })}
-                                    />
-                                    <Button
-                                        primary
-                                        disabled={
-                                            disabled ||
-                                            !saleID ||
-                                            loadingBtn.restoreBtn
-                                        }
-                                        onClick={submitRestoreSale}
-                                    >
-                                        Restore Sale
-                                    </Button>
-                                </React.Fragment>
+                                <>
+                                    <div>
+                                        <ControlledDropdown
+                                            value={saleID}
+                                            name="suspendedsales"
+                                            onChange={(val) => setSaleID(val)}
+                                            options={sales.map((s) => {
+                                                return {
+                                                    key: s._id,
+                                                    text: s.name,
+                                                    value: s._id,
+                                                };
+                                            })}
+                                        />
+                                    </div>
+                                    <br />
+                                    <div>
+                                        <Button
+                                            primary
+                                            disabled={
+                                                disabled ||
+                                                !saleID ||
+                                                loadingBtn.restoreBtn
+                                            }
+                                            onClick={submitRestoreSale}
+                                        >
+                                            Restore Sale
+                                        </Button>
+                                    </div>
+                                </>
                             )}
                             {sales.length === 0 && (
                                 <Alert severity="info">

--- a/frontend/src/Sale/SuspendSaleButton.tsx
+++ b/frontend/src/Sale/SuspendSaleButton.tsx
@@ -4,14 +4,15 @@ import {
     DialogContent,
     DialogTitle,
     Grid,
+    makeStyles,
 } from '@material-ui/core';
 import { Alert, AlertTitle } from '@material-ui/lab';
 import React, { FC, useEffect, useState } from 'react';
-import { DropdownProps, Form, TextAreaProps } from 'semantic-ui-react';
-import styled from 'styled-components';
+import { DropdownProps, Form } from 'semantic-ui-react';
 import { SuspendedSale } from '../context/getSuspendedSaleQuery';
 import { SaleContext } from '../context/SaleContext';
 import Button from '../ui/Button';
+import TextField from '../ui/TextField';
 import getSuspendedSalesQuery from './getSuspendedSalesQuery';
 
 interface Props {
@@ -29,16 +30,23 @@ interface SuspendButtonState {
     deleteBtn: boolean;
 }
 
-const ClearMargin = styled.div`
-    margin-top: 0px;
-    margin-bottom: 0px;
-`;
+const CharLimit: FC<{ text: string; limit: number }> = ({ text, limit }) => {
+    const { charLimit } = useStyles();
 
-const CharLimit = styled.p`
-    font-size: 12px;
-    color: rgba(0, 0, 0, 0.2);
-    float: right;
-`;
+    return (
+        <div className={charLimit}>
+            {text.length}/{limit}
+        </div>
+    );
+};
+
+const useStyles = makeStyles({
+    charLimit: {
+        fontSize: '12px',
+        color: 'rgba(0, 0, 0, 0.4)',
+        float: 'right',
+    },
+});
 
 const SuspendSaleButton: FC<Props> = ({
     restoreSale,
@@ -122,63 +130,55 @@ const SuspendSaleButton: FC<Props> = ({
                             <React.Fragment>
                                 <Grid item xs={6}>
                                     <h3>Suspend Sale</h3>
-                                    <Form>
-                                        <ClearMargin>
-                                            <Form.Input
-                                                id="suspend-sale-name"
-                                                label="Customer Name"
-                                                placeholder="Jace, the Mind Sculptor"
-                                                value={customerName}
-                                                onChange={(e, { value }) =>
-                                                    setCustomerName(
-                                                        value.substring(0, 50)
+                                    {/* <Form> */}
+                                    <div>
+                                        <TextField
+                                            fullWidth
+                                            label="Customer Name"
+                                            placeholder="Jace, the Mind Sculptor"
+                                            value={customerName}
+                                            onChange={(e) => {
+                                                setCustomerName(
+                                                    e.target.value.substring(
+                                                        0,
+                                                        50
                                                     )
-                                                }
-                                            />
-                                        </ClearMargin>
-                                        <ClearMargin>
-                                            <CharLimit>
-                                                {customerName.length}/50
-                                            </CharLimit>
-                                        </ClearMargin>
-                                        <ClearMargin>
-                                            <Form.TextArea
-                                                label="Notes"
-                                                placeholder="Sometimes, I forget things..."
-                                                value={notes}
-                                                onChange={(
-                                                    e,
-                                                    { value }: TextAreaProps
-                                                ) => {
-                                                    if (
-                                                        typeof value ===
-                                                        'string'
-                                                    ) {
-                                                        setNotes(
-                                                            value.substring(
-                                                                0,
-                                                                150
-                                                            )
-                                                        );
-                                                    }
-                                                }}
-                                            />
-                                        </ClearMargin>
-                                        <ClearMargin>
-                                            <CharLimit>
-                                                {notes.length}/150
-                                            </CharLimit>
-                                        </ClearMargin>
-                                        <Form.Button
-                                            id="suspend-sale-submit"
-                                            primary
-                                            disabled={disabled || !customerName}
-                                            loading={loadingBtn.suspendBtn}
-                                            onClick={submitSuspendSale}
-                                        >
-                                            Suspend Sale
-                                        </Form.Button>
-                                    </Form>
+                                                );
+                                            }}
+                                        />
+                                    </div>
+                                    <CharLimit text={customerName} limit={50} />
+                                    <div>
+                                        <TextField
+                                            multiline
+                                            minRows={3}
+                                            fullWidth
+                                            label="Notes"
+                                            placeholder="Sometimes, I forget things..."
+                                            value={notes}
+                                            onChange={(e) => {
+                                                setNotes(
+                                                    e.target.value.substring(
+                                                        0,
+                                                        150
+                                                    )
+                                                );
+                                            }}
+                                        />
+                                    </div>
+                                    <CharLimit text={notes} limit={150} />
+                                    <Button
+                                        primary
+                                        disabled={
+                                            disabled ||
+                                            !customerName ||
+                                            loadingBtn.suspendBtn
+                                        }
+                                        onClick={submitSuspendSale}
+                                    >
+                                        Suspend Sale
+                                    </Button>
+                                    {/* </Form> */}
                                 </Grid>
                             </React.Fragment>
                         )}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/15024562/132413838-23559c5f-dc8c-4989-a7c2-2d29456aa6dd.png)
(This is a serviceable work-in-progress design. My plans are to separate these two actions into separate workflows)

## Summary
This PR removes SUIR from `SuspendSaleButton`. It makes no attempt to cleanup the form entry logic or refactor/split this component out into other parts. Purely to work towards the SUIR-removal milestone.