### PR TITLE
Edits to bulk update

### DIFF
--- a/gc_functions/db_scripts/update_scryfall_bulk/collectionUpkeep.ts
+++ b/gc_functions/db_scripts/update_scryfall_bulk/collectionUpkeep.ts
@@ -7,7 +7,7 @@ async function collectionUpkeep(databaseName: string) {
 
     try {
         const { MONGO_URI } = process.env;
-        var client = await MongoClient.connect(MONGO_URI, mongoSettings); // 'const' scopes to the block, we need access in 'finally' to close the connection
+        var client = await MongoClient.connect(MONGO_URI, mongoSettings);
         const db = await client.db(databaseName || "test");
 
         console.log(`Connected to MongoDB database: ${db.databaseName}`);

--- a/gc_functions/db_scripts/update_scryfall_bulk/collectionUpkeep.ts
+++ b/gc_functions/db_scripts/update_scryfall_bulk/collectionUpkeep.ts
@@ -1,0 +1,38 @@
+require("dotenv").config();
+const MongoClient = require("mongodb").MongoClient;
+const COLLECTION = "scryfall_bulk_cards";
+
+async function collectionUpkeep(databaseName: string) {
+    const mongoSettings = { useNewUrlParser: true, useUnifiedTopology: true };
+
+    try {
+        const { MONGO_URI } = process.env;
+        var client = await MongoClient.connect(MONGO_URI, mongoSettings); // 'const' scopes to the block, we need access in 'finally' to close the connection
+        const db = await client.db(databaseName || "test");
+
+        console.log(`Connected to MongoDB database: ${db.databaseName}`);
+
+        // Recreate desired collection indexes
+        console.log("Recreating collection indexes...");
+        await db
+            .collection(COLLECTION)
+            .createIndexes([
+                { key: { id: 1 } },
+                { key: { name: 1, games: 1 } },
+                { key: { name: 1 } },
+            ]);
+        console.log("Collection indexes recreated");
+
+        // Delete all elements in the collection
+        console.log("Deleting collection documents...");
+        await db.collection(COLLECTION).deleteMany({});
+        console.log("Documents deleted, preparing to insert fresh cards");
+    } catch (error) {
+        throw error;
+    } finally {
+        await client.close();
+        console.log("Disconnected from MongoDB");
+    }
+}
+
+export default collectionUpkeep;

--- a/gc_functions/db_scripts/update_scryfall_bulk/index.ts
+++ b/gc_functions/db_scripts/update_scryfall_bulk/index.ts
@@ -1,4 +1,5 @@
 import yargs from "yargs";
+import collectionUpkeep from "./collectionUpkeep";
 import getLanguageCards from "./getLanguageCards";
 import mongoBulkImport from "./mongoBulkImport";
 import saveScryfallBulk from "./saveScryfallBulk";
@@ -25,20 +26,19 @@ async function init() {
 
         await saveScryfallBulk("all_cards"); // Save all_cards locally
 
+        await collectionUpkeep(database); // Maintain indexes and clear documents
+
+        // Add English cards
         console.log("Collating English cards...");
         const sourceEnglish = await getLanguageCards(SOURCE_JSON_URI, "en"); // Grab all English cards
         console.log(`Updating bulk for ${sourceEnglish.length} cards...`);
         await mongoBulkImport(sourceEnglish, database); // Persist them
 
-        /**
-         * Uncomment this if Japanese cards are required
-         *
-         * We might think about separating this out as another package.json command, but it's rarely used
-         */
-        // console.log("Collating Japanese cards...");
-        // const sourceJapanese = await getLanguageCards(SOURCE_JSON_URI, "ja"); // Grab all Japanese cards
-        // console.log(`Updating bulk for ${sourceJapanese.length} cards...`);
-        // await mongoBulkImport(sourceJapanese, database); // Persist them
+        // Add Japanese cards
+        console.log("Collating Japanese cards...");
+        const sourceJapanese = await getLanguageCards(SOURCE_JSON_URI, "ja"); // Grab all Japanese cards
+        console.log(`Updating bulk for ${sourceJapanese.length} cards...`);
+        await mongoBulkImport(sourceJapanese, database); // Persist them
 
         console.timeEnd("bulkUpdate");
         console.log(


### PR DESCRIPTION
## Summary
These changes to the update script effectively clear the collection completely, rebuild its indexes if necessary, and re-insert cards via bulk update, rather than upserting, which is not backwards-compatible with Scryfall API changes. The tradeoff here being that we must stay vigilant of Scryfall's changelog going forward so as not to accidentally clear the collection and re-insert data that is shaped differently.

This change is intended to take effect when the new `finishes` array support goes live.