### PR TITLE
Auth controller error handling

### DIFF
--- a/monolith/controllers/authController.ts
+++ b/monolith/controllers/authController.ts
@@ -28,39 +28,39 @@ const authController: Controller<RequestWithUserInfo> = async (
         token = token.slice(7, token.length);
     }
 
-    if (token) {
-        try {
-            // Will throw error if validation fails
-            const { userId, currentLocation } = jwt.verify(
-                token,
-                process.env.PRIVATE_KEY
-            ) as DecodedToken;
+    if (!token) {
+        return res.status(401).json('no token present on request');
+    }
 
-            const user: User = await getUserById(userId);
+    try {
+        // Will throw error if validation fails
+        const { userId, currentLocation } = jwt.verify(
+            token,
+            process.env.PRIVATE_KEY
+        ) as DecodedToken;
 
-            // Attach current location information to the req
-            // TODO: This should eventually just be a "store id"
-            req.currentLocation = currentLocation;
+        const user: User = await getUserById(userId);
 
-            // Attach user information
-            req.userId = userId;
-            req.locations = user.locations;
-            req.lightspeedEmployeeNumber = user.lightspeedEmployeeNumber;
+        // Attach current location information to the req
+        // TODO: This should eventually just be a "store id"
+        req.currentLocation = currentLocation;
 
-            // Flag admins
-            req.isAdmin = user.locations.length === 2;
+        // Attach user information
+        req.userId = userId;
+        req.locations = user.locations;
+        req.lightspeedEmployeeNumber = user.lightspeedEmployeeNumber;
 
-            console.log(
-                `Operation started by ${user.username} at location ${currentLocation}`
-            );
+        // Flag admins
+        req.isAdmin = user.locations.length === 2;
 
-            return next();
-        } catch (err) {
-            console.log(err);
-            res.status(401).send('Invalid token');
-        }
-    } else {
-        res.status(401).send('No token present on request');
+        console.log(
+            `Operation started by ${user.username} at location ${currentLocation}`
+        );
+
+        return next();
+    } catch (err) {
+        console.log(err);
+        res.status(401).json('invalid token');
     }
 };
 

--- a/monolith/routes/auth.ts
+++ b/monolith/routes/auth.ts
@@ -23,7 +23,7 @@ import {
 } from '../controllers';
 const router = express.Router();
 
-router.use(authController);
+router.use(errorBoundary(authController));
 router.post('/addCardToInventory', errorBoundary(addCardToInventoryController));
 router.post('/finishSale', errorBoundary(finishSaleValidationController));
 router.post('/finishSale', errorBoundary(finishSaleController));

--- a/monolith/routes/index.ts
+++ b/monolith/routes/index.ts
@@ -34,7 +34,7 @@ router.post('/jwt', async (req: JwtRequest, res) => {
 
         const token = await getJwt(username, password, currentLocation);
 
-        res.status(200).send(token);
+        res.status(200).json(token);
     } catch (err) {
         console.log(err);
         res.status(500).json(err);
@@ -63,7 +63,7 @@ router.get('/autocomplete', async (req, res) => {
 
     try {
         const results = await autocomplete(value.title);
-        res.status(200).send(results);
+        res.status(200).json(results);
     } catch (err) {
         console.log(err);
         res.status(500).json(err);
@@ -98,7 +98,7 @@ router.get('/getCardsWithInfo', async (req, res) => {
         const { title, matchInStock, location } = value;
 
         const message = await getCardsWithInfo(title, matchInStock, location);
-        res.status(200).send(message);
+        res.status(200).json(message);
     } catch (err) {
         console.log(err);
         res.status(500).json(err);
@@ -125,7 +125,7 @@ router.get('/getCardFromAllLocations', async (req, res) => {
 
     try {
         const message = await getCardFromAllLocations(value.title);
-        res.status(200).send(message);
+        res.status(200).json(message);
     } catch (err) {
         console.log(err);
         res.status(500).json(err);


### PR DESCRIPTION
## Summary
Rounds out the last few PR's by wrapping the authentication controller in an error boundary, and lightly refactoring its functionality to check for `!token` first as a short-circuit.

Also moves a few remaining `.send` response calls to `.json`.