### PR TITLE
Reduce sale payload size

### DIFF
--- a/frontend/src/context/SaleContext.tsx
+++ b/frontend/src/context/SaleContext.tsx
@@ -235,7 +235,14 @@ export const SaleProvider: FC<Props> = ({ children }) => {
             if (!!_id) await deleteSuspendedSaleQuery(_id);
 
             const { sale_data } = await finishSaleQuery({
-                cards: saleListCards,
+                cards: saleListCards.map((slc) => ({
+                    id: slc.id,
+                    price: slc.price,
+                    qtyToSell: slc.qtyToSell,
+                    name: slc.name,
+                    set_name: slc.set_name,
+                    finishCondition: slc.finishCondition,
+                })),
             });
 
             createToast({

--- a/frontend/src/context/finishSaleQuery.tsx
+++ b/frontend/src/context/finishSaleQuery.tsx
@@ -1,9 +1,18 @@
 import http from '../common/http';
+import { FinishCondition } from '../utils/ClientCard';
 import { FINISH_SALE } from '../utils/endpoints';
-import { SaleListCard } from './SaleContext';
+
+interface QueryCard {
+    id: string;
+    price: number;
+    qtyToSell: number;
+    name: string;
+    set_name: string;
+    finishCondition: FinishCondition;
+}
 
 interface Payload {
-    cards: SaleListCard[];
+    cards: QueryCard[];
 }
 
 interface ResponseData {

--- a/monolith/controllers/finishSaleValidationController.ts
+++ b/monolith/controllers/finishSaleValidationController.ts
@@ -34,10 +34,7 @@ const finishSaleValidationController: Controller<ReqWithFinishSaleCards> =
         for (let card of cards) {
             const { error }: JoiValidation<FinishSaleCard> = schema.validate(
                 card,
-                {
-                    abortEarly: false,
-                    allowUnknown: true,
-                }
+                { abortEarly: false }
             );
 
             if (error) {

--- a/monolith/interactors/createSuspendedSale.ts
+++ b/monolith/interactors/createSuspendedSale.ts
@@ -1,28 +1,11 @@
 import moment from 'moment';
-import RawScryfallCard from '../common/RawScryfallCard';
 import { ScryfallApiCard } from '../common/ScryfallApiCard';
-import { ClubhouseLocation, Collection, FinishSaleCard } from '../common/types';
+import { ClubhouseLocation, FinishSaleCard } from '../common/types';
 import getDatabaseConnection from '../database';
 import collectionFromLocation from '../lib/collectionFromLocation';
+import findBulkById from './findBulkById';
 import isValidInventory from './isValidInventory';
 import updateCardInventory from './updateCardInventory';
-
-/**
- * Finds a bulk card by its associated `_id`
- */
-async function findBulkById(id: string): Promise<RawScryfallCard> {
-    try {
-        const db = await getDatabaseConnection();
-
-        const card: RawScryfallCard = await db
-            .collection(Collection.scryfallBulkCards)
-            .findOne({ _id: id });
-
-        return card;
-    } catch (err) {
-        throw err;
-    }
-}
 
 /**
  * // TODO: Is this true??

--- a/monolith/interactors/createSuspendedSale.ts
+++ b/monolith/interactors/createSuspendedSale.ts
@@ -51,6 +51,7 @@ async function createSuspendedSale(
         // Zip them up with the received sale metadata
         const transformedCards = bulkCards.map((bc, idx) => {
             const currentSaleListCard = saleList[idx];
+
             const { price, qtyToSell, finishCondition, name, set_name } =
                 currentSaleListCard;
 

--- a/monolith/interactors/findBulkById.test.ts
+++ b/monolith/interactors/findBulkById.test.ts
@@ -1,0 +1,32 @@
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import getDatabaseConnection from '../database';
+import bulkCard from '../fixtures/fixtures';
+import findBulkById from './findBulkById';
+
+const SCRYFALL_BULK = 'scryfall_bulk_cards';
+
+let mongoServer;
+let db;
+
+// Set up the mongo memory instance
+beforeAll(async () => {
+    mongoServer = await MongoMemoryServer.create();
+    const uri = mongoServer.getUri();
+    db = await getDatabaseConnection(uri);
+
+    // Create fake bulk collection
+    const bulkCollection = await db.createCollection(SCRYFALL_BULK);
+
+    // Insert one bulk card, mimic the database seed script by overwriting `_id` with `card.id`
+    await bulkCollection.insert({ _id: bulkCard.id, ...bulkCard });
+});
+
+afterAll(async () => {
+    await mongoServer.stop();
+});
+
+test('Grabs the correct card by id', async () => {
+    const card = await findBulkById('f3d62dbd-63db-4ac9-950f-9852627f23f2');
+    expect(card.id).toBe('f3d62dbd-63db-4ac9-950f-9852627f23f2');
+    expect(card.name).toBe('Time Spiral');
+});

--- a/monolith/interactors/findBulkById.ts
+++ b/monolith/interactors/findBulkById.ts
@@ -1,0 +1,22 @@
+import RawScryfallCard from '../common/RawScryfallCard';
+import { Collection } from '../common/types';
+import getDatabaseConnection from '../database';
+
+/**
+ * Finds a bulk card by its associated `_id`
+ */
+async function findBulkById(id: string): Promise<RawScryfallCard> {
+    try {
+        const db = await getDatabaseConnection();
+
+        const card: RawScryfallCard = await db
+            .collection(Collection.scryfallBulkCards)
+            .findOne({ _id: id });
+
+        return card;
+    } catch (err) {
+        throw err;
+    }
+}
+
+export default findBulkById;

--- a/monolith/interactors/updateInventoryCards.test.ts
+++ b/monolith/interactors/updateInventoryCards.test.ts
@@ -1,4 +1,5 @@
 import { MongoMemoryServer } from 'mongodb-memory-server';
+import { FinishSaleCard } from '../common/types';
 import getDatabaseConnection from '../database';
 import addCardToInventory from './addCardToInventory';
 import { updateInventoryCards } from './updateInventoryCards';
@@ -38,18 +39,22 @@ test('Ensure multiple update', async () => {
         location: 'ch1',
     });
 
-    const cardsInSale = [
+    const cardsInSale: FinishSaleCard[] = [
         {
             qtyToSell: 1,
             finishCondition: 'NONFOIL_NM',
             id: '1337',
             name: 'Black Lotus',
+            price: 1.23,
+            set_name: 'LEA',
         },
         {
             qtyToSell: 3,
             finishCondition: 'NONFOIL_NM',
             id: '5699',
             name: 'Mox Diamond',
+            price: 1.23,
+            set_name: 'STH',
         },
     ];
 

--- a/monolith/jest.config.js
+++ b/monolith/jest.config.js
@@ -1,3 +1,4 @@
 module.exports = {
     preset: 'ts-jest',
+    modulePathIgnorePatterns: ['built'],
 };


### PR DESCRIPTION
## Summary
In an effort to combat slow sale finalization response times and possible HTTP `413` error responses, this PR addresses payload sizes for arguably the most-frequently used endpoint: `/finishSale`. 

The first step was to preserve the shape of documents persisted in the sales collection, and to do so, we recreate the `ScryfallApiCard` from the submitted card list `id`'s, and then persist them along with sale metadata.

Next, I added restrictions to the sale controller validation to _only_ allow specified properties on the Joi schema.

Finally, the frontend `SaleContext` and associated sale-finalization query now explicitly creates an acceptable data shape that the backend controller expects.

Along the way, I extracted and tested `findBulkById`, as it's used in sale suspension as well.