### PR TITLE
Support etched and retro frame filter searches

### DIFF
--- a/frontend/src/BrowseInventory/BrowseInventoryForm.tsx
+++ b/frontend/src/BrowseInventory/BrowseInventoryForm.tsx
@@ -36,6 +36,7 @@ const finishDropdownOptions: DropdownOption[] = [
     { key: 'nonfoil_foil', value: '', text: 'None' },
     { key: 'nonfoil', value: 'NONFOIL', text: 'Nonfoil' },
     { key: 'foil', value: 'FOIL', text: 'Foil' },
+    { key: 'etched', value: 'ETCHED', text: 'Etched' },
 ];
 
 const sortByDropdownOptions: DropdownOption[] = [

--- a/frontend/src/BrowseInventory/BrowseInventoryForm.tsx
+++ b/frontend/src/BrowseInventory/BrowseInventoryForm.tsx
@@ -82,6 +82,7 @@ const frameOptions: DropdownOption[] = [
     { key: 'borderless', value: 'borderless', text: 'Borderless' },
     { key: 'extendedArt', value: 'extendedArt', text: 'Extended Art' },
     { key: 'showcase', value: 'showcase', text: 'Showcase' },
+    { key: 'retro', value: 'retro', text: 'Retro' },
 ];
 
 export interface FormValues {

--- a/monolith/common/types.ts
+++ b/monolith/common/types.ts
@@ -77,7 +77,12 @@ export const typeLines = [
 
 export type TypeLine = typeof typeLines[number];
 
-export const frames = ['borderless', 'extendedArt', 'showcase'] as const;
+export const frames = [
+    'borderless',
+    'extendedArt',
+    'showcase',
+    'retro',
+] as const;
 
 export type Frame = typeof frames[number];
 

--- a/monolith/interactors/getCardsByFilter.ts
+++ b/monolith/interactors/getCardsByFilter.ts
@@ -100,13 +100,33 @@ const getCardsByFilter = async (
         const showcaseMatch = { frame_effects: 'showcase' };
         const extendedArtMatch = { frame_effects: 'extendedart' };
 
-        if (title) aggregation.push({ $match: nameMatch });
-        if (setName) aggregation.push({ $match: setNameMatch });
-        if (type) aggregation.push({ $match: typeMatch });
-        if (frame === 'borderless') aggregation.push({ $match: borderMatch });
-        if (frame === 'showcase') aggregation.push({ $match: showcaseMatch });
-        if (frame === 'extendedArt')
+        if (title) {
+            aggregation.push({ $match: nameMatch });
+        }
+        if (setName) {
+            aggregation.push({ $match: setNameMatch });
+        }
+        if (type) {
+            aggregation.push({ $match: typeMatch });
+        }
+        if (frame === 'borderless') {
+            aggregation.push({ $match: borderMatch });
+        }
+        if (frame === 'showcase') {
+            aggregation.push({ $match: showcaseMatch });
+        }
+        if (frame === 'extendedArt') {
             aggregation.push({ $match: extendedArtMatch });
+        }
+        if (frame === 'retro') {
+            aggregation.push({
+                $match: {
+                    frame: {
+                        $in: ['1993', '1997'],
+                    },
+                },
+            });
+        }
 
         // Pre-unwind, we add these fields
         const addFields = {
@@ -204,7 +224,8 @@ const getCardsByFilter = async (
                     },
                 },
             });
-        } else if (finish === 'NONFOIL') {
+        }
+        if (finish === 'NONFOIL') {
             aggregation.push({
                 $match: {
                     'inventory.k': {
@@ -217,7 +238,8 @@ const getCardsByFilter = async (
                     },
                 },
             });
-        } else if (finish === 'ETCHED') {
+        }
+        if (finish === 'ETCHED') {
             aggregation.push({
                 $match: {
                     'inventory.k': {

--- a/monolith/interactors/getCardsByFilter.ts
+++ b/monolith/interactors/getCardsByFilter.ts
@@ -217,6 +217,19 @@ const getCardsByFilter = async (
                     },
                 },
             });
+        } else if (finish === 'ETCHED') {
+            aggregation.push({
+                $match: {
+                    'inventory.k': {
+                        $in: [
+                            'ETCHED_NM',
+                            'ETCHED_LP',
+                            'ETCHED_MP',
+                            'ETCHED_HP',
+                        ],
+                    },
+                },
+            });
         }
 
         // End match format legality logic


### PR DESCRIPTION
## Summary
This PR includes support for searching by retro frame and etched finish cards. Simple changes to the frontend form, and backend Joi schema types, along with minor extensions to `getCardsByFilter`.