### PR TITLE
Support "undo" for bulk card addition

### DIFF
--- a/frontend/src/BulkInventory/BulkInventory.tsx
+++ b/frontend/src/BulkInventory/BulkInventory.tsx
@@ -120,9 +120,9 @@ const BulkInventory: FC = () => {
                 });
             }
 
-            setSubmittedCards([
-                ...submittedCards.filter((c) => c.uuid !== values.uuid),
-            ]);
+            setSubmittedCards(
+                submittedCards.filter((c) => c.uuid !== values.uuid)
+            );
         } catch (err) {
             console.log(err);
             createToast({

--- a/frontend/src/BulkInventory/BulkInventory.tsx
+++ b/frontend/src/BulkInventory/BulkInventory.tsx
@@ -9,6 +9,7 @@ import {
 } from '@material-ui/core';
 import { useFormik } from 'formik';
 import React, { FC, useEffect, useState } from 'react';
+import { v4 as uuid } from 'uuid';
 import CardImage from '../common/CardImage';
 import addCardToInventoryQuery from '../ManageInventory/addCardToInventoryQuery';
 import Button from '../ui/Button';
@@ -42,19 +43,24 @@ const useStyles = makeStyles(({ palette }) => ({
     },
 }));
 
-export interface FormValues {
+interface FormValues {
     bulkCard: BulkCard | null;
     finish: Finish;
     quantity: string;
     condition: Condition;
 }
 
+export type AddedCard = FormValues & { uuid: string };
+
 const BulkInventory: FC = () => {
     const { imageContainer, placeholderImage } = useStyles();
     const [currentCardImage, setCurrentCardImage] = useState<string>('');
-    const [submittedCards, setSubmittedCards] = useState<FormValues[]>([]);
+    const [submittedCards, setSubmittedCards] = useState<AddedCard[]>([]);
     const createToast = useToastContext();
 
+    /**
+     * Adds a card to inventory
+     */
     const onSubmit = async (values: FormValues) => {
         try {
             if (values.bulkCard) {
@@ -77,12 +83,50 @@ const BulkInventory: FC = () => {
                     severity: 'success',
                 });
             }
-            setSubmittedCards([values, ...submittedCards]);
+            setSubmittedCards([{ ...values, uuid: uuid() }, ...submittedCards]);
             resetForm();
         } catch (err) {
             console.log(err);
             createToast({
                 message: `Error adding card`,
+                severity: 'error',
+            });
+        }
+    };
+
+    /**
+     * Removes a card from inventory as well as the array of added cards
+     */
+    const onRemove = async (values: AddedCard) => {
+        try {
+            if (values.bulkCard) {
+                await addCardToInventoryQuery({
+                    quantity: -Number(values.quantity),
+                    finishCondition: createFinishCondition(
+                        values.finish,
+                        values.condition
+                    ),
+                    cardInfo: {
+                        id: values.bulkCard.scryfall_id,
+                        name: values.bulkCard.name,
+                        set_name: values.bulkCard.set_name,
+                        set: values.bulkCard.set_abbreviation,
+                    },
+                });
+
+                createToast({
+                    message: `Removed ${values.quantity}x ${values.bulkCard.name} from inventory`,
+                    severity: 'success',
+                });
+            }
+
+            setSubmittedCards([
+                ...submittedCards.filter((c) => c.uuid !== values.uuid),
+            ]);
+        } catch (err) {
+            console.log(err);
+            createToast({
+                message: `Error removing card`,
                 severity: 'error',
             });
         }
@@ -219,7 +263,10 @@ const BulkInventory: FC = () => {
             {submittedCards.length > 0 && (
                 <div>
                     <SectionText>Recently added cards</SectionText>
-                    <SubmittedCardsTable cards={submittedCards} />
+                    <SubmittedCardsTable
+                        cards={submittedCards}
+                        onRemove={onRemove}
+                    />
                 </div>
             )}
         </Container>

--- a/frontend/src/BulkInventory/SubmittedCardsTable.tsx
+++ b/frontend/src/BulkInventory/SubmittedCardsTable.tsx
@@ -7,14 +7,29 @@ import {
     TableHead,
     TableRow,
 } from '@material-ui/core';
-import React, { FC } from 'react';
-import { FormValues } from './BulkInventory';
+import React, { FC, useState } from 'react';
+import Button from '../ui/Button';
+import { AddedCard } from './BulkInventory';
 
 interface Props {
-    cards: FormValues[];
+    cards: AddedCard[];
+    onRemove: (values: AddedCard) => void;
 }
 
-const SubmittedCardsTable: FC<Props> = ({ cards }) => {
+const SubmittedCardsTable: FC<Props> = ({ cards, onRemove }) => {
+    const [onRemoveLoading, setOnRemoveLoading] = useState<boolean>(false);
+
+    const doRemove = async (card: AddedCard) => {
+        try {
+            setOnRemoveLoading(true);
+            await onRemove(card);
+        } catch (e) {
+            console.log(e);
+        } finally {
+            setOnRemoveLoading(false);
+        }
+    };
+
     return (
         <TableContainer component={Paper} variant="outlined">
             <Table size="small">
@@ -32,6 +47,7 @@ const SubmittedCardsTable: FC<Props> = ({ cards }) => {
                         <TableCell>
                             <b>Condition</b>
                         </TableCell>
+                        <TableCell />
                     </TableRow>
                 </TableHead>
                 <TableBody>
@@ -58,6 +74,14 @@ const SubmittedCardsTable: FC<Props> = ({ cards }) => {
                                         <TableCell>{quantity}</TableCell>
                                         <TableCell>{finish}</TableCell>
                                         <TableCell>{condition}</TableCell>
+                                        <TableCell align="right">
+                                            <Button
+                                                onClick={() => doRemove(c)}
+                                                disabled={onRemoveLoading}
+                                            >
+                                                Remove
+                                            </Button>
+                                        </TableCell>
                                     </TableRow>
                                 );
                             } else return null;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/15024562/135314747-a73d4847-c31e-41b3-a260-e371dca750f9.png)

## Summary
This PR enables support for "undo" functionality when adding bulk cards. If a user mistakenly added a card to inventory, there was no clean way to allow them to undo this action without manually navigating to the "manage inventory" screen to make edits there.

Here, we assign a `uuid` to each card entry which allows us to cleanly remove it from `submittedCards` (card metadata alone was not sufficient to prove uniqueness). `SubmittedCardsTable` is in charge of locking its UI to prevent multiple `onRemove` submissions.

Notably, I separated the form value interface from that of the added cards to separate concerns.