### PR TITLE
GH-Pages build script refactors

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,6 +30,7 @@
         "analyze": "source-map-explorer 'build/static/js/*.js'",
         "start": "react-scripts start",
         "build": "react-scripts build",
+        "build-pages": "rm -r ../docs && npm run build && mv ./build ../docs",
         "test": "react-scripts test",
         "eject": "react-scripts eject",
         "typecheck": "tsc --noEmit"


### PR DESCRIPTION
## Summary
We were performing too many manual tasks on release:
1. Version bump
2. Running `npm build`
3. Moving `/build` up a level
4. Deleting `/docs`
5. Renaming `/build` to `/docs`

Shell scripting to the rescue!