### PR TITLE
Refactor current API tests

### DIFF
--- a/monolith/interactors/addCardToInventory.test.ts
+++ b/monolith/interactors/addCardToInventory.test.ts
@@ -1,19 +1,19 @@
-const { MongoMemoryServer } = require('mongodb-memory-server');
-// TODO: We currently require in the built code. We should be requiring the TS file,
-// but this will require some finagling with tooling configs
-const {
-    default: addCardToInventory,
-} = require('../built/interactors/addCardToInventory');
-const getDatabaseConnection = require('../built/database').default;
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import getDatabaseConnection from '../database';
+import addCardToInventory from './addCardToInventory';
 
 let mongoServer;
 let db;
 
 // Set up the mongo memory instance
 beforeAll(async () => {
-    mongoServer = new MongoMemoryServer();
-    const uri = await mongoServer.getUri();
+    mongoServer = await MongoMemoryServer.create();
+    const uri = mongoServer.getUri();
     db = await getDatabaseConnection(uri);
+});
+
+afterAll(async () => {
+    await mongoServer.stop();
 });
 
 test('Single card addition', async () => {

--- a/monolith/interactors/getCardsWithInfo.test.ts
+++ b/monolith/interactors/getCardsWithInfo.test.ts
@@ -1,14 +1,8 @@
-const { MongoMemoryServer } = require('mongodb-memory-server');
-// TODO: We currently require in the built code. We should be requiring the TS file,
-// but this will require some finagling with tooling configs
-const {
-    default: getCardsWithInfo,
-} = require('../built/interactors/getCardsWithInfo');
-const {
-    default: addCardToInventory,
-} = require('../built/interactors/addCardToInventory');
-const getDatabaseConnection = require('../built/database').default;
-const bulkCard = require('../fixtures/fixtures');
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import getDatabaseConnection from '../database';
+import bulkCard from '../fixtures/fixtures';
+import addCardToInventory from './addCardToInventory';
+import getCardsWithInfo from './getCardsWithInfo';
 
 const SCRYFALL_BULK = 'scryfall_bulk_cards';
 
@@ -17,8 +11,8 @@ let db;
 
 // Set up the mongo memory instance
 beforeAll(async () => {
-    mongoServer = new MongoMemoryServer();
-    const uri = await mongoServer.getUri();
+    mongoServer = await MongoMemoryServer.create();
+    const uri = mongoServer.getUri();
     db = await getDatabaseConnection(uri);
 
     // Create fake bulk collection
@@ -37,6 +31,10 @@ beforeAll(async () => {
         set: bulkCard.set,
         location: 'ch1',
     });
+});
+
+afterAll(async () => {
+    await mongoServer.stop();
 });
 
 test('Fetching the bulk card to ensure it persisted', async () => {

--- a/monolith/interactors/updateInventoryCards.test.ts
+++ b/monolith/interactors/updateInventoryCards.test.ts
@@ -1,20 +1,15 @@
-const { MongoMemoryServer } = require('mongodb-memory-server');
-const { MongoClient } = require('mongodb');
-const {
-    default: addCardToInventory,
-} = require('../built/interactors/addCardToInventory');
-const {
-    updateInventoryCards,
-} = require('../built/interactors/updateInventoryCards');
-const getDatabaseConnection = require('../built/database').default;
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import getDatabaseConnection from '../database';
+import addCardToInventory from './addCardToInventory';
+import { updateInventoryCards } from './updateInventoryCards';
 
 let mongoServer;
 let db;
 
 // Set up the mongo memory instance
 beforeAll(async () => {
-    mongoServer = new MongoMemoryServer();
-    const uri = await mongoServer.getUri();
+    mongoServer = await MongoMemoryServer.create();
+    const uri = mongoServer.getUri();
     db = await getDatabaseConnection(uri);
 });
 

--- a/monolith/package-lock.json
+++ b/monolith/package-lock.json
@@ -38,7 +38,7 @@
                 "@types/request": "^2.48.5",
                 "@types/request-promise-native": "^1.0.17",
                 "jest": "^26.6.3",
-                "mongodb-memory-server": "^6.9.3",
+                "mongodb-memory-server": "^7.4.0",
                 "ts-jest": "^27.0.3",
                 "tslint": "^5.20.1",
                 "typescript": "^3.9.10"
@@ -1769,9 +1769,9 @@
             "dev": true
         },
         "node_modules/@types/tmp": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.0.tgz",
-            "integrity": "sha512-flgpHJjntpBAdJD43ShRosQvNC0ME97DCfGvZEDlAThQmnerRXrLbX6YgzRBQCZTthET9eAWFAMaYP0m0Y4HzQ==",
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.1.tgz",
+            "integrity": "sha512-7cTXwKP/HLOPVgjg+YhBdQ7bMiobGMuoBmrGmqwIWJv8elC6t1DfVc/mn4fD9UE1IjhwmhaQ5pGVXkmXbH0rhg==",
             "dev": true
         },
         "node_modules/@types/tough-cookie": {
@@ -2070,6 +2070,21 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/async-mutex": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.3.2.tgz",
+            "integrity": "sha512-HuTK7E7MT7jZEh1P9GtRW9+aTWiDWWi9InbZ5hjxrnRa39KS4BW04+xLBhYNS2aXhHUIKZSw3gj4Pn1pj+qGAA==",
+            "dev": true,
+            "dependencies": {
+                "tslib": "^2.3.1"
+            }
+        },
+        "node_modules/async-mutex/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+            "dev": true
         },
         "node_modules/asynckit": {
             "version": "0.4.0",
@@ -3851,9 +3866,9 @@
             }
         },
         "node_modules/find-cache-dir": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
-            "integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+            "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
             "dev": true,
             "dependencies": {
                 "commondir": "^1.0.1",
@@ -3866,12 +3881,6 @@
             "funding": {
                 "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
             }
-        },
-        "node_modules/find-package-json": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/find-package-json/-/find-package-json-1.2.0.tgz",
-            "integrity": "sha512-+SOGcLGYDJHtyqHd87ysBhmaeQ95oWspDKnMXBrnQ9Eq4OkLNqejgoaD8xVWu6GPa0B6roa6KinCMEMcVeqONw==",
-            "dev": true
         },
         "node_modules/find-up": {
             "version": "4.1.0",
@@ -7004,15 +7013,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/lockfile": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.4.tgz",
-            "integrity": "sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==",
-            "dev": true,
-            "dependencies": {
-                "signal-exit": "^3.0.2"
-            }
-        },
         "node_modules/lodash": {
             "version": "4.17.20",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
@@ -7314,14 +7314,14 @@
             }
         },
         "node_modules/mongodb": {
-            "version": "3.6.3",
-            "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.3.tgz",
-            "integrity": "sha512-rOZuR0QkodZiM+UbQE5kDsJykBqWi0CL4Ec2i1nrGrUI3KO11r6Fbxskqmq3JK2NH7aW4dcccBuUujAP0ERl5w==",
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.7.1.tgz",
+            "integrity": "sha512-iSVgexYr8ID0ieeNFUbRfQeOZxOchRck6kEDVySQRaa8VIw/1Pm+/LgcpZcl/BWV6nT0L8lP9qyl7dRPJ6mnLw==",
             "dependencies": {
                 "bl": "^2.2.1",
                 "bson": "^1.1.4",
                 "denque": "^1.4.1",
-                "require_optional": "^1.0.1",
+                "optional-require": "^1.0.3",
                 "safe-buffer": "^5.1.2"
             },
             "engines": {
@@ -7352,43 +7352,45 @@
             }
         },
         "node_modules/mongodb-memory-server": {
-            "version": "6.9.3",
-            "resolved": "https://registry.npmjs.org/mongodb-memory-server/-/mongodb-memory-server-6.9.3.tgz",
-            "integrity": "sha512-VU2ey+fknmZflHltPCznZr9fja8T6K7DTG5m7wSxmQC/Qf/kkKmRGqIPcZoEU5znRR/8m/EaOe+hFWkjmh1W5A==",
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/mongodb-memory-server/-/mongodb-memory-server-7.4.0.tgz",
+            "integrity": "sha512-V9sCsPprJxPMK68ZodidL6Z/J4DOziyGpGlx/VCIJfT6XcZ/907I8ZWGn3J92CWXPStsuIgW5wgFhPCH1RK35w==",
             "dev": true,
             "hasInstallScript": true,
             "dependencies": {
-                "mongodb-memory-server-core": "6.9.3"
+                "mongodb-memory-server-core": "7.4.0",
+                "tslib": "^2.3.0"
+            },
+            "engines": {
+                "node": ">=12.22.0"
             }
         },
         "node_modules/mongodb-memory-server-core": {
-            "version": "6.9.3",
-            "resolved": "https://registry.npmjs.org/mongodb-memory-server-core/-/mongodb-memory-server-core-6.9.3.tgz",
-            "integrity": "sha512-9ZaWemIQLbu9VG553ksMiV7TNnzICqXhSSQv/7Io6dnuO8VpoLLdd1wIz+r2YuWFP7U159JPWQc8QG9jIL27og==",
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/mongodb-memory-server-core/-/mongodb-memory-server-core-7.4.0.tgz",
+            "integrity": "sha512-y7/F+foGefthQVMhloHycjtkqStQtNvDRbpjkMN54FXm0+aE3qgUssFfBhfrxIhRHD2/g3Jm4Ms47WmLUPVQlA==",
             "dev": true,
             "dependencies": {
                 "@types/tmp": "^0.2.0",
-                "camelcase": "^6.0.0",
-                "cross-spawn": "^7.0.3",
+                "async-mutex": "^0.3.2",
+                "camelcase": "^6.1.0",
                 "debug": "^4.2.0",
-                "find-cache-dir": "^3.3.1",
-                "find-package-json": "^1.2.0",
+                "find-cache-dir": "^3.3.2",
                 "get-port": "^5.1.1",
                 "https-proxy-agent": "^5.0.0",
-                "lockfile": "^1.0.4",
                 "md5-file": "^5.0.0",
                 "mkdirp": "^1.0.4",
-                "semver": "^7.3.2",
+                "mongodb": "^3.6.9",
+                "new-find-package-json": "^1.1.0",
+                "semver": "^7.3.5",
                 "tar-stream": "^2.1.4",
                 "tmp": "^0.2.1",
-                "uuid": "8.3.0",
+                "tslib": "^2.3.0",
+                "uuid": "^8.3.1",
                 "yauzl": "^2.10.0"
             },
             "engines": {
-                "node": ">=10.15.0"
-            },
-            "optionalDependencies": {
-                "mongodb": "3.6.2"
+                "node": ">=12.22.0"
             }
         },
         "node_modules/mongodb-memory-server-core/node_modules/camelcase": {
@@ -7403,24 +7405,10 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/mongodb-memory-server-core/node_modules/cross-spawn": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-            "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-            "dev": true,
-            "dependencies": {
-                "path-key": "^3.1.0",
-                "shebang-command": "^2.0.0",
-                "which": "^2.0.1"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
         "node_modules/mongodb-memory-server-core/node_modules/debug": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-            "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+            "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
             "dev": true,
             "dependencies": {
                 "ms": "2.1.2"
@@ -7446,45 +7434,16 @@
                 "node": ">=10"
             }
         },
-        "node_modules/mongodb-memory-server-core/node_modules/mongodb": {
-            "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.2.tgz",
-            "integrity": "sha512-sSZOb04w3HcnrrXC82NEh/YGCmBuRgR+C1hZgmmv4L6dBz4BkRse6Y8/q/neXer9i95fKUBbFi4KgeceXmbsOA==",
-            "dev": true,
-            "optional": true,
-            "dependencies": {
-                "bl": "^2.2.1",
-                "bson": "^1.1.4",
-                "denque": "^1.4.1",
-                "require_optional": "^1.0.1",
-                "safe-buffer": "^5.1.2"
-            },
-            "engines": {
-                "node": ">=4"
-            },
-            "optionalDependencies": {
-                "saslprep": "^1.0.0"
-            }
-        },
         "node_modules/mongodb-memory-server-core/node_modules/ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
             "dev": true
         },
-        "node_modules/mongodb-memory-server-core/node_modules/path-key": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/mongodb-memory-server-core/node_modules/semver": {
-            "version": "7.3.4",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-            "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+            "version": "7.3.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+            "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
             "dev": true,
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -7496,50 +7455,26 @@
                 "node": ">=10"
             }
         },
-        "node_modules/mongodb-memory-server-core/node_modules/shebang-command": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-            "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-            "dev": true,
-            "dependencies": {
-                "shebang-regex": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/mongodb-memory-server-core/node_modules/shebang-regex": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
+        "node_modules/mongodb-memory-server-core/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+            "dev": true
         },
         "node_modules/mongodb-memory-server-core/node_modules/uuid": {
-            "version": "8.3.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
-            "integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==",
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
             "dev": true,
             "bin": {
                 "uuid": "dist/bin/uuid"
             }
         },
-        "node_modules/mongodb-memory-server-core/node_modules/which": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-            "dev": true,
-            "dependencies": {
-                "isexe": "^2.0.0"
-            },
-            "bin": {
-                "node-which": "bin/node-which"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
+        "node_modules/mongodb-memory-server/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+            "dev": true
         },
         "node_modules/morgan": {
             "version": "1.10.0",
@@ -7642,6 +7577,48 @@
             "engines": {
                 "node": ">= 0.6"
             }
+        },
+        "node_modules/new-find-package-json": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/new-find-package-json/-/new-find-package-json-1.1.0.tgz",
+            "integrity": "sha512-KOH3BNZcTKPzEkaJgG2iSUaurxKmefqRKmCOYH+8xqJytNIgjqU4J88BHfK+gy/UlEzlhccLyuJDJAcCgexSwA==",
+            "dev": true,
+            "dependencies": {
+                "debug": "^4.3.2",
+                "tslib": "^2.3.0"
+            },
+            "engines": {
+                "node": ">=12.22.0"
+            }
+        },
+        "node_modules/new-find-package-json/node_modules/debug": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+            "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+            "dev": true,
+            "dependencies": {
+                "ms": "2.1.2"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/new-find-package-json/node_modules/ms": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+            "dev": true
+        },
+        "node_modules/new-find-package-json/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+            "dev": true
         },
         "node_modules/nice-try": {
             "version": "1.0.5",
@@ -7960,6 +7937,17 @@
             "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
             "dependencies": {
                 "wordwrap": "~0.0.2"
+            }
+        },
+        "node_modules/optional-require": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.1.7.tgz",
+            "integrity": "sha512-cIeRZocXsZnZYn+SevbtSqNlLbeoS4mLzuNn4fvXRMDRNhTGg0sxuKXl0FnZCtnew85LorNxIbZp5OeliILhMw==",
+            "dependencies": {
+                "require-at": "^1.0.6"
+            },
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/optionator": {
@@ -8564,13 +8552,12 @@
                 "request": "^2.34"
             }
         },
-        "node_modules/require_optional": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
-            "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
-            "dependencies": {
-                "resolve-from": "^2.0.0",
-                "semver": "^5.1.0"
+        "node_modules/require-at": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/require-at/-/require-at-1.0.6.tgz",
+            "integrity": "sha512-7i1auJbMUrXEAZCOQ0VNJgmcT2VOKPRl2YGJwgpHpC9CE91Mv4/4UYIUm4chGJaI381ZDq1JUicFii64Hapd8g==",
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/require-directory": {
@@ -8620,14 +8607,6 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/resolve-from": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-            "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/resolve-url": {
@@ -9597,7 +9576,7 @@
                 "readable-stream": "^3.4.0"
             }
         },
-        "node_modules/tar-stream/node_modules/bl/node_modules/inherits": {
+        "node_modules/tar-stream/node_modules/inherits": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
@@ -12097,9 +12076,9 @@
             "dev": true
         },
         "@types/tmp": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.0.tgz",
-            "integrity": "sha512-flgpHJjntpBAdJD43ShRosQvNC0ME97DCfGvZEDlAThQmnerRXrLbX6YgzRBQCZTthET9eAWFAMaYP0m0Y4HzQ==",
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.1.tgz",
+            "integrity": "sha512-7cTXwKP/HLOPVgjg+YhBdQ7bMiobGMuoBmrGmqwIWJv8elC6t1DfVc/mn4fD9UE1IjhwmhaQ5pGVXkmXbH0rhg==",
             "dev": true
         },
         "@types/tough-cookie": {
@@ -12330,6 +12309,23 @@
             "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
             "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
             "dev": true
+        },
+        "async-mutex": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.3.2.tgz",
+            "integrity": "sha512-HuTK7E7MT7jZEh1P9GtRW9+aTWiDWWi9InbZ5hjxrnRa39KS4BW04+xLBhYNS2aXhHUIKZSw3gj4Pn1pj+qGAA==",
+            "dev": true,
+            "requires": {
+                "tslib": "^2.3.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+                    "dev": true
+                }
+            }
         },
         "asynckit": {
             "version": "0.4.0",
@@ -13728,21 +13724,15 @@
             }
         },
         "find-cache-dir": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
-            "integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+            "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
             "dev": true,
             "requires": {
                 "commondir": "^1.0.1",
                 "make-dir": "^3.0.2",
                 "pkg-dir": "^4.1.0"
             }
-        },
-        "find-package-json": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/find-package-json/-/find-package-json-1.2.0.tgz",
-            "integrity": "sha512-+SOGcLGYDJHtyqHd87ysBhmaeQ95oWspDKnMXBrnQ9Eq4OkLNqejgoaD8xVWu6GPa0B6roa6KinCMEMcVeqONw==",
-            "dev": true
         },
         "find-up": {
             "version": "4.1.0",
@@ -16117,15 +16107,6 @@
                 "p-locate": "^4.1.0"
             }
         },
-        "lockfile": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.4.tgz",
-            "integrity": "sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==",
-            "dev": true,
-            "requires": {
-                "signal-exit": "^3.0.2"
-            }
-        },
         "lodash": {
             "version": "4.17.20",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
@@ -16367,49 +16348,58 @@
             "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
         },
         "mongodb": {
-            "version": "3.6.3",
-            "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.3.tgz",
-            "integrity": "sha512-rOZuR0QkodZiM+UbQE5kDsJykBqWi0CL4Ec2i1nrGrUI3KO11r6Fbxskqmq3JK2NH7aW4dcccBuUujAP0ERl5w==",
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.7.1.tgz",
+            "integrity": "sha512-iSVgexYr8ID0ieeNFUbRfQeOZxOchRck6kEDVySQRaa8VIw/1Pm+/LgcpZcl/BWV6nT0L8lP9qyl7dRPJ6mnLw==",
             "requires": {
                 "bl": "^2.2.1",
                 "bson": "^1.1.4",
                 "denque": "^1.4.1",
-                "require_optional": "^1.0.1",
+                "optional-require": "^1.0.3",
                 "safe-buffer": "^5.1.2",
                 "saslprep": "^1.0.0"
             }
         },
         "mongodb-memory-server": {
-            "version": "6.9.3",
-            "resolved": "https://registry.npmjs.org/mongodb-memory-server/-/mongodb-memory-server-6.9.3.tgz",
-            "integrity": "sha512-VU2ey+fknmZflHltPCznZr9fja8T6K7DTG5m7wSxmQC/Qf/kkKmRGqIPcZoEU5znRR/8m/EaOe+hFWkjmh1W5A==",
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/mongodb-memory-server/-/mongodb-memory-server-7.4.0.tgz",
+            "integrity": "sha512-V9sCsPprJxPMK68ZodidL6Z/J4DOziyGpGlx/VCIJfT6XcZ/907I8ZWGn3J92CWXPStsuIgW5wgFhPCH1RK35w==",
             "dev": true,
             "requires": {
-                "mongodb-memory-server-core": "6.9.3"
+                "mongodb-memory-server-core": "7.4.0",
+                "tslib": "^2.3.0"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+                    "dev": true
+                }
             }
         },
         "mongodb-memory-server-core": {
-            "version": "6.9.3",
-            "resolved": "https://registry.npmjs.org/mongodb-memory-server-core/-/mongodb-memory-server-core-6.9.3.tgz",
-            "integrity": "sha512-9ZaWemIQLbu9VG553ksMiV7TNnzICqXhSSQv/7Io6dnuO8VpoLLdd1wIz+r2YuWFP7U159JPWQc8QG9jIL27og==",
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/mongodb-memory-server-core/-/mongodb-memory-server-core-7.4.0.tgz",
+            "integrity": "sha512-y7/F+foGefthQVMhloHycjtkqStQtNvDRbpjkMN54FXm0+aE3qgUssFfBhfrxIhRHD2/g3Jm4Ms47WmLUPVQlA==",
             "dev": true,
             "requires": {
                 "@types/tmp": "^0.2.0",
-                "camelcase": "^6.0.0",
-                "cross-spawn": "^7.0.3",
+                "async-mutex": "^0.3.2",
+                "camelcase": "^6.1.0",
                 "debug": "^4.2.0",
-                "find-cache-dir": "^3.3.1",
-                "find-package-json": "^1.2.0",
+                "find-cache-dir": "^3.3.2",
                 "get-port": "^5.1.1",
                 "https-proxy-agent": "^5.0.0",
-                "lockfile": "^1.0.4",
                 "md5-file": "^5.0.0",
                 "mkdirp": "^1.0.4",
-                "mongodb": "3.6.2",
-                "semver": "^7.3.2",
+                "mongodb": "^3.6.9",
+                "new-find-package-json": "^1.1.0",
+                "semver": "^7.3.5",
                 "tar-stream": "^2.1.4",
                 "tmp": "^0.2.1",
-                "uuid": "8.3.0",
+                "tslib": "^2.3.0",
+                "uuid": "^8.3.1",
                 "yauzl": "^2.10.0"
             },
             "dependencies": {
@@ -16419,21 +16409,10 @@
                     "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
                     "dev": true
                 },
-                "cross-spawn": {
-                    "version": "7.0.3",
-                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-                    "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-                    "dev": true,
-                    "requires": {
-                        "path-key": "^3.1.0",
-                        "shebang-command": "^2.0.0",
-                        "which": "^2.0.1"
-                    }
-                },
                 "debug": {
-                    "version": "4.3.1",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-                    "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+                    "version": "4.3.2",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+                    "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
                     "dev": true,
                     "requires": {
                         "ms": "2.1.2"
@@ -16445,71 +16424,32 @@
                     "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
                     "dev": true
                 },
-                "mongodb": {
-                    "version": "3.6.2",
-                    "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.2.tgz",
-                    "integrity": "sha512-sSZOb04w3HcnrrXC82NEh/YGCmBuRgR+C1hZgmmv4L6dBz4BkRse6Y8/q/neXer9i95fKUBbFi4KgeceXmbsOA==",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "bl": "^2.2.1",
-                        "bson": "^1.1.4",
-                        "denque": "^1.4.1",
-                        "require_optional": "^1.0.1",
-                        "safe-buffer": "^5.1.2",
-                        "saslprep": "^1.0.0"
-                    }
-                },
                 "ms": {
                     "version": "2.1.2",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
                     "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
                     "dev": true
                 },
-                "path-key": {
-                    "version": "3.1.1",
-                    "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-                    "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-                    "dev": true
-                },
                 "semver": {
-                    "version": "7.3.4",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-                    "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+                    "version": "7.3.5",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+                    "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
                     "dev": true,
                     "requires": {
                         "lru-cache": "^6.0.0"
                     }
                 },
-                "shebang-command": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-                    "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-                    "dev": true,
-                    "requires": {
-                        "shebang-regex": "^3.0.0"
-                    }
-                },
-                "shebang-regex": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-                    "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+                "tslib": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
                     "dev": true
                 },
                 "uuid": {
-                    "version": "8.3.0",
-                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
-                    "integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==",
+                    "version": "8.3.2",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+                    "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
                     "dev": true
-                },
-                "which": {
-                    "version": "2.0.2",
-                    "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-                    "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-                    "dev": true,
-                    "requires": {
-                        "isexe": "^2.0.0"
-                    }
                 }
             }
         },
@@ -16599,6 +16539,39 @@
             "version": "0.6.2",
             "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
             "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
+        },
+        "new-find-package-json": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/new-find-package-json/-/new-find-package-json-1.1.0.tgz",
+            "integrity": "sha512-KOH3BNZcTKPzEkaJgG2iSUaurxKmefqRKmCOYH+8xqJytNIgjqU4J88BHfK+gy/UlEzlhccLyuJDJAcCgexSwA==",
+            "dev": true,
+            "requires": {
+                "debug": "^4.3.2",
+                "tslib": "^2.3.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.3.2",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+                    "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.1.2"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                },
+                "tslib": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+                    "dev": true
+                }
+            }
         },
         "nice-try": {
             "version": "1.0.5",
@@ -16857,6 +16830,14 @@
             "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
             "requires": {
                 "wordwrap": "~0.0.2"
+            }
+        },
+        "optional-require": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.1.7.tgz",
+            "integrity": "sha512-cIeRZocXsZnZYn+SevbtSqNlLbeoS4mLzuNn4fvXRMDRNhTGg0sxuKXl0FnZCtnew85LorNxIbZp5OeliILhMw==",
+            "requires": {
+                "require-at": "^1.0.6"
             }
         },
         "optionator": {
@@ -17315,14 +17296,10 @@
                 "tough-cookie": "^2.3.3"
             }
         },
-        "require_optional": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
-            "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
-            "requires": {
-                "resolve-from": "^2.0.0",
-                "semver": "^5.1.0"
-            }
+        "require-at": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/require-at/-/require-at-1.0.6.tgz",
+            "integrity": "sha512-7i1auJbMUrXEAZCOQ0VNJgmcT2VOKPRl2YGJwgpHpC9CE91Mv4/4UYIUm4chGJaI381ZDq1JUicFii64Hapd8g=="
         },
         "require-directory": {
             "version": "2.1.1",
@@ -17362,11 +17339,6 @@
                     "dev": true
                 }
             }
-        },
-        "resolve-from": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-            "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
         },
         "resolve-url": {
             "version": "0.2.1",
@@ -18160,15 +18132,13 @@
                         "buffer": "^5.5.0",
                         "inherits": "^2.0.4",
                         "readable-stream": "^3.4.0"
-                    },
-                    "dependencies": {
-                        "inherits": {
-                            "version": "2.0.4",
-                            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-                            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-                            "dev": true
-                        }
                     }
+                },
+                "inherits": {
+                    "version": "2.0.4",
+                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+                    "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+                    "dev": true
                 },
                 "readable-stream": {
                     "version": "3.6.0",

--- a/monolith/package.json
+++ b/monolith/package.json
@@ -43,7 +43,7 @@
         "@types/request": "^2.48.5",
         "@types/request-promise-native": "^1.0.17",
         "jest": "^26.6.3",
-        "mongodb-memory-server": "^6.9.3",
+        "mongodb-memory-server": "^7.4.0",
         "ts-jest": "^27.0.3",
         "tslint": "^5.20.1",
         "typescript": "^3.9.10"


### PR DESCRIPTION
## Summary
Previous iterations of our API unit testing suite tested against directly built code, which was not a sustainable pattern. Here, we colocate associated interactor tests, and update `mongodb-memory-server` to a new version. This supports v7 and its associated M1 processor changes.

