### PR TITLE
Do not reset sale state on error

### DIFF
--- a/frontend/src/context/SaleContext.tsx
+++ b/frontend/src/context/SaleContext.tsx
@@ -243,8 +243,6 @@ export const SaleProvider: FC<Props> = ({ children }) => {
                 severity: 'error',
                 message: 'Sale was not created',
             });
-
-            resetSaleState();
         }
     };
 


### PR DESCRIPTION
## Summary
When handlers error, we should not be resetting state, especially in views where users spend the majority of their time inputting list data. It can lead to lost time and effort.