### PR TITLE
Fix zIndex layering bug

### DIFF
--- a/frontend/src/ui/CardRowContainer.tsx
+++ b/frontend/src/ui/CardRowContainer.tsx
@@ -6,20 +6,25 @@ interface Props {
     header: ReactNode;
 }
 
-const useStyles = makeStyles(({ spacing }) => ({
+const useStyles = makeStyles(({ spacing, zIndex }) => ({
     headerContainer: {
         paddingBottom: spacing(3),
+    },
+    imageContainer: {
+        zIndex: zIndex.mobileStepper,
     },
 }));
 
 const CardRowContainer: FC<Props> = ({ image, header, children }) => {
-    const { headerContainer } = useStyles();
+    const { headerContainer, imageContainer } = useStyles();
 
     return (
         <Paper variant="outlined">
             <Box p={2}>
                 <Grid container spacing={2}>
-                    <Grid item>{image}</Grid>
+                    <Grid item className={imageContainer}>
+                        {image}
+                    </Grid>
                     <Grid item xs={10}>
                         <div className={headerContainer}>{header}</div>
                         <div>{children}</div>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/15024562/136828780-f33e4b93-6ea5-40da-b791-419528c45f04.png)

## Summary
Transformed images layered below form `TextField` components, for an undetermined reason. The fix here was to apply themed `zIndex` values to the image container itself.