### PR TITLE
feat(fullstack): `admin` in client state

### DIFF
--- a/frontend/src/context/AuthProvider.tsx
+++ b/frontend/src/context/AuthProvider.tsx
@@ -10,6 +10,7 @@ export type ClubhouseLocation = 'ch1' | 'ch2';
 const tokenKey = 'clubhouse_JWT';
 const locationKey = 'currentLocation';
 const userKey = 'currentUser';
+const adminKey = 'admin';
 
 interface Context {
     handleLogin: (
@@ -22,12 +23,14 @@ interface Context {
     authToken: string | null;
     currentLocation: ClubhouseLocation | null;
     currentUser: string | null;
+    admin: boolean | null;
 }
 
 export const AuthContext = React.createContext<Context>({
     authToken: null,
     currentLocation: null,
     currentUser: null,
+    admin: null,
     isLoggedIn: () => false,
     handleLogout: () => null,
     handleLogin: () => new Promise(() => null),
@@ -42,17 +45,20 @@ const AuthProvider: FC<Props> = ({ children }) => {
         localStorage.getItem(tokenKey)
     );
 
-    const [
-        currentLocation,
-        setCurrentLocation,
-    ] = useLocalStorage<ClubhouseLocation | null>(
-        locationKey,
-        localStorage.getItem(locationKey) as ClubhouseLocation
-    );
+    const [currentLocation, setCurrentLocation] =
+        useLocalStorage<ClubhouseLocation | null>(
+            locationKey,
+            localStorage.getItem(locationKey) as ClubhouseLocation
+        );
 
     const [currentUser, setCurrentUser] = useLocalStorage<string | null>(
         userKey,
         localStorage.getItem(userKey)
+    );
+
+    const [admin, setAdmin] = useLocalStorage<boolean | null>(
+        adminKey,
+        JSON.parse(String(localStorage.getItem(adminKey)))
     );
 
     /**
@@ -85,6 +91,7 @@ const AuthProvider: FC<Props> = ({ children }) => {
                 setAuthToken(data.token);
                 setCurrentLocation(currentLocation);
                 setCurrentUser(username);
+                setAdmin(data.admin);
             }
 
             return data;
@@ -97,6 +104,7 @@ const AuthProvider: FC<Props> = ({ children }) => {
         setAuthToken(null);
         setCurrentLocation(null);
         setCurrentUser(null);
+        setAdmin(null);
 
         history.push('/login');
     };
@@ -109,6 +117,7 @@ const AuthProvider: FC<Props> = ({ children }) => {
                 authToken,
                 currentLocation,
                 currentUser,
+                admin,
                 handleLogin,
                 handleLogout,
                 isLoggedIn,

--- a/frontend/src/context/loginQuery.ts
+++ b/frontend/src/context/loginQuery.ts
@@ -5,6 +5,7 @@ type ClubhouseLocation = 'ch1' | 'ch2';
 
 interface ResponseData {
     token: string;
+    admin: boolean;
 }
 
 const loginQuery = async (

--- a/monolith/interactors/getJwt.ts
+++ b/monolith/interactors/getJwt.ts
@@ -7,14 +7,14 @@ async function getJwt(
     username: string,
     submittedPass: string,
     currentLocation: ClubhouseLocation
-): Promise<{ token: string } | string> {
+): Promise<{ token: string; admin: boolean } | string> {
     try {
         const user: User = await getUserByName(username);
 
         if (!user) return 'Not authorized';
 
         // Retrieve the Clubhouse location permissions and employee number for the user
-        const { _id, locations, password } = user;
+        const { _id, locations, password, admin } = user;
 
         // Check if the user is allowed in the location
         if (!locations.includes(currentLocation)) {
@@ -33,7 +33,7 @@ async function getJwt(
                 process.env.PRIVATE_KEY
             );
 
-            return { token: token };
+            return { token, admin };
         } else {
             return 'Not authorized';
         }

--- a/monolith/interactors/getUserByName.ts
+++ b/monolith/interactors/getUserByName.ts
@@ -7,6 +7,7 @@ export interface User {
     username: string;
     locations: string[];
     lightspeedEmployeeNumber: number;
+    admin: boolean;
 }
 
 export default async function getUserByName(username: string): Promise<User> {


### PR DESCRIPTION
## Summary
This PR exposes an `admin` boolean to the frontend by extending the login query payload and interactors, after extending the backend `User` document schema.