### PR TITLE
Reduce suspension payload size

### DIFF
--- a/frontend/src/context/SaleContext.tsx
+++ b/frontend/src/context/SaleContext.tsx
@@ -179,7 +179,23 @@ export const SaleProvider: FC<Props> = ({ children }) => {
             const data = await createSuspendedSaleQuery({
                 customerName: customerName,
                 notes: notes,
-                saleList: saleListCards,
+                saleList: saleListCards.map(
+                    ({
+                        id,
+                        price,
+                        qtyToSell,
+                        finishCondition,
+                        name,
+                        set_name,
+                    }) => ({
+                        id,
+                        price,
+                        qtyToSell,
+                        finishCondition,
+                        name,
+                        set_name,
+                    })
+                ),
             });
 
             resetSaleState();

--- a/frontend/src/context/createSuspendedSaleQuery.ts
+++ b/frontend/src/context/createSuspendedSaleQuery.ts
@@ -1,11 +1,20 @@
 import http from '../common/http';
 import { SUSPEND_SALE } from '../utils/endpoints';
-import { SaleListCard } from './SaleContext';
+import { FinishCondition } from '../utils/ScryfallCard';
+
+interface FinishSaleCard {
+    id: string;
+    price: number;
+    qtyToSell: number;
+    finishCondition: FinishCondition;
+    name: string;
+    set_name: string;
+}
 
 interface Payload {
     customerName: string;
     notes: string;
-    saleList: SaleListCard[];
+    saleList: FinishSaleCard[];
 }
 
 interface ResponseData {

--- a/monolith/common/RawScryfallCard.ts
+++ b/monolith/common/RawScryfallCard.ts
@@ -1,4 +1,4 @@
-export default interface ScryfallCard {
+export default interface RawScryfallCard {
     object: string;
     id: string;
     oracle_id: string;

--- a/monolith/common/ScryfallApiCard.ts
+++ b/monolith/common/ScryfallApiCard.ts
@@ -1,0 +1,73 @@
+import createDisplayName from '../lib/createDisplayName';
+import getCardImage from '../lib/getCardImage';
+import RawScryfallCard, { CardFacesEntity } from './ScryfallCard';
+
+// Language codes from Scryfall. See https://scryfall.com/docs/api/languages for reference.
+export type LanguageCode =
+    | 'en'
+    | 'es'
+    | 'fr'
+    | 'de'
+    | 'it'
+    | 'pt'
+    | 'ja'
+    | 'ko'
+    | 'ru'
+    | 'zhs'
+    | 'zht'
+    | 'he'
+    | 'la'
+    | 'grc'
+    | 'ar'
+    | 'sa'
+    | 'px';
+
+type Color = 'W' | 'U' | 'B' | 'R' | 'G';
+
+type Finishes = ('foil' | 'nonfoil' | 'etched' | 'glossy')[];
+
+export class ScryfallCard {
+    public id: string;
+    public name: string;
+    public printed_name: string | null;
+    public set: string;
+    public set_name: string;
+    public rarity: string;
+    public image_uris: { normal: string };
+    public card_faces: CardFacesEntity[];
+    public finishes: Finishes;
+    public colors: Color[];
+    public type_line: string;
+    public frame_effects: string[];
+    public lang: LanguageCode;
+    public border_color: string;
+    public display_name: string;
+    public cardImage: string;
+    public color_identity: Color[];
+    public promo_types: string[];
+    public tcgplayer_id: number | null;
+    public keywords: string[];
+
+    public constructor(card: RawScryfallCard) {
+        this.id = card.id;
+        this.name = card.name;
+        this.printed_name = card.printed_name || null;
+        this.set = card.set;
+        this.set_name = card.set_name;
+        this.rarity = card.rarity;
+        this.image_uris = card.image_uris || null;
+        this.card_faces = card.card_faces || [];
+        this.finishes = card.finishes;
+        this.colors = (card.colors || []) as Color[];
+        this.type_line = card.type_line;
+        this.frame_effects = card.frame_effects || [];
+        this.lang = card.lang as LanguageCode;
+        this.border_color = card.border_color;
+        this.color_identity = (card.color_identity || null) as Color[];
+        this.promo_types = card.promo_types || [];
+        this.keywords = card.keywords || [];
+        this.cardImage = getCardImage(this);
+        this.display_name = createDisplayName(this);
+        this.tcgplayer_id = card.tcgplayer_id || null;
+    }
+}

--- a/monolith/common/ScryfallApiCard.ts
+++ b/monolith/common/ScryfallApiCard.ts
@@ -26,7 +26,7 @@ type Color = 'W' | 'U' | 'B' | 'R' | 'G';
 
 type Finishes = ('foil' | 'nonfoil' | 'etched' | 'glossy')[];
 
-export class ScryfallCard {
+export class ScryfallApiCard {
     public id: string;
     public name: string;
     public printed_name: string | null;

--- a/monolith/common/ScryfallApiCard.ts
+++ b/monolith/common/ScryfallApiCard.ts
@@ -1,6 +1,6 @@
 import createDisplayName from '../lib/createDisplayName';
 import getCardImage from '../lib/getCardImage';
-import RawScryfallCard, { CardFacesEntity } from './ScryfallCard';
+import RawScryfallCard, { CardFacesEntity } from './RawScryfallCard';
 
 // Language codes from Scryfall. See https://scryfall.com/docs/api/languages for reference.
 export type LanguageCode =

--- a/monolith/common/ScryfallApiCard.ts
+++ b/monolith/common/ScryfallApiCard.ts
@@ -2,6 +2,7 @@ import createDisplayName from '../lib/createDisplayName';
 import getCardImage from '../lib/getCardImage';
 import RawScryfallCard, { CardFacesEntity } from './RawScryfallCard';
 
+// TODO: This belongs in RawScryfallCard
 // Language codes from Scryfall. See https://scryfall.com/docs/api/languages for reference.
 export type LanguageCode =
     | 'en'
@@ -22,8 +23,10 @@ export type LanguageCode =
     | 'sa'
     | 'px';
 
+// TODO: This belongs in RawScryfallCard
 type Color = 'W' | 'U' | 'B' | 'R' | 'G';
 
+// TODO: This belongs in RawScryfallCard
 type Finishes = ('foil' | 'nonfoil' | 'etched' | 'glossy')[];
 
 export class ScryfallApiCard {

--- a/monolith/common/ScryfallCard.ts
+++ b/monolith/common/ScryfallCard.ts
@@ -57,6 +57,8 @@ export default interface ScryfallCard {
     purchase_uris: PurchaseUris;
     image_uris?: ImageUris;
     finishes: ('foil' | 'nonfoil' | 'etched' | 'glossy')[];
+    printed_name?: string;
+    colors: string[];
 }
 
 export interface CardFacesEntity {
@@ -66,6 +68,7 @@ export interface CardFacesEntity {
     type_line: string;
     oracle_text: string;
     colors?: string[] | null;
+    color_identity?: string[] | null;
     power: string;
     toughness: string;
     artist: string;

--- a/monolith/controllers/createSuspendedSaleController.ts
+++ b/monolith/controllers/createSuspendedSaleController.ts
@@ -39,10 +39,7 @@ const createSuspendedSaleController: Controller<ReqWithSuspendSale> = async (
 
     const { error }: JoiValidation<SuspendSaleBody> = schema.validate(
         req.body,
-        {
-            abortEarly: false,
-            allowUnknown: true,
-        }
+        { abortEarly: false }
     );
 
     if (error) {

--- a/monolith/interactors/createSuspendedSale.test.ts
+++ b/monolith/interactors/createSuspendedSale.test.ts
@@ -1,11 +1,13 @@
 import { MongoMemoryServer } from 'mongodb-memory-server';
 import { FinishSaleCard } from '../common/types';
 import getDatabaseConnection from '../database';
+import timeSpiral from '../fixtures/fixtures';
 import addCardToInventory from './addCardToInventory';
 import createSuspendedSale from './createSuspendedSale';
 
 let mongoServer;
 let db;
+const bulkId = timeSpiral.id;
 
 // Set up the mongo memory instance
 beforeAll(async () => {
@@ -13,14 +15,27 @@ beforeAll(async () => {
     const uri = mongoServer.getUri();
     db = await getDatabaseConnection(uri);
 
+    // Seed bulk data
+    await db.collection('scryfall_bulk_cards').bulkWrite([
+        {
+            updateOne: {
+                filter: { _id: bulkId }, // upsert the inserted cards to have a String _id rather than ObjectId
+                update: {
+                    $set: { ...timeSpiral },
+                },
+                upsert: true,
+            },
+        },
+    ]);
+
     // Seed inventory with data
     await addCardToInventory({
         quantity: 4,
         finishCondition: 'NONFOIL_NM',
-        id: '2345',
-        name: 'Card Name',
-        set_name: 'Set Name',
-        set: 'SNM',
+        id: bulkId,
+        name: timeSpiral.name,
+        set_name: timeSpiral.set_name,
+        set: timeSpiral.set,
         location: 'ch1',
     });
 });
@@ -34,12 +49,12 @@ test('Suspending sale with invalid available inventory', async () => {
 
     const saleListCards: FinishSaleCard[] = [
         {
-            id: '2345',
+            id: bulkId,
             price: 2.34,
             qtyToSell: 5,
             finishCondition: 'NONFOIL_NM',
-            name: 'Card Name',
-            set_name: 'SNM',
+            name: timeSpiral.name,
+            set_name: timeSpiral.set,
         },
     ];
 
@@ -54,18 +69,18 @@ test('Suspending sale with invalid available inventory', async () => {
         error = e;
     }
 
-    expect(error.message).toBe(`Card Name's QOH of 5 exceeds inventory of 4`);
+    expect(error.message).toBe(`Time Spiral's QOH of 5 exceeds inventory of 4`);
 });
 
 test('Suspending sale with available inventory', async () => {
     const saleListCards: FinishSaleCard[] = [
         {
-            id: '2345',
+            id: bulkId,
             price: 2.34,
             qtyToSell: 1,
             finishCondition: 'NONFOIL_NM',
-            name: 'Card Name',
-            set_name: 'SNM',
+            name: timeSpiral.name,
+            set_name: timeSpiral.set,
         },
     ];
 
@@ -78,17 +93,17 @@ test('Suspending sale with available inventory', async () => {
 
     const foundDoc = await db
         .collection('card_inventory')
-        .findOne({ _id: '2345' });
+        .findOne({ _id: bulkId });
 
     expect(foundDoc).toMatchInlineSnapshot(`
 Object {
-  "_id": "2345",
-  "name": "Card Name",
+  "_id": "f3d62dbd-63db-4ac9-950f-9852627f23f2",
+  "name": "Time Spiral",
   "qoh": Object {
     "NONFOIL_NM": 3,
   },
-  "set": "SNM",
-  "set_name": "Set Name",
+  "set": "usg",
+  "set_name": "Urza's Saga",
 }
 `);
 });

--- a/monolith/interactors/createSuspendedSale.ts
+++ b/monolith/interactors/createSuspendedSale.ts
@@ -1,6 +1,6 @@
 import moment from 'moment';
+import RawScryfallCard from '../common/RawScryfallCard';
 import { ScryfallCard } from '../common/ScryfallApiCard';
-import ApiCard from '../common/ScryfallCard';
 import { ClubhouseLocation, Collection, FinishSaleCard } from '../common/types';
 import getDatabaseConnection from '../database';
 import collectionFromLocation from '../lib/collectionFromLocation';
@@ -40,11 +40,11 @@ async function validateInventory(
 /**
  * Finds a bulk card by its associated `_id`
  */
-async function findBulkById(id: string): Promise<ApiCard> {
+async function findBulkById(id: string): Promise<RawScryfallCard> {
     try {
         const db = await getDatabaseConnection();
 
-        const card: ApiCard = await db
+        const card: RawScryfallCard = await db
             .collection(Collection.scryfallBulkCards)
             .findOne({ _id: id });
 

--- a/monolith/interactors/createSuspendedSale.ts
+++ b/monolith/interactors/createSuspendedSale.ts
@@ -1,6 +1,6 @@
 import moment from 'moment';
 import RawScryfallCard from '../common/RawScryfallCard';
-import { ScryfallCard } from '../common/ScryfallApiCard';
+import { ScryfallApiCard } from '../common/ScryfallApiCard';
 import { ClubhouseLocation, Collection, FinishSaleCard } from '../common/types';
 import getDatabaseConnection from '../database';
 import collectionFromLocation from '../lib/collectionFromLocation';
@@ -102,7 +102,7 @@ async function createSuspendedSale(
                 currentSaleListCard;
 
             return {
-                ...new ScryfallCard(bc),
+                ...new ScryfallApiCard(bc),
                 price,
                 qtyToSell,
                 finishCondition,

--- a/monolith/interactors/deleteSuspendedSale.test.ts
+++ b/monolith/interactors/deleteSuspendedSale.test.ts
@@ -1,6 +1,7 @@
 import { MongoMemoryServer } from 'mongodb-memory-server';
 import { FinishSaleCard } from '../common/types';
 import getDatabaseConnection from '../database';
+import timeSpiral from '../fixtures/fixtures';
 import collectionFromLocation from '../lib/collectionFromLocation';
 import addCardToInventory from './addCardToInventory';
 import createSuspendedSale from './createSuspendedSale';
@@ -9,6 +10,7 @@ import getSuspendedSales from './getSuspendedSales';
 
 let mongoServer;
 let db;
+const bulkId = timeSpiral.id;
 
 // Set up the mongo memory instance
 beforeAll(async () => {
@@ -16,14 +18,27 @@ beforeAll(async () => {
     const uri = mongoServer.getUri();
     db = await getDatabaseConnection(uri);
 
+    // Seed bulk data
+    await db.collection('scryfall_bulk_cards').bulkWrite([
+        {
+            updateOne: {
+                filter: { _id: bulkId }, // upsert the inserted cards to have a String _id rather than ObjectId
+                update: {
+                    $set: { ...timeSpiral },
+                },
+                upsert: true,
+            },
+        },
+    ]);
+
     const saleListCards: FinishSaleCard[] = [
         {
-            id: '4567',
+            id: bulkId,
             price: 2.34,
             qtyToSell: 2,
             finishCondition: 'NONFOIL_NM',
-            name: 'Card Name',
-            set_name: 'SNM',
+            name: timeSpiral.name,
+            set_name: timeSpiral.set_name,
         },
     ];
 
@@ -31,10 +46,10 @@ beforeAll(async () => {
     await addCardToInventory({
         quantity: 4,
         finishCondition: 'NONFOIL_NM',
-        id: '4567',
-        name: 'Card Name',
-        set_name: 'Set Name',
-        set: 'SNM',
+        id: bulkId,
+        name: timeSpiral.name,
+        set_name: timeSpiral.set_name,
+        set: timeSpiral.set,
         location: 'ch1',
     });
 
@@ -59,7 +74,7 @@ test('Deleting suspended sale restores inventory', async () => {
 
     const beforeSuspendDoc = await db
         .collection(collectionFromLocation('ch1').cardInventory)
-        .findOne({ _id: '4567' });
+        .findOne({ _id: bulkId });
 
     expect(beforeSuspendDoc.qoh.NONFOIL_NM).toBe(2);
 
@@ -67,7 +82,7 @@ test('Deleting suspended sale restores inventory', async () => {
 
     const afterSuspendDoc = await db
         .collection(collectionFromLocation('ch1').cardInventory)
-        .findOne({ _id: '4567' });
+        .findOne({ _id: bulkId });
 
     expect(afterSuspendDoc.qoh.NONFOIL_NM).toBe(4);
 });

--- a/monolith/interactors/getCardPrintings.ts
+++ b/monolith/interactors/getCardPrintings.ts
@@ -1,4 +1,4 @@
-import ScryfallCard from '../common/ScryfallCard';
+import RawScryfallCard from '../common/RawScryfallCard';
 import { Collection } from '../common/types';
 import getDatabaseConnection from '../database';
 import cardDisplayName from '../lib/cardDisplayName';
@@ -15,7 +15,7 @@ class BulkCard {
     public frame: string;
     public image: string;
 
-    constructor(card: ScryfallCard) {
+    constructor(card: RawScryfallCard) {
         this.scryfall_id = card.id;
         this.name = card.name;
         this.display_name = cardDisplayName(card);

--- a/monolith/interactors/getSalesReport.ts
+++ b/monolith/interactors/getSalesReport.ts
@@ -1,4 +1,4 @@
-import ScryfallCard from '../common/ScryfallCard';
+import RawScryfallCard from '../common/RawScryfallCard';
 import {
     ClubhouseLocation,
     Collection,
@@ -17,7 +17,7 @@ interface CountByPrinting {
     };
     quantity_sold: number;
     card_title: string;
-    card_metadata: ScryfallCard;
+    card_metadata: RawScryfallCard;
     quantity_on_hand: QOH;
 }
 

--- a/monolith/lib/cardDisplayName.ts
+++ b/monolith/lib/cardDisplayName.ts
@@ -1,9 +1,9 @@
-import ScryfallCard from '../common/ScryfallCard';
+import RawScryfallCard from '../common/RawScryfallCard';
 
 /**
  * Creates a detailed user-friendly name for cards to discern what they are, without imagery
  */
-function cardDisplayName(card: ScryfallCard): string {
+function cardDisplayName(card: RawScryfallCard): string {
     const treatments: string[] = [];
     const baseTitle = card.name;
     const setName = card.set_name;

--- a/monolith/lib/cardImageUrl.ts
+++ b/monolith/lib/cardImageUrl.ts
@@ -1,6 +1,6 @@
-import ScryfallCard from '../common/ScryfallCard';
+import RawScryfallCard from '../common/RawScryfallCard';
 
-const cardImageUrl = (card: ScryfallCard) => {
+const cardImageUrl = (card: RawScryfallCard) => {
     let myImage: string;
 
     try {

--- a/monolith/lib/createDisplayName.ts
+++ b/monolith/lib/createDisplayName.ts
@@ -1,7 +1,7 @@
-import { ScryfallCard } from '../common/ScryfallApiCard';
+import { ScryfallApiCard } from '../common/ScryfallApiCard';
 
 type Card = Pick<
-    ScryfallCard,
+    ScryfallApiCard,
     | 'name'
     | 'frame_effects'
     | 'border_color'

--- a/monolith/lib/createDisplayName.ts
+++ b/monolith/lib/createDisplayName.ts
@@ -1,0 +1,38 @@
+import { ScryfallCard } from '../common/ScryfallApiCard';
+
+type Card = Pick<
+    ScryfallCard,
+    | 'name'
+    | 'frame_effects'
+    | 'border_color'
+    | 'lang'
+    | 'finishes'
+    | 'promo_types'
+>;
+
+/** Computes the proper displayName for a card, depending on its properties */
+const createDisplayName = (card: Card) => {
+    const { name, frame_effects, border_color, lang, promo_types } = card;
+
+    let displayName: string = name;
+
+    // Covers cards like Godzilla series
+    if (promo_types.includes('godzillaseries')) {
+        displayName += ` (IP series)`;
+        // Covers showcase cards like comic-art Illuna, Apex of Wishes
+    } else if (frame_effects.includes('showcase')) {
+        displayName += ` (Showcase)`;
+        // Covers cards like comic-art Vivien, Monsters' Advocate
+    } else if (frame_effects.length === 0 && border_color === 'borderless') {
+        displayName += ` (Borderless)`;
+        // Covers cards with extended left and roght border art
+    } else if (frame_effects.includes('extendedart')) {
+        displayName += ` (Extended art)`;
+    }
+
+    if (lang !== 'en') displayName += ` (${lang.toUpperCase()})`;
+
+    return displayName;
+};
+
+export default createDisplayName;

--- a/monolith/lib/getCardImage.ts
+++ b/monolith/lib/getCardImage.ts
@@ -1,6 +1,6 @@
-import { ScryfallCard } from '../common/ScryfallApiCard';
+import { ScryfallApiCard } from '../common/ScryfallApiCard';
 
-const getCardImage = (card: ScryfallCard) => {
+const getCardImage = (card: ScryfallApiCard) => {
     let myImage: string;
 
     try {

--- a/monolith/lib/getCardImage.ts
+++ b/monolith/lib/getCardImage.ts
@@ -1,0 +1,15 @@
+import { ScryfallCard } from '../common/ScryfallApiCard';
+
+const getCardImage = (card: ScryfallCard) => {
+    let myImage: string;
+
+    try {
+        // If normal prop doesn't exist, move to catch block for flip card faces
+        myImage = card.image_uris.normal;
+    } catch (e) {
+        myImage = card.card_faces[0].image_uris.normal;
+    }
+
+    return myImage;
+};
+export default getCardImage;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/15024562/135735265-3cd51862-c9e4-424a-9f86-b4c3d59eaee8.png)

## Summary
When suspending a sale, we originally passed the transformed SuspendSaleContext state directly to the backend, which persisted it. However, for particularly large lists, the server would issue a `413 Payload too large` error, which was frustrating. I intend this PR to be the first step towards streamlining and decoupling the API and frontend from Scryfall's API.

In this PR, we instead pass only the required properties needed to identify a card in a sale, and instead find those cards server-side and persist them, thereby reducing payload size substantially. This involved duplicating the frontend `ScryfallCard` class to the backend, and using it to transform the raw bulk cards found, which allowed us to match previously suspended sales in a backwards-compatible way.

My hope is that with this class in the backend, we can now pass highly opinionated card objects to the frontend, reducing the need for mapping raw Scryfall card objects we have typically returned using the `getCardsWithInfo` controller, and greatly reducing (possibly eliminating!) frontend coupling to Scryfall's card object shape.
