### PR TITLE
Improve `getCardsByFilter` performance and support colors array

### DIFF
--- a/frontend/src/BrowseInventory/BrowseInventory.tsx
+++ b/frontend/src/BrowseInventory/BrowseInventory.tsx
@@ -75,20 +75,17 @@ const BrowseInventory: FC = () => {
                 finish: filters.finish || undefined,
                 colors:
                     filters.colorsArray.length > 0
-                        ? filters.colorsArray
-                              .map((c) => {
-                                  const colorsMap: Record<string, string> = {
-                                      White: 'W',
-                                      Blue: 'U',
-                                      Black: 'B',
-                                      Red: 'R',
-                                      Green: 'G',
-                                  };
+                        ? filters.colorsArray.map((c) => {
+                              const colorsMap: Record<string, string> = {
+                                  White: 'W',
+                                  Blue: 'U',
+                                  Black: 'B',
+                                  Red: 'R',
+                                  Green: 'G',
+                              };
 
-                                  return colorsMap[c];
-                              })
-                              .sort()
-                              .join('')
+                              return colorsMap[c];
+                          })
                         : undefined,
                 colorSpecificity: filters.colorSpecificity || undefined,
                 type: filters.typeLine || undefined,

--- a/frontend/src/BrowseInventory/filteredCardsQuery.ts
+++ b/frontend/src/BrowseInventory/filteredCardsQuery.ts
@@ -9,7 +9,7 @@ export interface Filters {
     minPrice?: number;
     maxPrice?: number;
     finish?: string;
-    colors?: string;
+    colors?: string[];
     colorSpecificity?: string;
     type?: string;
     frame?: string;

--- a/monolith/common/validations.ts
+++ b/monolith/common/validations.ts
@@ -33,3 +33,5 @@ export const validPrice = Joi.number().min(0).required();
 export const validTradeType = Joi.string()
     .valid(Trade.Cash, Trade.Credit)
     .required();
+const validColor = Joi.string().valid('W', 'U', 'B', 'R', 'G');
+export const validColors = Joi.array().items(validColor);

--- a/monolith/controllers/getCardsByFilterController.ts
+++ b/monolith/controllers/getCardsByFilterController.ts
@@ -13,6 +13,7 @@ import {
     TypeLine,
 } from '../common/types';
 import {
+    validColors,
     validColorSpecificity,
     validFinish,
     validFormatLegalities,
@@ -29,7 +30,7 @@ export interface GetCardsByFilterQuery {
     setName?: string;
     format?: FormatLegality;
     finish?: Finish;
-    colors?: string;
+    colors?: string[];
     sortBy?: SortBy;
     colorSpecificity?: ColorSpecificity;
     type?: TypeLine;
@@ -49,7 +50,7 @@ const getCardsByFilterController: Controller<RequestWithUserInfo> = async (
         setName: validString,
         format: validFormatLegalities,
         finish: validFinish,
-        colors: validString,
+        colors: validColors,
         sortBy: validSort,
         colorSpecificity: validColorSpecificity,
         type: validTypeline,

--- a/monolith/interactors/getCardsByFilter.ts
+++ b/monolith/interactors/getCardsByFilter.ts
@@ -18,7 +18,7 @@ const LIMIT = 100;
  * sortBy - `name` or `price`
  * sortByDirection - `1` or `-1`
  * page - used to modify internal SKIP constant for pagination
- * colors - a sorted string, used to identify cards by one or more colors
+ * colors - an array of colors
  * type - the typeline search, like `Artifact` or `Creature`
  * frame - the desired frame effect filter (borderless, extended-art, showcase, etc)
  */


### PR DESCRIPTION
## Summary
Scryfall's recent migration left orphaned documents in the `card_inventory` collection that won't ever be matched to their respective bulk in a `$lookup` pipeline operation. Therefore, this PR attempts to exclude them from further pipeline operations using a preemptive measure.

Additionally, we have lightly modified the client to send `colors` as an array rather than a joined string, which improves comparisons and no longer requires complex array operations from the bulk card end.