### PR TITLE
Remove semantic UI css

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -26,7 +26,6 @@
                 "react-router-dom": "^5.2.1",
                 "react-scripts": "4.0.3",
                 "react-to-print": "^2.13.0",
-                "semantic-ui-css": "^2.4.1",
                 "styled-components": "^5.3.1",
                 "typescript": "^4.4.2",
                 "uuid": "^8.3.2"
@@ -19605,14 +19604,6 @@
             "integrity": "sha512-2P4PtieJeEwVgTU9QEcwIRDQ/mXJLX8/+I3ur+Pg16nS8oNbrGxEso9NyYWy8NAmXiNl4dlAp5MwoNeCWzON4w==",
             "dependencies": {
                 "node-forge": "^0.10.0"
-            }
-        },
-        "node_modules/semantic-ui-css": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/semantic-ui-css/-/semantic-ui-css-2.4.1.tgz",
-            "integrity": "sha512-Pkp0p9oWOxlH0kODx7qFpIRYpK1T4WJOO4lNnpNPOoWKCrYsfHqYSKgk5fHfQtnWnsAKy7nLJMW02bgDWWFZFg==",
-            "dependencies": {
-                "jquery": "x.*"
             }
         },
         "node_modules/semver": {
@@ -39398,14 +39389,6 @@
             "integrity": "sha512-2P4PtieJeEwVgTU9QEcwIRDQ/mXJLX8/+I3ur+Pg16nS8oNbrGxEso9NyYWy8NAmXiNl4dlAp5MwoNeCWzON4w==",
             "requires": {
                 "node-forge": "^0.10.0"
-            }
-        },
-        "semantic-ui-css": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/semantic-ui-css/-/semantic-ui-css-2.4.1.tgz",
-            "integrity": "sha512-Pkp0p9oWOxlH0kODx7qFpIRYpK1T4WJOO4lNnpNPOoWKCrYsfHqYSKgk5fHfQtnWnsAKy7nLJMW02bgDWWFZFg==",
-            "requires": {
-                "jquery": "x.*"
             }
         },
         "semver": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,7 +22,6 @@
         "react-router-dom": "^5.2.1",
         "react-scripts": "4.0.3",
         "react-to-print": "^2.13.0",
-        "semantic-ui-css": "^2.4.1",
         "styled-components": "^5.3.1",
         "typescript": "^4.4.2",
         "uuid": "^8.3.2"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,9 @@
-import { createMuiTheme, makeStyles, ThemeProvider } from '@material-ui/core';
+import {
+    createTheme,
+    CssBaseline,
+    makeStyles,
+    ThemeProvider,
+} from '@material-ui/core';
 import React, { FC } from 'react';
 import { Route, Switch } from 'react-router-dom';
 import AdminRoute from './AuthenticatedRoute';
@@ -32,10 +37,19 @@ const useStyles = makeStyles(({ spacing }) => ({
     },
 }));
 
-const theme = createMuiTheme({
+const theme = createTheme({
     palette: {
         primary: {
             main: '#2185d0',
+        },
+    },
+    overrides: {
+        MuiCssBaseline: {
+            '@global': {
+                a: {
+                    textDecoration: 'none',
+                },
+            },
         },
     },
 });
@@ -46,6 +60,7 @@ const App: FC = () => {
     return (
         <AuthProvider>
             <ThemeProvider theme={theme}>
+                <CssBaseline />
                 <ToastProvider>
                     <NavBar />
                     <Switch>

--- a/frontend/src/Sale/SaleSearchCardList.tsx
+++ b/frontend/src/Sale/SaleSearchCardList.tsx
@@ -18,15 +18,15 @@ const BrowseCardList: FC<Props> = ({ loading, term, cards }) => {
         if (term && !cards.length) {
             // Check to make sure the user has searched and no results
             return (
-                <p>
+                <>
                     Zero results for <em>{term}</em>
-                </p>
+                </>
             );
         }
         return (
-            <p>
+            <>
                 <em>"Don't give the people what they want"</em>
-            </p>
+            </>
         );
     };
 

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -2,7 +2,6 @@ import '@fontsource/roboto';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { HashRouter } from 'react-router-dom';
-import 'semantic-ui-css/semantic.min.css';
 import App from './App';
 import './index.css';
 import * as serviceWorker from './serviceWorker';


### PR DESCRIPTION
## Summary
In order for our former view library to display properly, it depended upon `semantic-ui-css`, which has now been uninstalled. Replacing it is MUI's out-of-the-box css reset component called `CssBaseline`.

After importing it, I'd noticed that links retained their `text-decoration`, which I chose to override in a global configuration on the theme.

There's also a minor fix to the sale view placeholder which caused some unnecessary padding, presumably from `<p />` tag defaults.