### PR TITLE
Toast UI errors

### DIFF
--- a/frontend/src/BrowseInventory/BrowseInventory.tsx
+++ b/frontend/src/BrowseInventory/BrowseInventory.tsx
@@ -18,6 +18,7 @@ import SearchIcon from '@material-ui/icons/Search';
 import Pagination from '@material-ui/lab/Pagination';
 import React, { FC, useState } from 'react';
 import Placeholder from '../ui/Placeholder';
+import { useToastContext } from '../ui/ToastContext';
 import BrowseInventoryForm, {
     FormValues,
     initialFilters,
@@ -47,6 +48,7 @@ interface State {
 }
 
 const BrowseInventory: FC = () => {
+    const { createToast, createErrorToast } = useToastContext();
     const [state, setState] = useState<State>({
         cards: [],
         count: 0,
@@ -114,6 +116,7 @@ const BrowseInventory: FC = () => {
             });
         } catch (err) {
             console.log(err);
+            createErrorToast(err);
         }
     };
 

--- a/frontend/src/BrowseInventory/BrowseInventoryForm.tsx
+++ b/frontend/src/BrowseInventory/BrowseInventoryForm.tsx
@@ -11,6 +11,7 @@ import Button from '../ui/Button';
 import ControlledDropdown, { DropdownOption } from '../ui/ControlledDropdown';
 import ControlledMultiSelect from '../ui/ControlledMultiSelect';
 import ControlledSearchBar from '../ui/ControlledSearchBar';
+import { useToastContext } from '../ui/ToastContext';
 import { SectionText } from '../ui/Typography';
 import setNameQuery from './setNameQuery';
 
@@ -128,6 +129,7 @@ const FormContainer = withStyles(({ spacing }) => ({
 }))(Paper);
 
 const BrowseInventoryForm: FC<Props> = ({ doSubmit }) => {
+    const { createErrorToast } = useToastContext();
     const [editionDropdownOptions, setEditionDropdownOptions] = useState<
         DropdownOption[]
     >([]);
@@ -141,6 +143,7 @@ const BrowseInventoryForm: FC<Props> = ({ doSubmit }) => {
             );
         } catch (err) {
             console.log(err);
+            createErrorToast(err);
         }
     };
 

--- a/frontend/src/BrowseReceiving/BrowseReceivingListDialog.tsx
+++ b/frontend/src/BrowseReceiving/BrowseReceivingListDialog.tsx
@@ -15,6 +15,7 @@ import CardImageTooltip from '../ui/CardImageTooltip';
 import Loading from '../ui/Loading';
 import MetaData from '../ui/MetaData';
 import SetIcon from '../ui/SetIcon';
+import { useToastContext } from '../ui/ToastContext';
 import displayEmpty from '../utils/displayEmpty';
 import displayFinishCondition from '../utils/finishCondition';
 import formatDate from '../utils/formatDate';
@@ -38,6 +39,7 @@ function displayTrade(trade: Trade) {
 }
 
 const BrowseReceivingListDialog: FC<Props> = ({ receivedId, onClose }) => {
+    const { createErrorToast } = useToastContext();
     const [loading, setLoading] = useState<boolean>(false);
     const [data, setData] = useState<Received | null>(null);
 
@@ -50,6 +52,7 @@ const BrowseReceivingListDialog: FC<Props> = ({ receivedId, onClose }) => {
                 setLoading(false);
             } catch (err) {
                 console.log(err);
+                createErrorToast(err);
             }
         })();
     }, []);

--- a/frontend/src/BulkInventory/BulkInventory.tsx
+++ b/frontend/src/BulkInventory/BulkInventory.tsx
@@ -56,7 +56,7 @@ const BulkInventory: FC = () => {
     const { imageContainer, placeholderImage } = useStyles();
     const [currentCardImage, setCurrentCardImage] = useState<string>('');
     const [submittedCards, setSubmittedCards] = useState<AddedCard[]>([]);
-    const createToast = useToastContext();
+    const { createToast } = useToastContext();
 
     /**
      * Adds a card to inventory

--- a/frontend/src/BulkInventory/BulkInventory.tsx
+++ b/frontend/src/BulkInventory/BulkInventory.tsx
@@ -56,7 +56,7 @@ const BulkInventory: FC = () => {
     const { imageContainer, placeholderImage } = useStyles();
     const [currentCardImage, setCurrentCardImage] = useState<string>('');
     const [submittedCards, setSubmittedCards] = useState<AddedCard[]>([]);
-    const { createToast } = useToastContext();
+    const { createToast, createErrorToast } = useToastContext();
 
     /**
      * Adds a card to inventory
@@ -87,10 +87,7 @@ const BulkInventory: FC = () => {
             resetForm();
         } catch (err) {
             console.log(err);
-            createToast({
-                message: `Error adding card`,
-                severity: 'error',
-            });
+            createErrorToast(err);
         }
     };
 
@@ -125,10 +122,7 @@ const BulkInventory: FC = () => {
             );
         } catch (err) {
             console.log(err);
-            createToast({
-                message: `Error removing card`,
-                severity: 'error',
-            });
+            createErrorToast(err);
         }
     };
 

--- a/frontend/src/BulkInventory/BulkSearchBar.tsx
+++ b/frontend/src/BulkInventory/BulkSearchBar.tsx
@@ -13,6 +13,7 @@ import React, {
     useState,
 } from 'react';
 import SetIcon from '../ui/SetIcon';
+import { useToastContext } from '../ui/ToastContext';
 import bulkInventoryQuery, { BulkCard } from './bulkInventoryQuery';
 
 export type Option = BulkCard;
@@ -34,6 +35,7 @@ interface Props {
 
 const BulkSearchBar: FC<Props> = ({ value, onChange, onHighlight }) => {
     const classes = useStyles();
+    const { createErrorToast } = useToastContext();
     const [loading, setLoading] = useState<boolean>(false);
     const [options, setOptions] = useState<Option[]>([]);
     const [internalValue, setInternalValue] = useState<Option | null>(value);
@@ -87,8 +89,9 @@ const BulkSearchBar: FC<Props> = ({ value, onChange, onHighlight }) => {
             setInternalValue(value);
             await onChange(value);
             setLoading(false);
-        } catch (e) {
-            console.log(e);
+        } catch (err) {
+            console.log(err);
+            createErrorToast(err);
         }
     };
 

--- a/frontend/src/BulkInventory/SubmittedCardsTable.tsx
+++ b/frontend/src/BulkInventory/SubmittedCardsTable.tsx
@@ -9,6 +9,7 @@ import {
 } from '@material-ui/core';
 import React, { FC, useState } from 'react';
 import Button from '../ui/Button';
+import { useToastContext } from '../ui/ToastContext';
 import { AddedCard } from './BulkInventory';
 
 interface Props {
@@ -17,14 +18,16 @@ interface Props {
 }
 
 const SubmittedCardsTable: FC<Props> = ({ cards, onRemove }) => {
+    const { createErrorToast } = useToastContext();
     const [onRemoveLoading, setOnRemoveLoading] = useState<boolean>(false);
 
     const doRemove = async (card: AddedCard) => {
         try {
             setOnRemoveLoading(true);
             await onRemove(card);
-        } catch (e) {
-            console.log(e);
+        } catch (err) {
+            console.log(err);
+            createErrorToast(err);
         } finally {
             setOnRemoveLoading(false);
         }

--- a/frontend/src/Login/Login.tsx
+++ b/frontend/src/Login/Login.tsx
@@ -62,7 +62,7 @@ const validate = ({ username, password, location }: FormValues) => {
 const Login = () => {
     const { formGap } = useStyles();
     const { isLoggedIn, handleLogin } = useAuthContext();
-    const createToast = useToastContext();
+    const { createToast } = useToastContext();
 
     const onSubmit = async ({ username, password, location }: FormValues) => {
         if (!location) return;

--- a/frontend/src/ManageInventory/ManageInventoryListItem.tsx
+++ b/frontend/src/ManageInventory/ManageInventoryListItem.tsx
@@ -16,7 +16,7 @@ interface Props {
 }
 
 const ManageInventoryListItem: FC<Props> = ({ card }) => {
-    const createToast = useToastContext();
+    const { createToast } = useToastContext();
     const { finishes, name, set_name, set, id, cardImage } = card;
 
     // Defaults to 'NONFOIL', but the form component will manage this for us

--- a/frontend/src/ManageInventory/ManageInventoryListItem.tsx
+++ b/frontend/src/ManageInventory/ManageInventoryListItem.tsx
@@ -16,7 +16,7 @@ interface Props {
 }
 
 const ManageInventoryListItem: FC<Props> = ({ card }) => {
-    const { createToast } = useToastContext();
+    const { createToast, createErrorToast } = useToastContext();
     const { finishes, name, set_name, set, id, cardImage } = card;
 
     // Defaults to 'NONFOIL', but the form component will manage this for us
@@ -52,6 +52,7 @@ const ManageInventoryListItem: FC<Props> = ({ card }) => {
             $('#searchBar').focus().select();
         } catch (err) {
             console.log(err);
+            createErrorToast(err);
         }
     };
 

--- a/frontend/src/ManageInventory/TotalStoreInventory.tsx
+++ b/frontend/src/ManageInventory/TotalStoreInventory.tsx
@@ -1,6 +1,7 @@
 import { Box, makeStyles, Typography } from '@material-ui/core';
 import React, { FC, useEffect, useState } from 'react';
 import InventoryChip from '../ui/InventoryChip';
+import { useToastContext } from '../ui/ToastContext';
 import { ClientCard } from '../utils/ClientCard';
 import allLocationInventoryQuery, {
     ResponseData,
@@ -31,6 +32,7 @@ interface Props {
 }
 
 const TotalStoreInventory: FC<Props> = ({ title, searchResults }) => {
+    const { createErrorToast } = useToastContext();
     const { labelContainer, chipContainer } = useStyles();
     const [quantities, setQuantities] = useState<ResponseData>({
         ch1: { foilQty: 0, nonfoilQty: 0, etchedQty: 0 },
@@ -48,6 +50,7 @@ const TotalStoreInventory: FC<Props> = ({ title, searchResults }) => {
                 setLoading(false);
             } catch (err) {
                 console.log(err);
+                createErrorToast(err);
             }
         })();
     }, [title, searchResults]);

--- a/frontend/src/Receiving/ReceivingSearchItem.tsx
+++ b/frontend/src/Receiving/ReceivingSearchItem.tsx
@@ -15,7 +15,7 @@ interface Props {
 }
 
 const ReceivingSearchItem: FC<Props> = ({ card }) => {
-    const createToast = useToastContext();
+    const { createToast } = useToastContext();
     const { addToList } = useReceivingContext();
     const { cardImage, finishes, name } = card;
     // Defaults to 'NONFOIL', but the form component will manage this for us

--- a/frontend/src/context/ReceivingContext.tsx
+++ b/frontend/src/context/ReceivingContext.tsx
@@ -66,7 +66,7 @@ interface AddToListMeta {
 const ReceivingContext = createContext<Context>(defaultContext);
 
 const ReceivingProvider: FC<Props> = ({ children }) => {
-    const createToast = useToastContext();
+    const { createToast } = useToastContext();
     const [searchResults, setSearchResults] = useState<ClientCard[]>([]);
     const [receivingList, setReceivingList] = useState<ReceivingCard[]>([]);
 

--- a/frontend/src/context/ReceivingContext.tsx
+++ b/frontend/src/context/ReceivingContext.tsx
@@ -66,7 +66,7 @@ interface AddToListMeta {
 const ReceivingContext = createContext<Context>(defaultContext);
 
 const ReceivingProvider: FC<Props> = ({ children }) => {
-    const { createToast } = useToastContext();
+    const { createToast, createErrorToast } = useToastContext();
     const [searchResults, setSearchResults] = useState<ClientCard[]>([]);
     const [receivingList, setReceivingList] = useState<ReceivingCard[]>([]);
 
@@ -192,12 +192,9 @@ const ReceivingProvider: FC<Props> = ({ children }) => {
                 severity: 'success',
                 message: `${receivingList.length} cards were added to inventory!`,
             });
-        } catch (e) {
-            console.log(e);
-            createToast({
-                severity: 'error',
-                message: 'Error receiving cards',
-            });
+        } catch (err) {
+            console.log(err);
+            createErrorToast(err);
         }
     };
 

--- a/frontend/src/context/SaleContext.tsx
+++ b/frontend/src/context/SaleContext.tsx
@@ -65,7 +65,7 @@ const SaleContext = createContext<Context>({
 });
 
 export const SaleProvider: FC<Props> = ({ children }) => {
-    const { createToast } = useToastContext();
+    const { createToast, createErrorToast } = useToastContext();
     const [saleListCards, setSaleListCards] = useState<SaleListCard[]>([]);
     const [searchTerm, setSearchTerm] = useState<string>('');
     const [searchResults, setSearchResults] = useState<ClientCard[]>([]);
@@ -150,12 +150,9 @@ export const SaleProvider: FC<Props> = ({ children }) => {
                 severity: 'success',
                 message: `You are viewing ${sale.name}'s sale`,
             });
-        } catch (e) {
-            console.log(e);
-            createToast({
-                severity: 'error',
-                message: `Error`,
-            });
+        } catch (err) {
+            console.log(err);
+            createErrorToast(err);
         }
     };
 
@@ -204,12 +201,9 @@ export const SaleProvider: FC<Props> = ({ children }) => {
                 severity: 'success',
                 message: `${data.ops[0].name}'s sale was suspended`,
             });
-        } catch (e) {
-            console.log(e);
-            createToast({
-                severity: 'error',
-                message: 'Error suspending sale',
-            });
+        } catch (err) {
+            console.log(err);
+            createErrorToast(err);
         }
     };
 
@@ -224,12 +218,9 @@ export const SaleProvider: FC<Props> = ({ children }) => {
                 severity: 'success',
                 message: `${name}'s sale was deleted`,
             });
-        } catch (e) {
-            console.log(e);
-            createToast({
-                severity: 'error',
-                message: 'Error deleting suspended sale',
-            });
+        } catch (err) {
+            console.log(err);
+            createErrorToast(err);
         }
     };
 
@@ -253,12 +244,9 @@ export const SaleProvider: FC<Props> = ({ children }) => {
             });
 
             resetSaleState();
-        } catch (e) {
-            console.log(e);
-            createToast({
-                severity: 'error',
-                message: 'Sale was not created',
-            });
+        } catch (err) {
+            console.log(err);
+            createErrorToast(err);
         }
     };
 

--- a/frontend/src/context/SaleContext.tsx
+++ b/frontend/src/context/SaleContext.tsx
@@ -65,7 +65,7 @@ const SaleContext = createContext<Context>({
 });
 
 export const SaleProvider: FC<Props> = ({ children }) => {
-    const createToast = useToastContext();
+    const { createToast } = useToastContext();
     const [saleListCards, setSaleListCards] = useState<SaleListCard[]>([]);
     const [searchTerm, setSearchTerm] = useState<string>('');
     const [searchResults, setSearchResults] = useState<ClientCard[]>([]);

--- a/frontend/src/ui/ToastContext.tsx
+++ b/frontend/src/ui/ToastContext.tsx
@@ -11,10 +11,12 @@ interface ToastArgs {
 
 interface IToastContext {
     createToast: ({ severity, message }: ToastArgs) => void;
+    createErrorToast: (err: any) => void;
 }
 
 const ToastContext = createContext<IToastContext>({
     createToast: () => null,
+    createErrorToast: () => null,
 });
 
 const ToastProvider: FC = ({ children }) => {
@@ -29,8 +31,19 @@ const ToastProvider: FC = ({ children }) => {
         setOpen(true);
     };
 
+    /**
+     * We can't make any assumptions about error objects when caught at runtime,
+     * so here we create a toast and stringify the object for convenience
+     */
+    const createErrorToast = (err: any) => {
+        createToast({
+            severity: 'error',
+            message: JSON.stringify(err, null, 2),
+        });
+    };
+
     return (
-        <ToastContext.Provider value={{ createToast }}>
+        <ToastContext.Provider value={{ createToast, createErrorToast }}>
             <Snackbar
                 open={open}
                 autoHideDuration={3000}
@@ -44,9 +57,6 @@ const ToastProvider: FC = ({ children }) => {
     );
 };
 
-export const useToastContext = () => {
-    const { createToast } = useContext(ToastContext);
-    return createToast;
-};
+export const useToastContext = () => useContext(ToastContext);
 
 export default ToastProvider;


### PR DESCRIPTION
## Summary
We were inconsistent in bubbling errors up to the UI in a predictable way. Given the recent `errorBoundary` changes on the backend, I've chosen to bubble up errors to the UI for authenticated users, which should make debugging a much speedier process going forward.

In this PR we've extended `ToastContext` with a `createErrorToast` function that issues a toast with `error` severity and a stringified representation of the caught `err` object.