### PR TITLE
chore(frontend): remove manage inventory feature

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,12 +12,10 @@ import BrowseReceiving from './BrowseReceiving/BrowseReceiving';
 import BrowseSales from './BrowseSales/BrowseSales';
 import BulkInventory from './BulkInventory/BulkInventory';
 import AuthProvider from './context/AuthProvider';
-import InventoryProvider from './context/InventoryContext';
 import ReceivingProvider from './context/ReceivingContext';
 import { SaleProvider } from './context/SaleContext';
 import Home from './LandingPage/Home';
 import Login from './Login/Login';
-import ManageInventory from './ManageInventory/ManageInventory';
 import NavBar from './NavBar/NavBar';
 import PublicInventory from './PublicInventory/PublicInventory';
 import Receiving from './Receiving/Receiving';
@@ -67,11 +65,6 @@ const App: FC = () => {
                         <Route exact path="/" component={Home} />
                         <div className={backgroundColor}>
                             <div className={contentContainer}>
-                                <AdminRoute exact path="/manage-inventory">
-                                    <InventoryProvider>
-                                        <ManageInventory />
-                                    </InventoryProvider>
-                                </AdminRoute>
                                 <AdminRoute exact path="/new-sale">
                                     <SaleProvider>
                                         <Sale />

--- a/frontend/src/NavBar/NavLinks.test.tsx
+++ b/frontend/src/NavBar/NavLinks.test.tsx
@@ -17,7 +17,6 @@ test('Correct link navigation', async () => {
         </MemoryRouter>
     );
 
-    await screen.findByText('Manage Inventory');
     await screen.findByText('New Sale');
     await screen.findByText('Receiving');
     await screen.findByText('Browse Inventory');
@@ -25,7 +24,6 @@ test('Correct link navigation', async () => {
     await screen.findByText('Browse Receiving');
     await screen.findByText('Log Out');
 
-    await fireEvent.click(await screen.findByText('Manage Inventory'));
     await fireEvent.click(await screen.findByText('New Sale'));
     await fireEvent.click(await screen.findByText('Receiving'));
     await fireEvent.click(await screen.findByText('Browse Inventory'));
@@ -36,7 +34,6 @@ test('Correct link navigation', async () => {
     expect(pathHistory).toMatchInlineSnapshot(`
         Array [
           "/",
-          "/manage-inventory",
           "/new-sale",
           "/receiving",
           "/browse-inventory",

--- a/frontend/src/NavBar/NavLinks.tsx
+++ b/frontend/src/NavBar/NavLinks.tsx
@@ -1,5 +1,4 @@
 import { Divider, List, ListItem, ListItemIcon } from '@material-ui/core';
-import AddIcon from '@material-ui/icons/Add';
 import AttachMoneyIcon from '@material-ui/icons/AttachMoney';
 import BusinessCenterIcon from '@material-ui/icons/BusinessCenter';
 import EqualizerIcon from '@material-ui/icons/Equalizer';
@@ -18,18 +17,6 @@ const NavLinks: FC<{}> = () => {
 
     return (
         <List>
-            <ListItem
-                button
-                component={RouterLink}
-                to="/manage-inventory"
-                selected={pathname === '/manage-inventory'}
-                replace
-            >
-                <ListItemIcon>
-                    <AddIcon color="primary" />
-                </ListItemIcon>
-                Manage Inventory
-            </ListItem>
             <ListItem
                 button
                 component={RouterLink}


### PR DESCRIPTION
This PR removes the Manage Inventory feature from the nav bar and the routing structure. We haven't removed the internals just yet, until we're sure that users will continue without it.