### PR TITLE
Improve sale validation

### DIFF
--- a/frontend/src/Sale/FinishSale.tsx
+++ b/frontend/src/Sale/FinishSale.tsx
@@ -17,8 +17,12 @@ const FinishSale: FC<Props> = () => {
     const { finalizeSale } = useSaleContext();
 
     const handleFinalizeSale = async () => {
-        setSubmit({ loading: true, disabled: true });
-        await finalizeSale();
+        try {
+            setSubmit({ loading: true, disabled: true });
+            await finalizeSale();
+        } catch (err) {
+            setSubmit({ loading: false, disabled: false });
+        }
     };
 
     return (

--- a/frontend/src/context/SaleContext.tsx
+++ b/frontend/src/context/SaleContext.tsx
@@ -245,8 +245,8 @@ export const SaleProvider: FC<Props> = ({ children }) => {
 
             resetSaleState();
         } catch (err) {
-            console.log(err);
             createErrorToast(err);
+            throw err;
         }
     };
 

--- a/monolith/controllers/finishSaleValidationController.ts
+++ b/monolith/controllers/finishSaleValidationController.ts
@@ -12,38 +12,49 @@ import {
     validPrice,
     validStringRequired,
 } from '../common/validations';
+import isValidInventory from '../interactors/isValidInventory';
 
 /**
  * Sale middleware that sanitizes card array to ensure inputs are valid. Will throw errors and end sale if needed
  */
-const finishSaleValidationController: Controller<ReqWithFinishSaleCards> = (
-    req,
-    res,
-    next
-) => {
-    const schema = Joi.object<FinishSaleCard>({
-        id: validStringRequired,
-        price: validPrice,
-        qtyToSell: validInteger,
-        name: validStringRequired,
-        set_name: validStringRequired,
-        finishCondition: validFinishConditions,
-    });
-
-    const { cards } = req.body;
-
-    for (let card of cards) {
-        const { error }: JoiValidation<FinishSaleCard> = schema.validate(card, {
-            abortEarly: false,
-            allowUnknown: true,
+const finishSaleValidationController: Controller<ReqWithFinishSaleCards> =
+    async (req, res, next) => {
+        const schema = Joi.object<FinishSaleCard>({
+            id: validStringRequired,
+            price: validPrice,
+            qtyToSell: validInteger,
+            name: validStringRequired,
+            set_name: validStringRequired,
+            finishCondition: validFinishConditions,
         });
 
-        if (error) {
-            return res.status(400).json(error);
-        }
-    }
+        const { cards } = req.body;
+        const { currentLocation } = req;
 
-    return next();
-};
+        for (let card of cards) {
+            const { error }: JoiValidation<FinishSaleCard> = schema.validate(
+                card,
+                {
+                    abortEarly: false,
+                    allowUnknown: true,
+                }
+            );
+
+            if (error) {
+                return res.status(400).json(error);
+            }
+        }
+
+        /**
+         * Determine if any of the passed cards's intended sale quantities exceed available inventory
+         */
+        const validations = cards.map(async (c) => {
+            await isValidInventory(c, currentLocation);
+        });
+
+        await Promise.all(validations);
+
+        return next();
+    };
 
 export default finishSaleValidationController;

--- a/monolith/interactors/createSuspendedSale.test.ts
+++ b/monolith/interactors/createSuspendedSale.test.ts
@@ -69,7 +69,9 @@ test('Suspending sale with invalid available inventory', async () => {
         error = e;
     }
 
-    expect(error.message).toBe(`Time Spiral's QOH of 5 exceeds inventory of 4`);
+    expect(error.message).toBe(
+        `Time Spiral's quantity of 5 exceeds available inventory of 4`
+    );
 });
 
 test('Suspending sale with available inventory', async () => {

--- a/monolith/interactors/isValidInventory.test.ts
+++ b/monolith/interactors/isValidInventory.test.ts
@@ -16,11 +16,11 @@ beforeAll(async () => {
     // Seed card in inventory with lower quantity
     await addCardToInventory({
         quantity: 2,
-        finishCondition: 'FOIL_NM',
-        id: '1234',
-        name: 'CardName',
-        set_name: 'SetName',
-        set: 'SNM',
+        finishCondition: 'NONFOIL_NM',
+        id: '49585',
+        name: 'MyFooCard',
+        set_name: 'MyFooSet',
+        set: 'MFS',
         location: 'ch1',
     });
 });
@@ -31,12 +31,12 @@ afterAll(async () => {
 
 test('Validates inventory correctly', async () => {
     const salelistCard: FinishSaleCard = {
-        id: '1234',
+        id: '49585',
         price: 3.45,
         qtyToSell: 4,
-        finishCondition: 'FOIL_NM',
-        name: 'CardName',
-        set_name: 'SNM',
+        finishCondition: 'NONFOIL_NM',
+        name: 'MyFooCard',
+        set_name: 'MFS',
     };
 
     const isValid = async () => await isValidInventory(salelistCard, 'ch1');

--- a/monolith/interactors/isValidInventory.test.ts
+++ b/monolith/interactors/isValidInventory.test.ts
@@ -1,0 +1,50 @@
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import { FinishSaleCard } from '../common/types';
+import getDatabaseConnection from '../database';
+import addCardToInventory from './addCardToInventory';
+import isValidInventory from './isValidInventory';
+
+let mongoServer;
+let db;
+
+// Set up the mongo memory instance
+beforeAll(async () => {
+    mongoServer = await MongoMemoryServer.create();
+    const uri = mongoServer.getUri();
+    db = await getDatabaseConnection(uri);
+
+    // Seed card in inventory with lower quantity
+    await addCardToInventory({
+        quantity: 2,
+        finishCondition: 'FOIL_NM',
+        id: '1234',
+        name: 'CardName',
+        set_name: 'SetName',
+        set: 'SNM',
+        location: 'ch1',
+    });
+});
+
+afterAll(async () => {
+    await mongoServer.stop();
+});
+
+test('Validates inventory correctly', async () => {
+    const salelistCard: FinishSaleCard = {
+        id: '1234',
+        price: 3.45,
+        qtyToSell: 4,
+        finishCondition: 'FOIL_NM',
+        name: 'CardName',
+        set_name: 'SNM',
+    };
+
+    const isValid = async () => await isValidInventory(salelistCard, 'ch1');
+
+    /**
+     * We access `rejects` here because `toThrow` is used for synchronous functions
+     *
+     * `.rejects` unwraps the promise rejection reason for testing
+     */
+    expect(isValid).rejects.toThrow();
+});

--- a/monolith/interactors/isValidInventory.test.ts
+++ b/monolith/interactors/isValidInventory.test.ts
@@ -45,6 +45,9 @@ test('Validates inventory correctly', async () => {
      * We access `rejects` here because `toThrow` is used for synchronous functions
      *
      * `.rejects` unwraps the promise rejection reason for testing
+     *
+     * TODO: Should isValidInventory even throw? Perhaps we should return false.
+     * The implementation point is simply a Promise.all() chain testing for truthiness, after all
      */
     expect(isValid).rejects.toThrow();
 });

--- a/monolith/interactors/isValidInventory.ts
+++ b/monolith/interactors/isValidInventory.ts
@@ -1,0 +1,35 @@
+import { ClubhouseLocation, FinishSaleCard } from '../common/types';
+import getDatabaseConnection from '../database';
+import collectionFromLocation from '../lib/collectionFromLocation';
+
+/**
+ * Validates a card's quantity-to-sell against available inventory during a sale or sale-suspension
+ */
+async function isValidInventory(
+    saleCard: FinishSaleCard,
+    location: ClubhouseLocation
+) {
+    try {
+        const { qtyToSell, finishCondition, name, id } = saleCard;
+        const db = await getDatabaseConnection();
+        const collection = db.collection(
+            collectionFromLocation(location).cardInventory
+        );
+
+        const doc = await collection.findOne({ _id: id });
+
+        const quantityOnHand = doc.qoh[finishCondition];
+
+        if (qtyToSell > quantityOnHand) {
+            throw new Error(
+                `${name}'s quantity of ${qtyToSell} exceeds available inventory of ${quantityOnHand}`
+            );
+        }
+
+        return true;
+    } catch (e) {
+        throw e;
+    }
+}
+
+export default isValidInventory;


### PR DESCRIPTION
## Summary
Found a bug in development that could have caused some confusion if it ever bubbled up to userland. I suspect the small and controlled scale of the application affected why this never showed up in production, but it should be dealt with nonetheless.

To reproduce:
1. Open a tab and add 2 copies of a card through manage inventory
2. Open another tab, go to make a new sale, and attempt to add the two cards to the sale list
3. Navigate back to tab 1 and remove the cards from inventory
4. Switch back to sales and click "finalize sale". The sale completes, despite those cards not being in inventory!

Usually step 4 is mitigated by the fact that employees physically pull cards to inspect them prior to sale. However, we perform this validation on sale suspension, so it naturally makes sense for us to do the same with proper sales.

In this PR, I've extracted the validation interactor that originally existed in `createSuspendedSale`, tested it, and integrated it into the `finishSaleValidationController` to stop sales in their tracks should it throw an error.

Note: Unsuspended sales are deleted entirely on submission, and inventory is restored prior to selling one, so they remain un-affected as inventory is reconciled properly.